### PR TITLE
fix: use absolute path resolution for plugin scripts and agents

### DIFF
--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/review-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/review-orchestrator.md
@@ -13,7 +13,7 @@ the user's main context stays clean.
 ## Inputs (provided in your prompt)
 
 - **MANIFEST_JSON**: The full JSON from `review-prepare.js`
-- **REFERENCE_MD_PATH**: Glob path to locate `**/reviewing-changes/REFERENCE.md`
+- **REFERENCE_MD_PATH**: Absolute path to `reviewing-changes/REFERENCE.md` (resolved by the calling skill)
 
 ## Step 1 — Parse Manifest and Present Plan
 
@@ -42,7 +42,7 @@ included in this review.
 
 ## Step 2 — Dispatch Dimension Subagents
 
-Read REFERENCE.md (locate via Glob at REFERENCE_MD_PATH). Use section 2 "Subagent Prompt Template".
+Read REFERENCE.md at REFERENCE_MD_PATH. Use section 2 "Subagent Prompt Template".
 
 For each dimension with `status: "ACTIVE"` or `status: "TRUNCATED"`:
 

--- a/plugins/sdlc-utilities/commands/pr.md
+++ b/plugins/sdlc-utilities/commands/pr.md
@@ -23,18 +23,17 @@ creates a new one.
 
 ### Step 1: Run the Pre-processing Script
 
-Locate the script:
-
-```text
-**/scripts/pr-prepare.js
-```
-
-Build the command from the arguments passed to this command:
+Locate and run the script:
 
 ```bash
+# Resolve script: check installed plugin location first, then fall back to project tree
+SCRIPT=$(find ~/.claude/plugins -name "pr-prepare.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find . -name "pr-prepare.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate pr-prepare.js. Is the sdlc plugin installed?" >&2; exit 2; }
+
 # Write to temp file — large diffs (100KB+) break shell pipes
 PR_CONTEXT_FILE=$(mktemp /tmp/pr-context-XXXXXX.json)
-node <script-path>/pr-prepare.js $ARGUMENTS > "$PR_CONTEXT_FILE"
+node "$SCRIPT" $ARGUMENTS > "$PR_CONTEXT_FILE"
 EXIT_CODE=$?
 ```
 

--- a/plugins/sdlc-utilities/skills/customizing-pr-template/SKILL.md
+++ b/plugins/sdlc-utilities/skills/customizing-pr-template/SKILL.md
@@ -191,10 +191,11 @@ After the user accepts:
 After writing, locate and run the validation script:
 
 ```bash
-node <script-path>/validate-pr-template.js --project-root .
+SCRIPT=$(find ~/.claude/plugins -name "validate-pr-template.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find . -name "validate-pr-template.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate validate-pr-template.js. Is the sdlc plugin installed?" >&2; exit 2; }
+node "$SCRIPT" --project-root .
 ```
-
-Locate the script with Glob: `**/scripts/validate-pr-template.js`
 
 - If validation **passes**: show the summary table from the script output.
 - If validation **fails**: show the error and offer to fix it automatically.

--- a/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
+++ b/plugins/sdlc-utilities/skills/initializing-review-dimensions/SKILL.md
@@ -10,8 +10,9 @@ Project-aware dimension creator: scan tech stack, propose tailored dimensions wi
 let the user select, write files, and validate with the validation script.
 
 Supporting references (dimension format spec, 5 example dimensions) are in
-`reviewing-changes/REFERENCE.md` and `reviewing-changes/EXAMPLES.md`. Locate them with Glob:
-`**/reviewing-changes/REFERENCE.md`.
+`reviewing-changes/REFERENCE.md` and `reviewing-changes/EXAMPLES.md`. Locate them using Glob
+with `path: ~/.claude` and pattern `**/reviewing-changes/REFERENCE.md`. If not found, retry
+Glob with the default path (cwd). Use the same approach for EXAMPLES.md.
 
 ---
 
@@ -83,8 +84,12 @@ Check `.claude/review-dimensions/` for already-installed dimension files.
 
 In `--add` (expansion) mode:
 
-- Locate the validation script with Glob: `**/scripts/validate-dimensions.js`
-- Run: `node <plugin-scripts-path>/validate-dimensions.js --project-root . --json`
+- Locate the validation script:
+  ```bash
+  SCRIPT=$(find ~/.claude/plugins -name "validate-dimensions.js" -path "*/scripts/*" 2>/dev/null | head -1)
+  [ -z "$SCRIPT" ] && SCRIPT=$(find . -name "validate-dimensions.js" -path "*/scripts/*" 2>/dev/null | head -1)
+  ```
+- Run: `node "$SCRIPT" --project-root . --json`
 - Extract the list of currently installed dimension names from the output
 - Note their trigger patterns so new proposals avoid identical globs
 
@@ -196,10 +201,12 @@ For each selected dimension:
 
 ### Step 7 — Validate Installation
 
