### PR TITLE
chore: update docs to reflect sdlc-utilities to sdlc-marketplace rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 This repository is a **Claude Code plugin marketplace** that ships the `sdlc-utilities` plugin for software development lifecycle (SDLC) automation. Installation requires two steps:
 
 ```text
-/plugin marketplace add rnagrodzki/sdlc-utilities
-/plugin install sdlc@sdlc-utilities
+/plugin marketplace add rnagrodzki/sdlc-marketplace
+/plugin install sdlc@sdlc-marketplace
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sdlc-utilities
+# sdlc-marketplace
 
 A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that automates SDLC tasks: generates structured PR descriptions from commits and diffs, and runs project-customizable multi-dimension code reviews matched to your changed files.
 
@@ -16,7 +16,7 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that auto
 ### Step 1 — Add the marketplace
 
 ```text
-/plugin marketplace add rnagrodzki/sdlc-utilities
+/plugin marketplace add rnagrodzki/sdlc-marketplace
 ```
 
 This registers the marketplace catalog. No plugins are installed yet.
@@ -24,7 +24,7 @@ This registers the marketplace catalog. No plugins are installed yet.
 ### Step 2 — Install the plugin
 
 ```text
-/plugin install sdlc@sdlc-utilities
+/plugin install sdlc@sdlc-marketplace
 ```
 
 Or browse interactively: run `/plugin`, go to the **Discover** tab, and select the plugin to install.
@@ -42,18 +42,18 @@ See [docs/getting-started.md](docs/getting-started.md) for a full first-use walk
 ### Step 1 — Refresh the marketplace catalog
 
 ```text
-/plugin marketplace update sdlc-utilities
+/plugin marketplace update sdlc-marketplace
 ```
 
 ### Step 2 — Update the plugin
 
 ```text
-/plugin update sdlc@sdlc-utilities
+/plugin update sdlc@sdlc-marketplace
 ```
 
 ### Enable auto-update
 
-Open `/plugin`, go to the **Marketplaces** tab, and toggle auto-update for `sdlc-utilities`. When enabled, Claude Code checks for new versions on startup.
+Open `/plugin`, go to the **Marketplaces** tab, and toggle auto-update for `sdlc-marketplace`. When enabled, Claude Code checks for new versions on startup.
 
 ---
 
@@ -102,13 +102,13 @@ To skip the check when a version bump is intentionally not needed, add the **`sk
 This happens when the plugin name registered in the marketplace doesn't match the identity in `plugin.json`. Clear the cache, restart, and reinstall:
 
 ```bash
-rm -rf ~/.claude/plugins/cache/sdlc-utilities
+rm -rf ~/.claude/plugins/cache/sdlc-marketplace
 ```
 
 Then restart Claude Code and run:
 
 ```text
-/plugin install sdlc@sdlc-utilities
+/plugin install sdlc@sdlc-marketplace
 ```
 
 ### Plugin not updating after marketplace refresh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ This repository serves two roles:
 ## Directory Structure
 
 ```text
-sdlc-utilities/
+sdlc-marketplace/
 ├── .claude-plugin/
 │   └── marketplace.json          # Marketplace manifest (entry point)
 ├── plugins/
@@ -43,13 +43,13 @@ sdlc-utilities/
 The root `marketplace.json` tells Claude Code: "This repository contains plugins. Here
 is where to find them." It lists each plugin with a name and a relative source path.
 
-When a user runs `/plugin marketplace add rnagrodzki/sdlc-utilities` in Claude Code:
+When a user runs `/plugin marketplace add rnagrodzki/sdlc-marketplace` in Claude Code:
 
 1. Clones or references this repository
 2. Reads `.claude-plugin/marketplace.json`
 3. Discovers the listed plugins and makes them available to browse
 
-No plugins are installed yet at this point. The user must then run `/plugin install sdlc@sdlc-utilities` (or use the interactive **Discover** tab in `/plugin`) to install the plugin.
+No plugins are installed yet at this point. The user must then run `/plugin install sdlc@sdlc-marketplace` (or use the interactive **Discover** tab in `/plugin`) to install the plugin.
 
 **Important:** The `name` in each `marketplace.json` plugin entry must match the `name` in the corresponding `plugin.json`. A mismatch causes "plugin not found" errors when users try to update via the `/plugin` UI, because Claude Code looks up the installed plugin identity (from `plugin.json`) in the marketplace catalog.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 ### Step 1 — Add the marketplace
 
 ```text
-/plugin marketplace add rnagrodzki/sdlc-utilities
+/plugin marketplace add rnagrodzki/sdlc-marketplace
 ```
 
 This registers the marketplace catalog with Claude Code. No plugins are installed yet.
@@ -13,7 +13,7 @@ This registers the marketplace catalog with Claude Code. No plugins are installe
 ### Step 2 — Install the plugin
 
 ```text
-/plugin install sdlc@sdlc-utilities
+/plugin install sdlc@sdlc-marketplace
 ```
 
 Or browse interactively: run `/plugin`, go to the **Discover** tab, and select the plugin to install.
@@ -34,18 +34,18 @@ After installation, start a new Claude Code session. You should see a message fr
 ### Refresh the marketplace catalog
 
 ```text
-/plugin marketplace update sdlc-utilities
+/plugin marketplace update sdlc-marketplace
 ```
 
 ### Update the plugin
 
 ```text
-/plugin update sdlc@sdlc-utilities
+/plugin update sdlc@sdlc-marketplace
 ```
 
 ### Enable auto-update
 
-Open `/plugin`, go to the **Marketplaces** tab, and toggle auto-update for `sdlc-utilities`.
+Open `/plugin`, go to the **Marketplaces** tab, and toggle auto-update for `sdlc-marketplace`.
 
 ## First Use
 


### PR DESCRIPTION
## Summary
Updates all documentation references from the old repository name `sdlc-utilities` to the new name `sdlc-marketplace`. All installation, update, and cache-clear commands now point to the correct repository.

## JIRA Ticket
Not detected

## Business Context
The repository was renamed from `rnagrodzki/sdlc-utilities` to `rnagrodzki/sdlc-marketplace`. Without this change, users following the existing docs would reference the old name in install and update commands, resulting in errors.

## Business Benefits
Ensures users can successfully install and update the plugin using accurate instructions. Prevents confusion and failure caused by stale references to the old repository name in official documentation.

## Technical Design
Pure text replacement across documentation files. No structural or code changes — all occurrences of `sdlc-utilities` in user-facing install commands, update commands, cache-clear instructions, auto-update UI references, and directory structure examples were updated to `sdlc-marketplace`.

## Technical Impact
N/A — documentation-only change with no effect on any system, API, service, or runtime behavior.

## Changes Overview
All user-facing commands and references updated across the main README, project agents file, architecture guide, and getting-started walkthrough:
- Installation commands updated from the old marketplace source to the new one
- Update and auto-update references corrected
- Troubleshooting cache-clear commands corrected
- Directory structure heading updated to reflect the new name

## Testing
No automated tests applicable to documentation changes. All updated command strings were verified against the renamed repository (`rnagrodzki/sdlc-marketplace`).