### PR TITLE
fix: update test datasets and fixtures for renamed skills

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ tasks:
       - promptfoo eval --config promptfooconfig-exec.yaml --env-file .env
 
   test:skill:
-    desc: "Run tests for specific skills (args: skill name, e.g. task test:skill -- sdlc-creating-pull-requests)"
+    desc: "Run tests for specific skills (args: skill name, e.g. task test:skill -- pr-sdlc)"
     silent: true
     dir: tests/promptfoo
     cmds:

--- a/tests/promptfoo/README.md
+++ b/tests/promptfoo/README.md
@@ -17,7 +17,7 @@ From repo root:
 task test          # LLM behavioral tests (all 6 skills)
 task test:exec     # Script execution tests (no LLM, fast)
 task test:all      # Both behavioral and exec tests
-task test:skill -- sdlc-creating-pull-requests  # Single skill
+task test:skill -- pr-sdlc  # Single skill
 task test:view     # Open web UI to inspect results
 ```
 

--- a/tests/promptfoo/datasets/plugin-check-sdlc.yaml
+++ b/tests/promptfoo/datasets/plugin-check-sdlc.yaml
@@ -2,12 +2,12 @@
 #   healthy-plugin-structure -- CORRECT: all 16 checks pass
 #   broken-plugin-structure  -- CORRECT: 3 errors + 1 warning, specific PD IDs fail
 
-- description: "sdlc-validating-plugin-discovery: all 16 checks pass on healthy structure"
+- description: "plugin-check-sdlc: all 16 checks pass on healthy structure"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-validating-plugin-discovery/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/plugin-check-sdlc/SKILL.md"
     project_context: "file://fixtures/healthy-plugin-structure.md"
     user_request: >
-      Run /sdlc:plugin-check. The validate-discovery.js report is provided in the project context
+      Run /plugin-check-sdlc. The validate-discovery.js report is provided in the project context
       showing all checks passing. Display the results.
   assert:
     # Must report passing status
@@ -29,12 +29,12 @@
         actions beyond confirming the plugin is correctly wired. It does not fabricate any failing
         checks not present in the fixture.
 
-- description: "sdlc-validating-plugin-discovery: failed checks shown with fix guidance"
+- description: "plugin-check-sdlc: failed checks shown with fix guidance"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-validating-plugin-discovery/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/plugin-check-sdlc/SKILL.md"
     project_context: "file://fixtures/broken-plugin-structure.md"
     user_request: >
-      Run /sdlc:plugin-check. The validate-discovery.js report from the project context shows
+      Run /plugin-check-sdlc. The validate-discovery.js report from the project context shows
       4 failing checks. Display the failures and provide fix guidance.
   assert:
     # Must report specific failing check IDs

--- a/tests/promptfoo/datasets/pr-customize-sdlc.yaml
+++ b/tests/promptfoo/datasets/pr-customize-sdlc.yaml
@@ -3,11 +3,11 @@
 #   project-with-pr-template  -- CORRECT: validates editing existing template
 #   project-with-dimensions   -- INVALID: review context, not PR template context
 
-- description: "sdlc-customizing-pr-template: proposes new template from scanned project signals"
+- description: "pr-customize-sdlc: proposes new template from scanned project signals"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-customizing-pr-template/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-customize-sdlc/SKILL.md"
     project_context: "file://fixtures/project-no-pr-template.md"
-    user_request: "Run /sdlc:pr-customize to create a PR template for this project."
+    user_request: "Run /pr-customize-sdlc to create a PR template for this project."
   assert:
     # Must propose section headings
     - type: regex
@@ -28,11 +28,11 @@
         of at least 20 characters. It presents the proposal and asks the user to accept, edit,
         or customize specific sections.
 
-- description: "sdlc-customizing-pr-template: edits existing template preserving custom sections"
+- description: "pr-customize-sdlc: edits existing template preserving custom sections"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-customizing-pr-template/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-customize-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-pr-template.md"
-    user_request: "Run /sdlc:pr-customize to update the existing PR template."
+    user_request: "Run /pr-customize-sdlc to update the existing PR template."
   assert:
     # Must reference the existing custom sections
     - type: regex

--- a/tests/promptfoo/datasets/pr-sdlc.yaml
+++ b/tests/promptfoo/datasets/pr-sdlc.yaml
@@ -6,12 +6,12 @@
 #   project-with-dimensions        -- INVALID: not a PR context
 #   project-no-dimensions          -- INVALID: not a PR context
 
-- description: "sdlc-creating-pull-requests: standard PR creation with all 8 sections"
+- description: "pr-sdlc: standard PR creation with all 8 sections"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-creating-pull-requests/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-with-commits.md"
     user_request: >
-      Run /sdlc:pr for this feature branch. The pr-prepare.js output is provided in the project
+      Run /pr-sdlc for this feature branch. The pr-prepare.js output is provided in the project
       context above. Generate the PR title and all required sections of the description.
   assert:
     # Must produce section headings (at least Summary)
@@ -37,12 +37,12 @@
         paths). Business sections (Business Context, Business Benefits) are either filled with
         evidence-based content or marked N/A with reasoning — they are not left blank.
 
-- description: "sdlc-creating-pull-requests: JIRA ticket auto-detected from branch name"
+- description: "pr-sdlc: JIRA ticket auto-detected from branch name"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-creating-pull-requests/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-jira.md"
     user_request: >
-      Run /sdlc:pr for this branch. The pr-prepare.js output is in the project context.
+      Run /pr-sdlc for this branch. The pr-prepare.js output is in the project context.
       Generate the full PR title and description.
   assert:
     # Must detect and show PROJ-456
@@ -59,12 +59,12 @@
         a different ticket number or say "Not detected". The PR title and description focus on
         the authentication timeout fix described in the commits.
 
-- description: "sdlc-creating-pull-requests: custom template replaces default 8 sections"
+- description: "pr-sdlc: custom template replaces default 8 sections"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-creating-pull-requests/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-custom-template.md"
     user_request: >
-      Run /sdlc:pr for this feature branch. The pr-prepare.js output is provided in the project
+      Run /pr-sdlc for this feature branch. The pr-prepare.js output is provided in the project
       context above. Generate the PR title and all required sections of the description.
   assert:
     # Must produce all 3 custom template sections
@@ -102,11 +102,11 @@
         changes were verified (references the integration and unit tests visible in the diff).
         No content is fabricated — all claims trace back to the commits and diff provided.
 
-- description: "sdlc-creating-pull-requests: main branch rejected with clear error"
+- description: "pr-sdlc: main branch rejected with clear error"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-creating-pull-requests/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-on-main.md"
-    user_request: "Run /sdlc:pr to create a pull request."
+    user_request: "Run /pr-sdlc to create a pull request."
   assert:
     # Must mention the reason for rejection (main/master/protected/error)
     - type: regex

--- a/tests/promptfoo/datasets/review-init-sdlc.yaml
+++ b/tests/promptfoo/datasets/review-init-sdlc.yaml
@@ -4,11 +4,11 @@
 #   project-with-cicd-monorepo -- CORRECT: TypeScript monorepo + CI/CD; tests extended dimension catalog
 #   healthy-plugin-structure   -- INVALID: plugin manifest context, not a project to scan
 
-- description: "sdlc-initializing-review-dimensions: scans tech stack and proposes tailored dimensions"
+- description: "review-init-sdlc: scans tech stack and proposes tailored dimensions"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-initializing-review-dimensions/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-init-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-tech-stack.md"
-    user_request: "Run /sdlc:review-init to scan this project and propose review dimensions."
+    user_request: "Run /review-init-sdlc to scan this project and propose review dimensions."
   assert:
     # Must always include the baseline code-quality dimension
     - type: icontains
@@ -32,11 +32,11 @@
         in the fixture. Trigger patterns reference the actual project directories (src/components/,
         src/pages/, __tests__/).
 
-- description: "sdlc-initializing-review-dimensions: monorepo with CI/CD gets extended dimension proposals"
+- description: "review-init-sdlc: monorepo with CI/CD gets extended dimension proposals"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-initializing-review-dimensions/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-init-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-cicd-monorepo.md"
-    user_request: "Run /sdlc:review-init to scan this project and propose review dimensions."
+    user_request: "Run /review-init-sdlc to scan this project and propose review dimensions."
   assert:
     # Must always include baseline
     - type: icontains
@@ -65,11 +65,11 @@
         security, api-review, or data-integrity dimensions since there is no auth/ORM/route
         evidence in the fixture. It presents the proposals to the user before creating files.
 
-- description: "sdlc-initializing-review-dimensions: Python/FastAPI project gets appropriate proposals"
+- description: "review-init-sdlc: Python/FastAPI project gets appropriate proposals"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-initializing-review-dimensions/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-init-sdlc/SKILL.md"
     project_context: "file://fixtures/project-no-dimensions.md"
-    user_request: "Run /sdlc:review-init for this project."
+    user_request: "Run /review-init-sdlc for this project."
   assert:
     # Must always include baseline
     - type: icontains

--- a/tests/promptfoo/datasets/review-sdlc.yaml
+++ b/tests/promptfoo/datasets/review-sdlc.yaml
@@ -4,12 +4,12 @@
 #   project-no-dimensions              -- CORRECT: edge case; no dimensions installed → error + suggestion
 #   feature-branch-*                   -- INVALID: PR context, not review context
 
-- description: "sdlc-reviewing-changes: multi-dimension review with active dimensions"
+- description: "review-sdlc: multi-dimension review with active dimensions"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-reviewing-changes/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-dimensions.md"
     user_request: >
-      Run /sdlc:review on this project. The review-prepare.js manifest is provided in the
+      Run /review-sdlc on this project. The review-prepare.js manifest is provided in the
       project context. Display the review plan showing which dimensions are active.
   assert:
     # Must reference dimensions concept
@@ -31,12 +31,12 @@
         The response mentions the specific dimension names and does not fabricate additional
         dimensions not present in the manifest.
 
-- description: "sdlc-reviewing-changes: dry-run shows plan without dispatching agents"
+- description: "review-sdlc: dry-run shows plan without dispatching agents"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-reviewing-changes/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-dimensions.md"
     user_request: >
-      Run /sdlc:review --dry-run on this project. The review-prepare.js manifest is in the
+      Run /review-sdlc --dry-run on this project. The review-prepare.js manifest is in the
       project context. Show the review plan only — do not dispatch any review agents.
   assert:
     # Must acknowledge dry-run mode
@@ -58,12 +58,12 @@
         NOT produce any actual code review findings or comments. It describes what would happen
         if the --dry-run flag were omitted.
 
-- description: "sdlc-reviewing-changes: surfaces dimension suggestions for uncovered files"
+- description: "review-sdlc: surfaces dimension suggestions for uncovered files"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-reviewing-changes/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-uncovered-suggestions.md"
     user_request: >
-      Run /sdlc:review on this project. The review-prepare.js manifest is in the project context.
+      Run /review-sdlc on this project. The review-prepare.js manifest is in the project context.
       Show the review plan including any suggestions for uncovered files.
   assert:
     # Must mention the suggested dimension names
@@ -72,10 +72,10 @@
     # Must reference the uncovered file paths or types
     - type: regex
       value: '(workflows|ci\.yml|config|\.env)'
-    # Must point to review-init --add
+    # Must point to review-init-sdlc --add
     - type: regex
-      value: "(review-init|--add)"
-    # Behavioral: surfaces suggestions, directs user to review-init
+      value: "(review-init-sdlc|--add)"
+    # Behavioral: surfaces suggestions, directs user to review-init-sdlc
     - type: llm-rubric
       value: >
         The response reads the manifest showing 5 uncovered files with 2 dimension suggestions:
@@ -83,25 +83,25 @@
         configuration-management-review (for src/config/db.ts, src/config/auth.ts, .env.example).
         It displays these suggestions in the review plan — either in a "Suggested new dimensions"
         block or as plan critique warnings — and references the specific file paths or types.
-        It recommends running /sdlc:review-init --add to create those dimensions. It does NOT
+        It recommends running /review-init-sdlc --add to create those dimensions. It does NOT
         create the dimension files itself during the review run.
 
-- description: "sdlc-reviewing-changes: no dimensions installed reports error and suggests review-init"
+- description: "review-sdlc: no dimensions installed reports error and suggests review-init-sdlc"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-reviewing-changes/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
     project_context: "file://fixtures/project-no-dimensions.md"
-    user_request: "Run /sdlc:review on this project."
+    user_request: "Run /review-sdlc on this project."
   assert:
     # Must report the missing dimensions problem
     - type: regex
       value: "(no.+dimension|dimension.+not.+found|no review dimension|0 dimension)"
-    # Must suggest running review-init
+    # Must suggest running review-init-sdlc
     - type: regex
-      value: "(review-init|/sdlc:review-init)"
+      value: "(review-init-sdlc|/review-init-sdlc)"
     # Behavioral: clear error message, correct suggestion
     - type: llm-rubric
       value: >
         The response reads the error from the review-prepare.js manifest (no dimensions found)
         and clearly reports that no review dimensions are installed. It recommends running
-        /sdlc:review-init to create tailored dimensions for this Python/FastAPI project. It does
+        /review-init-sdlc to create tailored dimensions for this Python/FastAPI project. It does
         NOT fabricate a review without dimensions. The message is clear and actionable.

--- a/tests/promptfoo/datasets/version-sdlc.yaml
+++ b/tests/promptfoo/datasets/version-sdlc.yaml
@@ -3,12 +3,12 @@
 #   project-no-version-config    -- CORRECT: init flow detects package.json
 #   feature-branch-with-commits  -- INVALID: PR context, not versioning context
 
-- description: "sdlc-versioning-releases: release flow warns about breaking change"
+- description: "version-sdlc: release flow warns about breaking change"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-versioning-releases/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-version-config.md"
     user_request: >
-      Run /sdlc:version patch. The version-prepare.js output is provided in the project context.
+      Run /version-sdlc patch. The version-prepare.js output is provided in the project context.
       Show the release plan and any warnings.
   assert:
     # Must reference the current or next version
@@ -30,12 +30,12 @@
         and asks the user to confirm before proceeding. It does NOT silently apply the patch bump
         despite the breaking change.
 
-- description: "sdlc-versioning-releases: init flow detects package.json and proposes config"
+- description: "version-sdlc: init flow detects package.json and proposes config"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-versioning-releases/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
     project_context: "file://fixtures/project-no-version-config.md"
     user_request: >
-      Run /sdlc:version --init. The version-prepare.js output is in the project context.
+      Run /version-sdlc --init. The version-prepare.js output is in the project context.
       Show the detected setup and proposed configuration.
   assert:
     # Must identify the version file
@@ -56,12 +56,12 @@
         to confirm (accept/modify/cancel) before writing the config file. It does NOT write any
         files in this simulation — it describes what would happen with confirmation.
 
-- description: "sdlc-versioning-releases: hotfix release annotates commit and tag"
+- description: "version-sdlc: hotfix release annotates commit and tag"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-versioning-releases/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
     project_context: "file://fixtures/project-hotfix-release.md"
     user_request: >
-      Run /sdlc:version patch --hotfix. The version-prepare.js output is provided
+      Run /version-sdlc patch --hotfix. The version-prepare.js output is provided
       in the project context. Show the release plan.
   assert:
     # Must show version bump
@@ -87,12 +87,12 @@
         It asks the user to confirm (yes / edit / cancel) before proceeding. It does NOT execute
         any git commands without explicit user approval.
 
-- description: "sdlc-versioning-releases: regular release does not include hotfix annotation"
+- description: "version-sdlc: regular release does not include hotfix annotation"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-versioning-releases/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
     project_context: "file://fixtures/project-with-version-config.md"
     user_request: >
-      Run /sdlc:version major. The version-prepare.js output is provided in the project context.
+      Run /version-sdlc major. The version-prepare.js output is provided in the project context.
       Show the release plan. This is NOT a hotfix — do not use the --hotfix flag.
   assert:
     # Must show version bump
@@ -114,15 +114,15 @@
         release attribute anywhere. It warns about the breaking change detected and asks the user
         to confirm before proceeding.
 
-- description: "sdlc-versioning-releases: release blocked when version config missing"
+- description: "version-sdlc: release blocked when version config missing"
   vars:
-    skill_path: "plugins/sdlc-utilities/skills/sdlc-versioning-releases/SKILL.md"
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
     project_context: >
       The user is on branch feat/add-search, trying to cut a release. Running version-prepare.js
       produces this JSON output:
-      {"flow": "release", "errors": ["No version config found. Run /sdlc:version --init to set up
+      {"flow": "release", "errors": ["No version config found. Run /version-sdlc --init to set up
       versioning for this project."], "warnings": [], "currentVersion": null, "config": null}
-    user_request: "Run /sdlc:version minor to cut a release."
+    user_request: "Run /version-sdlc minor to cut a release."
   assert:
     # Must report the error
     - type: regex
@@ -132,11 +132,11 @@
       value: "Release Plan"
     # Must suggest --init
     - type: regex
-      value: "(--init|version --init|sdlc:version --init)"
+      value: "(--init|version-sdlc --init|/version-sdlc --init)"
     # Behavioral: surfaces error, suggests init, does not attempt release
     - type: llm-rubric
       value: >
         The response reads the error from version-prepare.js ("No version config found") and
-        clearly reports that the release cannot proceed. It recommends running /sdlc:version --init
+        clearly reports that the release cannot proceed. It recommends running /version-sdlc --init
         first to initialize versioning configuration. It does NOT attempt to guess a version or
         proceed with a release. The message is actionable and references the correct command.

--- a/tests/promptfoo/fixtures-fs/broken-marketplace/plugins/sdlc-utilities/commands/pr.md
+++ b/tests/promptfoo/fixtures-fs/broken-marketplace/plugins/sdlc-utilities/commands/pr.md
@@ -1,5 +1,0 @@
----
-description: Create or update a GitHub pull request.
----
-
-Invoke the `sdlc-nonexistent` skill with the provided arguments.

--- a/tests/promptfoo/fixtures-fs/healthy-marketplace/plugins/sdlc-utilities/commands/pr.md
+++ b/tests/promptfoo/fixtures-fs/healthy-marketplace/plugins/sdlc-utilities/commands/pr.md
@@ -1,7 +1,0 @@
----
-description: Create or update a GitHub pull request with an auto-generated description.
----
-
-Run the `sdlc-creating-pull-requests` skill to create or update a pull request.
-
-Invoke the `sdlc-creating-pull-requests` skill with the provided arguments.

--- a/tests/promptfoo/fixtures-fs/healthy-marketplace/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/tests/promptfoo/fixtures-fs/healthy-marketplace/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: sdlc-creating-pull-requests
+name: pr-sdlc
 description: Creates or updates GitHub pull requests with auto-generated 8-section descriptions.
 ---
 
-# sdlc-creating-pull-requests
+# pr-sdlc
 
 This skill automates pull request creation with structured descriptions.

--- a/tests/promptfoo/fixtures/feature-branch-on-main.md
+++ b/tests/promptfoo/fixtures/feature-branch-on-main.md
@@ -29,6 +29,6 @@
 
 ## Context
 
-The user attempted to run `/sdlc:pr` while on the `main` branch. The script detected this
+The user attempted to run `/pr-sdlc` while on the `main` branch. The script detected this
 protected branch and returned an error. No diff or commit data is available because
 the operation was blocked before any git queries were made.

--- a/tests/promptfoo/fixtures/healthy-plugin-structure.md
+++ b/tests/promptfoo/fixtures/healthy-plugin-structure.md
@@ -13,17 +13,10 @@ plugins/
   sdlc-utilities/
     .claude-plugin/
       plugin.json         ← name: "sdlc", description, version: "0.7.1"
-    commands/
-      pr.md               ← frontmatter: description present
-      review.md           ← frontmatter: description present
-      version.md          ← frontmatter: description present
-      plugin-check.md     ← frontmatter: description present
-      review-init.md      ← frontmatter: description present
-      pr-customize.md     ← frontmatter: description present
     skills/
-      sdlc-creating-pull-requests/
+      pr-sdlc/
         SKILL.md          ← frontmatter: name + description present
-      sdlc-reviewing-changes/
+      review-sdlc/
         SKILL.md          ← frontmatter: name + description present
         REFERENCE.md      ← exists (referenced in SKILL.md)
         EXAMPLES.md       ← exists (referenced in SKILL.md)

--- a/tests/promptfoo/fixtures/project-no-dimensions.md
+++ b/tests/promptfoo/fixtures/project-no-dimensions.md
@@ -30,7 +30,7 @@ httpx==0.25.2
 
 `.claude/review-dimensions/` directory does **not exist**.
 
-No review dimensions have been installed for this project. Running `/sdlc:review-init`
+No review dimensions have been installed for this project. Running `/review-init-sdlc`
 would scan the project and propose dimensions based on the detected stack (FastAPI, SQLAlchemy,
 Alembic migrations, pytest).
 
@@ -48,7 +48,7 @@ Alembic migrations, pytest).
   ],
   "dimensions": [],
   "errors": [
-    "No review dimensions found. Run /sdlc:review-init to create tailored dimensions for this project."
+    "No review dimensions found. Run /review-init-sdlc to create tailored dimensions for this project."
   ]
 }
 ```

