### PR TITLE
feat: add user-approval gate before posting review comments

### DIFF
--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/review-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/review-orchestrator.md
@@ -19,7 +19,7 @@ the user's main context stays clean.
 
 Parse MANIFEST_JSON. Display the review plan:
 
-```
+```text
 Review Plan
   Base branch:   {base_branch}
   Changed files: {git.changed_files.length}
@@ -54,7 +54,7 @@ For each dimension with `status: "ACTIVE"` or `status: "TRUNCATED"`:
    - `{filtered diff}` → the content read from `dimension.diff_file`
    - Add commit context section before the Output Format section:
 
-     ```
+     ```text
      ## Commit Context
 
      Use these to understand the author's intent:
@@ -102,18 +102,38 @@ Format the comment using the template from REFERENCE.md section 3.
 - `APPROVED WITH NOTES` — any `high` finding, OR ≥ 5 `medium` findings
 - `APPROVED` — all other cases
 
-**Post the comment:**
+**Present for confirmation:**
 
-If `manifest.pr.exists`:
+If `manifest.pr.exists`, display the full formatted comment and ask for explicit user
+approval before posting. **Do not execute `gh api` without explicit user approval.**
 
-```bash
-gh api repos/{manifest.pr.owner}/{manifest.pr.repo}/issues/{manifest.pr.number}/comments \
-  -f body="{comment}"
+```text
+Review comment ready to post to PR #{manifest.pr.number}:
+─────────────────────────────────────────────
+{consolidated comment}
+─────────────────────────────────────────────
+
+Post this review comment to PR #{manifest.pr.number}? (yes / save / cancel)
+  yes    — post the comment to the PR
+  save   — save review to .claude/reviews/<branch>-<date>.md instead
+  cancel — keep in terminal only (already shown above)
 ```
+
+Wait for the user's response:
+
+- `yes` → post via `gh api`:
+
+  ```bash
+  gh api repos/{manifest.pr.owner}/{manifest.pr.repo}/issues/{manifest.pr.number}/comments \
+    -f body="{comment}"
+  ```
+
+- `save` → write the review to `.claude/reviews/<branch>-<date>.md`
+- `cancel` → skip posting; review is already visible in the terminal
 
 If no PR: present the full review in the terminal, then offer:
 
-```
+```text
 No PR found. Options:
   1. Create a draft PR to attach this review as a comment
   2. Save review to .claude/reviews/<branch>-<date>.md
@@ -128,7 +148,7 @@ comment to the new PR using the `gh api` command above.
 
 Output this summary for the main context to display:
 
-```
+```text
 Review complete
   Dimensions run:  {active} ({skipped} skipped — no matching files)
   Total findings:  {total}
@@ -147,3 +167,7 @@ Before returning:
 - All findings reference a specific `file:line`
 - Verdict computed from actual severity counts (not hardcoded)
 - Temp diff directory (`manifest.diff_dir`) has been removed
+
+## DO NOT
+
+- Post the review comment to a PR via `gh api` without explicit user approval


### PR DESCRIPTION
## Summary

Adds an explicit user-approval gate to the review-orchestrator agent before posting review comments to GitHub PRs. Users are shown the full formatted comment and prompted to choose: post, save locally, or cancel. Bumps the plugin version to 0.5.0.

## Business Context

Users running `/sdlc:review` on a branch with an open PR had no opportunity to review the generated comment before it was posted publicly. This is a safety gap — automated actions that post to shared state (GitHub PR comments) should always require explicit user approval.

## Business Benefits

- Users can inspect and approve review comments before they appear on the PR
- Prevents accidental posting of incorrect or incomplete review feedback
- Adds a `save` option so reviews can be persisted locally without posting
- Aligns with the project principle that actions affecting shared state require explicit consent

## Technical Design

Updated `review-orchestrator.md` to display the full consolidated comment and present a three-option confirmation prompt (`yes` / `save` / `cancel`) before executing `gh api`. The `save` path writes the review to `.claude/reviews/<branch>-<date>.md`. Also fixed several fenced code blocks that were missing the `text` language identifier. Added a "DO NOT" section explicitly prohibiting posting without user approval.

## Technical Impact

The review-orchestrator agent no longer auto-posts review comments — it now waits for explicit user approval. This is a **behavioral breaking change** for any workflow that expected automatic posting after a review run. No changes to skill interfaces, hook payloads, or script APIs.

## Changes Overview

- `plugins/sdlc-utilities/.claude-plugin/plugin.json` — Version bumped from 0.4.0 to 0.5.0
- `plugins/sdlc-utilities/agents/review-orchestrator.md` — Added user-approval flow with yes/save/cancel menu before posting review comment; fixed fenced code block language identifiers (` ``` ` → ` ```text `); added "DO NOT" section prohibiting auto-posting

## Testing

Manually reviewed the agent file changes. The approval gate logic is declarative (agent instructions), so correctness is verified by reading the diff. No automated tests exist for agent behavior in this repository.