### PR TITLE
chore(release): bump version to 0.5.1 and add version config

### DIFF
--- a/.claude/version.json
+++ b/.claude/version.json
@@ -1,0 +1,8 @@
+{
+  "mode": "file",
+  "versionFile": "plugins/sdlc-utilities/.claude-plugin/plugin.json",
+  "fileType": "plugin.json",
+  "tagPrefix": "v",
+  "changelog": false,
+  "changelogFile": "CHANGELOG.md"
+}

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "rnagrodzki"
   }


### PR DESCRIPTION
## Summary
Adds the `.claude/version.json` configuration file for the `/sdlc:version` command and bumps the plugin version from 0.5.0 to 0.5.1.

## Business Context
The `/sdlc:version` command was introduced in v0.5.0 but lacked a version configuration file in this repository, meaning the command couldn't automatically locate and bump the plugin version. This PR closes that gap.

## Business Benefits
- Enables automated semantic versioning for the sdlc-utilities plugin via `/sdlc:version`
- Eliminates manual version editing in `plugin.json`, reducing release friction

## Technical Design
Added a `version.json` configuration that points the versioning skill to the plugin manifest (`plugin.json`), uses `v`-prefixed tags, and disables changelog generation. The plugin version was bumped to 0.5.1 to reflect the release.

## Technical Impact
None. The new config file is additive and the version bump is backwards-compatible.

## Changes Overview
- `.claude/version.json` — new versioning configuration targeting the plugin manifest
- `plugins/sdlc-utilities/.claude-plugin/plugin.json` — version bump from 0.5.0 to 0.5.1

## Testing
Verified by running `/sdlc:version` to confirm the configuration is correctly detected and the version field is updated in `plugin.json`.