--- a/tests/promptfoo/promptfooconfig.yaml
+++ b/tests/promptfoo/promptfooconfig.yaml
@@ -15,9 +15,9 @@ defaultTest:
     provider: "file://providers/claude-cli.js"
 
 tests:
-  - file://datasets/sdlc-creating-pull-requests.yaml
-  - file://datasets/sdlc-reviewing-changes.yaml
-  - file://datasets/sdlc-versioning-releases.yaml
-  - file://datasets/sdlc-validating-plugin-discovery.yaml
-  - file://datasets/sdlc-initializing-review-dimensions.yaml
-  - file://datasets/sdlc-customizing-pr-template.yaml
+  - file://datasets/pr-sdlc.yaml
+  - file://datasets/review-sdlc.yaml
+  - file://datasets/version-sdlc.yaml
+  - file://datasets/plugin-check-sdlc.yaml
+  - file://datasets/review-init-sdlc.yaml
+  - file://datasets/pr-customize-sdlc.yaml


### PR DESCRIPTION
## Summary

- Renamed all 6 dataset YAML files in `tests/promptfoo/datasets/` to match the new short `-sdlc` postfix skill names (e.g. `sdlc-creating-pull-requests.yaml` → `pr-sdlc.yaml`)
- Updated all internal `skill_path` values, `description` prefixes, and command references (`/sdlc:*` → `/<skill>-sdlc`) in every dataset file
- Updated `promptfooconfig.yaml` to reference the renamed dataset files
- Updated `tests/promptfoo/README.md` and `Taskfile.yml` example skill name
- Updated fixture markdown files (`healthy-plugin-structure.md`, `feature-branch-on-main.md`, `project-no-dimensions.md`) to use new skill names and remove the deleted `commands/` directory
- Renamed `fixtures-fs/healthy-marketplace` skill directory from `sdlc-creating-pull-requests` to `pr-sdlc` and updated its `SKILL.md` `name:` field
- Removed `commands/pr.md` from both `healthy-marketplace` and `broken-marketplace` fixture directories (commands/ was deleted from the real plugin)
- Verified `validate-discovery.js` still reports 16/16 passing checks against the updated `healthy-marketplace` fixture

## Test plan

- [ ] Run `task test:exec` to confirm script execution tests still pass
- [ ] Run `task test:skill -- pr-sdlc` to confirm a single skill test resolves correctly
- [ ] Confirm `validate-discovery.js` passes 16/16 on `healthy-marketplace` fixture (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)