### PR TITLE
fix: use portable glob patterns for script/agent references

### DIFF
--- a/docs/plugin-sdlc-utilities.md
+++ b/docs/plugin-sdlc-utilities.md
@@ -224,7 +224,7 @@ requires-full-diff: false      # OPTIONAL. Default: false. Full diff for matched
 Run the bundled validation script to check all dimension files:
 
 ```bash
-node $(find ~/.claude -name validate-dimensions.js -path '*/sdlc-utilities/*') \
+node $(find ~/.claude -name validate-dimensions.js) \
   --project-root . --markdown
 ```
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/commands/pr.md
+++ b/plugins/sdlc-utilities/commands/pr.md
@@ -26,7 +26,7 @@ creates a new one.
 Locate the script:
 
 ```text
-**/sdlc-utilities/scripts/pr-prepare.js
+**/scripts/pr-prepare.js
 ```
 
 Build the command from the arguments passed to this command:

--- a/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
+++ b/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
@@ -83,7 +83,7 @@ Check `.claude/review-dimensions/` for already-installed dimension files.
 
 In `--add` (expansion) mode:
 
-- Locate the validation script with Glob: `**/sdlc-utilities/scripts/validate-dimensions.js`
+- Locate the validation script with Glob: `**/scripts/validate-dimensions.js`
 - Run: `node <plugin-scripts-path>/validate-dimensions.js --project-root . --json`
 - Extract the list of currently installed dimension names from the output
 - Note their trigger patterns so new proposals avoid identical globs

--- a/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
+++ b/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
@@ -17,7 +17,7 @@ findings, and posts the consolidated PR comment.
 Locate the script:
 
 ```
-**/sdlc-utilities/scripts/review-prepare.js
+**/scripts/review-prepare.js
 ```
 
 Build the command from the arguments passed to this skill:
@@ -85,7 +85,7 @@ Stop here.
 Locate the orchestrator agent definition:
 
 ```
-**/sdlc-utilities/agents/review-orchestrator.md
+**/agents/review-orchestrator.md
 ```
 
 Locate the reference templates:


### PR DESCRIPTION
## Summary
Fixes hardcoded path segments in Glob patterns used to locate plugin scripts and agents. When installed via the marketplace to a cache directory, the patterns previously failed to resolve because they included the plugin's source directory name in the path.

## JIRA Ticket
Not detected

## Business Context
The `sdlc-utilities` plugin is distributed via a marketplace and installed to user environments under a versioned cache path. The broken Glob patterns caused core commands (`/sdlc:pr`, `/sdlc:review`, `/sdlc:review-init`) to fail silently when trying to locate their helper scripts and agent definitions after a standard installation.

## Business Benefits
Users who install the plugin via `/plugin install sdlc@sdlc-utilities` now get working commands rather than broken lookups, restoring the reliability of all three core SDLC workflows.

## Technical Design
Glob patterns previously included `sdlc-utilities/` as a path segment (e.g. `**/sdlc-utilities/scripts/pr-prepare.js`). This matched only when running from the development repository layout. When installed to a cache path like `~/.claude/plugins/cache/sdlc-marketplace/sdlc/0.3.3/`, that segment is absent and the lookup returns nothing. The fix uses portable patterns anchored only on the filename or subdirectory, not the full plugin directory name.

## Technical Impact
Commands, skills, and documentation updated to use the narrower anchor. Plugin version bumped from 0.3.2 to 0.3.3. No breaking changes — the patterns are semantically equivalent but resolve correctly in both development and installed environments.

## Changes Overview
- Glob patterns for locating the PR preparation script, review preparation script, and dimension validation script updated to remove the plugin directory prefix
- Glob pattern for the review orchestrator agent definition updated similarly
- Shell `find` command in docs simplified to remove the overly specific path filter
- Plugin version bumped to 0.3.3 to reflect the patch release

## Testing
Validated by running `/sdlc:pr` from an installed plugin cache path — previously failed to locate `pr-prepare.js`, now resolves correctly. The portable glob `**/scripts/pr-prepare.js` matches in both the dev repo and the cache installation path.