### PR TITLE
chore: hide internal skills from slash-command menu and clean up docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,6 @@ Automates common SDLC tasks.
 | `/sdlc:review [--base <branch>] [--dimensions <name,...>] [--dry-run]` | Run multi-dimension code review on the current branch |
 | `/sdlc:review-init [--add]` | Initialize or expand project review dimensions by scanning the tech stack |
 
-### Skills
-
-| Skill | Purpose |
-| --- | --- |
-| `sdlc:creating-pull-requests` | Analyse commits and diffs; generate structured 8-section PR descriptions (Summary / JIRA Ticket / Business Context / Business Benefits / Technical Design / Technical Impact / Changes Overview / Testing) |
-| `sdlc:reviewing-changes` | Load project dimensions from `.claude/review-dimensions/`, match to changed files, dispatch parallel review subagents, deduplicate findings, post consolidated PR comment |
-| `sdlc:initializing-review-dimensions` | Scan project tech stack and propose tailored review dimension files with project-specific evidence; create and validate selected files |
-
 ---
 
 ## Architecture Principles

--- a/docs/adding-skills.md
+++ b/docs/adding-skills.md
@@ -85,6 +85,7 @@ See `./checklist.md` for the full verification checklist.
 | `name` field | Lowercase, hyphens only, max 64 chars. Use prefix or gerund pattern (see above). |
 | `description` field | Maximum 1024 characters |
 | `SKILL.md` content | Maximum 500 lines |
+| `user-invokable` field | Set to `false` to hide the skill from the `/` menu. Use for skills that have a corresponding slash command as their entry point — the command handles argument parsing and preparation before delegating to the skill. Claude can still invoke the skill automatically; only user-initiated invocation via `/` is suppressed. |
 
 ## Writing Effective Descriptions
 

--- a/docs/plugin-sdlc-utilities.md
+++ b/docs/plugin-sdlc-utilities.md
@@ -77,27 +77,6 @@ Create this PR? (yes / edit / cancel)
 
 ---
 
-## `sdlc:creating-pull-requests` Skill
-
-Reusable knowledge skill that analyzes commits and diffs to generate PR descriptions in the Conventional PR format. Loaded by the `/sdlc:pr` command and available to any other command or skill that needs to produce PR content.
-
-### Template (8 sections, always all present)
-
-```text
-## Summary          — 1-3 sentence plain-language overview, no jargon
-## JIRA Ticket      — auto-detected from branch/commits, or "Not detected"
-## Business Context — why this change is needed from a business perspective
-## Business Benefits— value delivered: user impact, efficiency, risk reduction
-## Technical Design — architecture, key decisions, trade-offs
-## Technical Impact — affected systems, breaking changes, migration needs
-## Changes Overview — what changed, grouped by concern (no file paths)
-## Testing          — how it was verified: automated tests, manual steps
-```
-
-### Trigger Phrases
-
-**When triggered**: "create PR", "open pull request", "update PR", "write PR description"
-
 ---
 
 ## `/sdlc:review` — Multi-Dimension Code Review
@@ -213,22 +192,6 @@ Validation: 4/4 dimensions pass all checks.
 ```
 
 ---
-
-## `sdlc:reviewing-changes` Skill
-
-Loaded by `/sdlc:review`. Implements the full 11-step PCIDCI workflow: dimension discovery
-and validation, file matching, parallel subagent dispatch, deduplication, and PR comment posting.
-
-**Trigger phrases**: "review changes", "code review", "review PR", "multi-dimension review", "run review"
-
----
-
-## `sdlc:initializing-review-dimensions` Skill
-
-Loaded by `/sdlc:review-init`. Scans the tech stack, generates project-specific evidence for
-each proposal, refines with a critique/improve pass, creates files, and validates them.
-
-**Trigger phrases**: "initialize review dimensions", "add review dimension", "setup code review", "create dimension files", "expand review config"
 
 ---
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/creating-pull-requests/SKILL.md
+++ b/plugins/sdlc-utilities/skills/creating-pull-requests/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: creating-pull-requests
 description: "Use this skill when creating or updating a pull request, updating a PR description, or generating PR content from commits and diffs. Handles the full PR workflow: consumes pre-computed context from pr-prepare.js, generates description with plan-critique-improve-do-critique-improve, user review, and gh CLI execution. Triggers on: create PR, open pull request, update PR, write PR description, PR summary, or when asked to describe changes for a pull request."
+user-invokable: false
 ---
 
 # Creating Pull Requests

--- a/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
+++ b/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: initializing-review-dimensions
 description: "Use this skill to initialize or expand review dimensions for a project. Scans the project's tech stack, dependencies, file patterns, and architecture to propose relevant review dimensions tailored to the specific project. Triggers on: initialize review dimensions, add review dimension, setup code review, create dimension files, expand review config, review-init."
+user-invokable: false
 ---
 
 # Initializing Review Dimensions

--- a/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
+++ b/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reviewing-changes
 description: "Use this skill when reviewing code changes across project-defined dimensions (security, performance, docs, concurrency, etc.). Runs review-prepare.js to pre-compute all git data, then delegates to the review-orchestrator agent. Triggers on: review changes, code review, review PR, multi-dimension review, run review."
+user-invokable: false
 ---
 
 # Reviewing Changes


### PR DESCRIPTION
## Summary
Hides the three SDLC utility skills from the Claude Code slash-command menu by adding `user-invokable: false` to their frontmatter. These skills are implementation details invoked by commands, not intended for direct user invocation. Removes documentation sections that duplicated content already present in the skill files themselves.

## JIRA Ticket
Not detected

## Business Context
N/A — this is a pure internal tooling improvement with no external business dimension.

## Business Benefits
N/A — this is a pure internal tooling improvement with no external business dimension.

## Technical Design
Adds the `user-invokable: false` frontmatter field to three SKILL.md files to suppress them from the `/` menu. Redundant skill-description sections are removed from AGENTS.md and the plugin reference doc; that content already lives in the skill files. The skill-authoring guide is updated with a new table row documenting the `user-invokable` convention so future skill authors know when and how to use it.

## Technical Impact
Plugin version bumped from 0.3.1 to 0.3.2. No breaking changes — skills remain fully accessible via automatic invocation by commands; only user-initiated `/skill-name` invocation via the menu is suppressed.

## Changes Overview
Three internal skills (PR creation, change review, dimension initialization) marked as non-user-invokable so they no longer appear alongside user-facing commands in the slash-command menu. Skill reference tables and verbose individual skill descriptions removed from the repository README and plugin documentation. The skill-authoring guide gains a row explaining the `user-invokable` field, when to set it to `false`, and what effect that has.

## Testing
Manual verification that the three skills no longer appear in the `/` menu while the corresponding slash commands (`/sdlc:pr`, `/sdlc:review`, `/sdlc:review-init`) continue to invoke them correctly. No automated tests are affected by this change.