### PR TITLE
fix: update script comments and messages for renamed skills

### DIFF
--- a/plugins/sdlc-utilities/scripts/pr-prepare.js
+++ b/plugins/sdlc-utilities/scripts/pr-prepare.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * pr-prepare.js
- * Pre-computes all data needed for the sdlc-creating-pull-requests skill:
+ * Pre-computes all data needed for the pr-sdlc skill:
  * git state, remote sync, PR mode detection, commit history, diff, JIRA ticket.
  * Outputs JSON to stdout so the LLM can focus solely on description generation.
  *

--- a/plugins/sdlc-utilities/scripts/review-prepare.js
+++ b/plugins/sdlc-utilities/scripts/review-prepare.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * review-prepare.js
- * Pre-computes all data needed for the sdlc-reviewing-changes skill:
+ * Pre-computes all data needed for the review-sdlc skill:
  * git state, changed files, dimension matching, diff splitting,
  * commit context, PR metadata. Outputs JSON manifest + per-dimension
  * .diff files to a temp directory.
@@ -503,7 +503,7 @@ function main() {
 
   const dims = loadAndMatchDimensions(projectRoot, changedFiles, dimensionFilter);
   if (dims.length === 0) {
-    process.stderr.write('No review dimensions found in .claude/review-dimensions/.\nRun /sdlc:review-init to create tailored review dimensions.\n');
+    process.stderr.write('No review dimensions found in .claude/review-dimensions/.\nRun /review-init-sdlc to create tailored review dimensions.\n');
     process.exit(1);
   }
 

--- a/plugins/sdlc-utilities/scripts/validate-dimensions.js
+++ b/plugins/sdlc-utilities/scripts/validate-dimensions.js
@@ -62,7 +62,7 @@ function formatMarkdown(report) {
   if (report.dimensions.length === 0) {
     lines.push(`No dimension files found in \`${report.dimensions_dir}\`.`);
     lines.push('');
-    lines.push('Run `/sdlc:review-init` to create tailored review dimensions for this project.');
+    lines.push('Run `/review-init-sdlc` to create tailored review dimensions for this project.');
     return lines.join('\n');
   }
 

--- a/plugins/sdlc-utilities/scripts/version-prepare.js
+++ b/plugins/sdlc-utilities/scripts/version-prepare.js
@@ -2,9 +2,9 @@
 /**
  * version-prepare.js
  *
- * Pre-processing script for the /sdlc:version command.
+ * Pre-processing script for the /version-sdlc command.
  * Collects version source, git tags, commits since last tag, and remote state
- * into a single JSON blob consumed by the sdlc-versioning-releases skill.
+ * into a single JSON blob consumed by the version-sdlc skill.
  *
  * Usage:
  *   node version-prepare.js [major|minor|patch] [--init] [--pre <label>]
@@ -240,7 +240,7 @@ async function main() {
   }
 
   if (!config) {
-    errors.push('No version config found. Run /sdlc:version --init to set up versioning for this project.');
+    errors.push('No version config found. Run /version-sdlc --init to set up versioning for this project.');
     output({ flow: 'release', errors, warnings }, 1);
     return;
   }


### PR DESCRIPTION
## Summary

- Updates JSDoc header comments in `pr-prepare.js`, `review-prepare.js`, and `version-prepare.js` to reference the new skill names (`pr-sdlc`, `review-sdlc`, `version-sdlc`)
- Updates user-facing error messages in `review-prepare.js` and `version-prepare.js` to reference the new command invocations (`/review-init-sdlc`, `/version-sdlc --init`)
- Updates the markdown output in `validate-dimensions.js` to suggest `/review-init-sdlc` instead of `/sdlc:review-init`

## Test plan

- [ ] Verify `node plugins/sdlc-utilities/scripts/validate-dimensions.js --markdown` outputs `/review-init-sdlc` in the empty-dimensions message
- [ ] Verify `node plugins/sdlc-utilities/scripts/version-prepare.js` (with no config) outputs error referencing `/version-sdlc --init`
- [ ] Verify `node plugins/sdlc-utilities/scripts/review-prepare.js` (with no dimensions dir) outputs stderr referencing `/review-init-sdlc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)