-Run the validation script:
+Run the validation script (use `SCRIPT` resolved in Step 2, or re-resolve if Step 2 was skipped):
 
 ```bash
-node <plugin-scripts-path>/validate-dimensions.js --project-root . --markdown
+SCRIPT=$(find ~/.claude/plugins -name "validate-dimensions.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find . -name "validate-dimensions.js" -path "*/scripts/*" 2>/dev/null | head -1)
+node "$SCRIPT" --project-root . --markdown
 ```
 
 Present the markdown output table.

--- a/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
+++ b/plugins/sdlc-utilities/skills/reviewing-changes/SKILL.md
@@ -14,18 +14,17 @@ findings, and posts the consolidated PR comment.
 
 ## Step 1 — Run Preparation Script
 
-Locate the script:
-
-```
-**/scripts/review-prepare.js
-```
-
-Build the command from the arguments passed to this skill:
+Locate and run the script:
 
 ```bash
+# Resolve script: check installed plugin location first, then fall back to project tree
+SCRIPT=$(find ~/.claude/plugins -name "review-prepare.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find . -name "review-prepare.js" -path "*/scripts/*" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate review-prepare.js. Is the sdlc plugin installed?" >&2; exit 2; }
+
 # Write to temp file — large manifests (100KB+) break shell pipes
 MANIFEST_FILE=$(mktemp /tmp/review-manifest-XXXXXX.json)
-node <script-path>/review-prepare.js \
+node "$SCRIPT" \
   --project-root . \
   [--base <branch>]        # include if --base was provided
   [--dimensions <names>]   # include if --dimensions was provided
@@ -82,24 +81,19 @@ Stop here.
 
 ## Step 3 — Spawn Orchestrator Agent
 
-Locate the orchestrator agent definition:
+Locate the orchestrator agent definition using Glob with `path: ~/.claude` and pattern
+`**/agents/review-orchestrator.md`. If not found, retry Glob with the default path (cwd).
 
-```
-**/agents/review-orchestrator.md
-```
-
-Locate the reference templates:
-
-```
-**/reviewing-changes/REFERENCE.md
-```
+Locate the reference templates using Glob with `path: ~/.claude` and pattern
+`**/reviewing-changes/REFERENCE.md`. If not found, retry Glob with the default path (cwd).
+Store the resolved absolute path as `REFERENCE_MD_PATH`.
 
 Spawn a single Agent (subagent_type: general-purpose) with the orchestrator agent's
 instructions and this context embedded in the prompt:
 
 ```
 MANIFEST_JSON: {the full JSON manifest from Step 1}
-REFERENCE_MD_PATH: **/reviewing-changes/REFERENCE.md
+REFERENCE_MD_PATH: {resolved absolute path to REFERENCE.md from above}
 ```
 
 Wait for the orchestrator to complete and return results.


### PR DESCRIPTION
## Summary
Fixes script and agent path resolution across the sdlc-utilities plugin by replacing glob-based `**/<filename>` patterns with explicit `find`-based resolution that checks the installed plugin cache first, then falls back to the local project tree.

## JIRA Ticket
Not detected

## Business Context
The plugin is distributed via the Claude Code marketplace and installed into `~/.claude/plugins/cache/`. The previous glob patterns worked in development (where scripts live in the project tree) but failed when users installed the plugin via `/plugin install`, causing all script-dependent commands to break.

## Business Benefits
All marketplace-installed users of `/sdlc:pr`, `/sdlc:review`, `/sdlc:review-init`, and `/sdlc:pr-customize` will have reliably working commands after this fix. Removes a silent failure mode that would only surface at runtime.

## Technical Design
Each script reference is now resolved with a two-step `find` strategy: check `~/.claude/plugins` (marketplace install location) first, then fall back to the project directory. This makes the resolution order explicit and predictable for both installed and development usage. The review orchestrator is updated to receive a pre-resolved absolute path for `REFERENCE.md` rather than being responsible for its own glob resolution.

## Technical Impact
All command and skill files that invoke helper scripts are affected: the PR creation command, reviewing-changes skill, review-orchestrator agent, dimension initialization skill, and PR template customization skill. No breaking changes — the resolution logic is fully backwards-compatible with local development usage.

## Changes Overview
- Script lookup logic updated in the PR creation and code review workflows to use `find`-based absolute resolution
- Dimension initialization and PR template validation updated with the same resolution pattern
- Review orchestrator decoupled from glob-based path resolution — now receives a pre-resolved absolute path from the calling skill
- Reviewing-changes skill updated to resolve orchestrator and reference files using `path: ~/.claude` Glob calls with cwd fallback
- Plugin version bumped to 0.3.5

## Testing
Verified by the structure of the fix itself: the `find ~/.claude/plugins ... | head -1` pattern is the standard way to locate files in the Claude plugin cache. The fallback to `find .` preserves existing behavior for contributors running skills from the project directory.