### PR TITLE
fix: update project config files for renamed skills

### DIFF
--- a/.claude/review-dimensions/runtime-contract.md
+++ b/.claude/review-dimensions/runtime-contract.md
@@ -14,7 +14,7 @@ severity: high
 
 # Runtime Contract Review
 
-Review the command→script→skill execution pipeline for correctness and resilience. Every command in this project follows the pattern: resolve script → run to temp file → read JSON → delegate to skill. A documented version skew bug in `sdlc-creating-pull-requests` (installed `pr-prepare.js` silently omitting `customTemplate`) illustrates how contract violations surface only at runtime. This dimension checks that all parties in the pipeline — command, script, and skill — agree on the interface.
+Review the command→script→skill execution pipeline for correctness and resilience. Every command in this project follows the pattern: resolve script → run to temp file → read JSON → delegate to skill. A documented version skew bug in `pr-sdlc` (installed `pr-prepare.js` silently omitting `customTemplate`) illustrates how contract violations surface only at runtime. This dimension checks that all parties in the pipeline — command, script, and skill — agree on the interface.
 
 ## Checklist
 

--- a/.claude/review-dimensions/script-resolution.md
+++ b/.claude/review-dimensions/script-resolution.md
@@ -22,7 +22,7 @@ Review the runtime script resolution and file reference lookup patterns embedded
 - [ ] Every resolution block ends with a failure guard: `[ -z "$SCRIPT" ] && { echo "ERROR: ..."; exit 2; }` — no silent continuation with an empty `$SCRIPT`
 - [ ] The error message in the failure guard names the specific script and explains how to fix it (e.g., "Is the sdlc plugin installed?")
 - [ ] Glob-based reference file lookups (REFERENCE.md, EXAMPLES.md, agent definitions) use `path: ~/.claude` first and explicitly document a cwd fallback if not found
-- [ ] Glob patterns for reference file lookups are specific enough to match exactly one file — e.g., `**/sdlc-reviewing-changes/REFERENCE.md` not `**/REFERENCE.md`
+- [ ] Glob patterns for reference file lookups are specific enough to match exactly one file — e.g., `**/review-sdlc/REFERENCE.md` not `**/REFERENCE.md`
 - [ ] No resolution pattern uses hardcoded absolute paths other than the conventional `~/.claude/plugins` prefix
 - [ ] When a skill re-resolves the same script in a later step (e.g., first in Step 2 for validation, then in Step 7 for execution), both resolution blocks use identical find patterns — no divergent logic for the same script
 - [ ] `head -1` is used after `find` to pick one result — verify the script name is specific enough that exactly one match is expected; flag if the name is generic enough to create ambiguity

--- a/.github/instructions/script-resolution.instructions.md
+++ b/.github/instructions/script-resolution.instructions.md
@@ -15,7 +15,7 @@ Default severity: high
 - Every resolution block ends with a failure guard: `[ -z "$SCRIPT" ] && { echo "ERROR: ..."; exit 2; }` — no silent continuation with an empty `$SCRIPT`
 - The error message in the failure guard names the specific script and explains how to fix it (e.g., "Is the sdlc plugin installed?")
 - Glob-based reference file lookups (REFERENCE.md, EXAMPLES.md, agent definitions) use `path: ~/.claude` first and explicitly document a cwd fallback if not found
-- Glob patterns for reference file lookups are specific enough to match exactly one file — e.g., `**/sdlc-reviewing-changes/REFERENCE.md` not `**/REFERENCE.md`
+- Glob patterns for reference file lookups are specific enough to match exactly one file — e.g., `**/review-sdlc/REFERENCE.md` not `**/REFERENCE.md`
 - No resolution pattern uses hardcoded absolute paths other than the conventional `~/.claude/plugins` prefix
 - When a skill re-resolves the same script in a later step, both resolution blocks use identical find patterns — no divergent logic for the same script
 - `head -1` is used after `find` — verify the script name is specific enough that exactly one match is expected


### PR DESCRIPTION
## Summary

- Updates `sdlc-creating-pull-requests` → `pr-sdlc` in `.claude/review-dimensions/runtime-contract.md`
- Updates `sdlc-reviewing-changes` → `review-sdlc` example in `.claude/review-dimensions/script-resolution.md`
- Updates `sdlc-reviewing-changes` → `review-sdlc` example in `.github/instructions/script-resolution.instructions.md`

## Test plan

- [ ] Confirm no old skill names (`sdlc-creating-pull-requests`, `sdlc-reviewing-changes`) remain in the three files
- [ ] Confirm the updated names match the rename mapping (`pr-sdlc`, `review-sdlc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)