### PR TITLE
feat: update docs for skills-primary architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,7 @@ Each plugin lives under `plugins/<name>/` and follows the structure:
 
 ```text
 .claude-plugin/plugin.json   # Plugin manifest
-commands/                    # Slash commands (*.md)
-skills/                      # Skills (one subdirectory each)
+skills/                      # Skills (one subdirectory each; user-invocable skills appear in the / menu)
 hooks/hooks.json             # Session-start and other hooks
 scripts/                     # Node.js helper scripts (optional; invoked via Bash)
 ```
@@ -44,24 +43,24 @@ scripts/                     # Node.js helper scripts (optional; invoked via Bas
 ## Working in This Repository
 
 - **Adding a skill:** Follow `docs/adding-skills.md`. Place the skill under `plugins/<plugin>/skills/<skill-name>/SKILL.md`.
-- **Adding a command:** Follow `docs/adding-commands.md`. Place it under `plugins/<plugin>/commands/<command>.md`.
+- **Adding a command (legacy):** Follow `docs/adding-commands.md`. New functionality should be added as skills with `user-invocable: true` instead.
 - **Adding a hook:** Follow `docs/adding-hooks.md`. Edit `plugins/<plugin>/hooks/hooks.json`.
 - **Plugin manifest fields:** See `docs/architecture.md` for required fields in `plugin.json`.
 
 ---
 
-## Documenting Commands
+## Documenting Skills
 
-Every command must have a dedicated reference doc in `docs/commands/<command-name>.md`. Use `docs/command-template.md` as the starting point.
+Every skill must have a dedicated reference doc in `docs/skills/<skill-name>.md`. Use `docs/skill-doc-template.md` as the starting point.
 
-Each command doc must include:
+Each skill doc must include:
 
-- **Overview** — what the command does in 2–3 sentences
+- **Overview** — what the skill does in 2–3 sentences
 - **Usage** — basic invocation
 - **Flags** — table with flag, description, and default
 - **Examples** — concrete invocations with expected output
 - **Prerequisites** — required tools and config files
 - **What It Creates or Modifies** — files and artifacts produced
-- **Related Commands** — cross-links to companion commands
+- **Related Skills** — cross-links to companion skills
 
-The command name in `docs/commands/` must match the command filename in `plugins/<plugin>/commands/`. Link the doc from the commands table in `README.md`.
+The skill name in `docs/skills/` must match the skill directory name in `plugins/<plugin>/skills/`. Link the doc from the skills table in `README.md`.

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ Open `/plugin`, go to **Marketplaces**, and toggle auto-update for `sdlc-marketp
 
 ---
 
-## Commands
+## Skills
 
-| Command | Description |
+| Skill | Description |
 | --- | --- |
-| [`/sdlc:pr`](docs/commands/pr.md) | Create a PR with an auto-generated structured description |
-| [`/sdlc:pr-customize`](docs/commands/pr-customize.md) | Create or edit a project-specific PR template interactively |
-| [`/sdlc:review`](docs/commands/review.md) | Run multi-dimension code review on the current branch |
-| [`/sdlc:review-init`](docs/commands/review-init.md) | Scan the project and create tailored review dimension files |
-| [`/sdlc:version`](docs/commands/version.md) | Bump version, create git tag, optionally generate CHANGELOG, and push |
-| [`/sdlc:plugin-check`](docs/commands/plugin-check.md) | Validate the plugin discovery chain (manifests, commands, skills, hooks) |
+| [`/pr-sdlc`](docs/skills/pr-sdlc.md) | Create a PR with an auto-generated structured description |
+| [`/pr-customize-sdlc`](docs/skills/pr-customize-sdlc.md) | Create or edit a project-specific PR template interactively |
+| [`/review-sdlc`](docs/skills/review-sdlc.md) | Run multi-dimension code review on the current branch |
+| [`/review-init-sdlc`](docs/skills/review-init-sdlc.md) | Scan the project and create tailored review dimension files |
+| [`/version-sdlc`](docs/skills/version-sdlc.md) | Bump version, create git tag, optionally generate CHANGELOG, and push |
+| [`/plugin-check-sdlc`](docs/skills/plugin-check-sdlc.md) | Validate the plugin discovery chain (manifests, skills, hooks) |
 
 ---
 
@@ -55,7 +55,7 @@ Open `/plugin`, go to **Marketplaces**, and toggle auto-update for `sdlc-marketp
 | [Architecture](docs/architecture.md) | Repository structure, plugin system, name resolution |
 | [Plugin Installation](docs/plugin-installation.md) | How plugins are installed, discovered, and resolved at runtime |
 | [Adding Skills](docs/adding-skills.md) | Create custom skills for your project |
-| [Adding Commands](docs/adding-commands.md) | Create custom slash commands |
+| [Adding Commands](docs/adding-commands.md) | Create custom slash commands (legacy — prefer skills) |
 | [Adding Hooks](docs/adding-hooks.md) | Set up automated actions on session events |
 
 ## Troubleshooting

--- a/docs/adding-commands.md
+++ b/docs/adding-commands.md
@@ -1,5 +1,10 @@
 # Adding Commands
 
+> **Legacy approach.** Commands are supported for backwards compatibility but the
+> skills-primary model is preferred. For new functionality, create a skill with
+> `user-invocable: true` instead — skills appear in the `/` menu directly and own
+> their own argument parsing and preparation. See [Adding Skills](adding-skills.md).
+
 ## Overview
 
 Commands define slash commands (e.g., `/setup`) that users invoke directly in

--- a/docs/adding-skills.md
+++ b/docs/adding-skills.md
@@ -17,13 +17,16 @@ Choose a directory name that makes the skill's purpose immediately obvious. Two 
 are used in this repo — pick the one that fits the plugin's naming style:
 
 - **Prefix pattern** (used by `aisa` skills): `<plugin-prefix>-<noun>`, e.g., `aisa-init`, `aisa-evolve-health`
-- **Prefix pattern** (used by `sdlc` skills): `sdlc-<verb>-ing-<noun>`, e.g., `sdlc-creating-pull-requests`
+- **Suffix pattern** (used by `sdlc` skills): `<action-verb>-sdlc`, e.g., `pr-sdlc`, `review-sdlc`, `version-sdlc`
+
+The `-sdlc` suffix convention for this plugin puts the action word first (making the `/` menu
+scannable) and appends `-sdlc` for disambiguation in a user's combined namespace of project
+skills and plugin skills.
 
 Use lowercase and hyphens only. Avoid vague names (`setup`, `utils`) — names should be specific.
 
-> **Name resolution:** When loaded from a marketplace plugin, skills are referenced as
-> `<plugin-name>:<skill-name>` (e.g., `aisa:aisa-init`). The plugin name
-> comes from the `name` field in `plugin.json`.
+> **Name resolution:** User-invocable skills are callable directly by their directory name with
+> no prefix. A skill in `skills/pr-sdlc/` is invoked as `/pr-sdlc`.
 
 ### Step 2: Create SKILL.md
 
@@ -82,10 +85,10 @@ See `./checklist.md` for the full verification checklist.
 
 | Rule | Limit |
 |---|---|
-| `name` field | Lowercase, hyphens only, max 64 chars. Use prefix or gerund pattern (see above). |
+| `name` field | Lowercase, hyphens only, max 64 chars. Use prefix or action-suffix pattern (see above). |
 | `description` field | Maximum 1024 characters |
 | `SKILL.md` content | Maximum 500 lines |
-| `user-invokable` field | Set to `false` to hide the skill from the `/` menu. Use for skills that have a corresponding slash command as their entry point — the command handles argument parsing and preparation before delegating to the skill. Claude can still invoke the skill automatically; only user-initiated invocation via `/` is suppressed. |
+| `user-invocable` field | Set to `true` to expose the skill in the `/` menu so users can invoke it directly (e.g., `/pr-sdlc`). Set to `false` (or omit) for internal skills invoked only by Claude automatically or by other skills. The skills-primary model favors `user-invocable: true` — skills own argument parsing and preparation directly. |
 
 ## Writing Effective Descriptions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,12 +20,10 @@ sdlc-marketplace/
 │       ├── .claude-plugin/
 │       │   └── plugin.json       # Plugin manifest (name: "sdlc")
 │       ├── agents/               # Agent definitions (orchestrators spawned by skills)
-│       ├── skills/               # Skill definitions
+│       ├── skills/               # Skill definitions (user-invocable skills appear in the / menu)
 │       │   └── <skill-name>/
 │       │       ├── SKILL.md      # Skill entry point (YAML frontmatter + instructions)
 │       │       └── *.md          # Optional supporting files
-│       ├── commands/             # Slash command definitions
-│       │   └── <command>.md      # Command file (YAML frontmatter + instructions)
 │       ├── hooks/
 │       │   └── hooks.json        # Hook configuration
 │       └── scripts/
@@ -63,25 +61,24 @@ Each plugin has its own `.claude-plugin/plugin.json` that declares:
 
 ### Name Resolution
 
-When a plugin is loaded from a marketplace, Claude Code prefixes all commands and skills
-with the plugin's `name` (from `plugin.json`), using the format `<plugin-name>:<item-name>`.
+When a plugin is loaded from a marketplace, Claude Code installs skills so that
+user-invocable skills are callable directly by their directory name — with **no prefix**.
 
-**Commands** — invoked as `/<plugin-name>:<command-name>`:
+**Skills** — a skill named `pr-sdlc` in `skills/pr-sdlc/` is invoked as `/pr-sdlc`:
 
-| File                | `plugin.json` `name` | Resolved command    |
-|---------------------|----------------------|---------------------|
-| `commands/pr.md`    | `sdlc`               | `/sdlc:pr`          |
-| `commands/review.md`| `sdlc`               | `/sdlc:review`      |
+| Directory             | Invocation        |
+|-----------------------|-------------------|
+| `skills/pr-sdlc/`     | `/pr-sdlc`        |
+| `skills/review-sdlc/` | `/review-sdlc`    |
+| `skills/version-sdlc/`| `/version-sdlc`   |
 
-**Skills** — referenced as `<plugin-name>:<skill-name>`:
+The `-sdlc` suffix on each skill name provides disambiguation: action word first,
+`-sdlc` suffix ensures the skill is identifiable in a user's combined skill namespace
+(project skills + plugin skills). Use the pattern `<action>-sdlc` for all skills in
+this plugin.
 
-| Directory                                   | `plugin.json` `name` | Resolved name                            |
-|---------------------------------------------|----------------------|------------------------------------------|
-| `skills/sdlc-creating-pull-requests/`       | `sdlc`               | `sdlc:sdlc-creating-pull-requests`       |
-| `skills/sdlc-reviewing-changes/`            | `sdlc`               | `sdlc:sdlc-reviewing-changes`            |
-
-The `name` field in `plugin.json` is the namespace prefix — **not** the directory name. Keep it
-stable — renaming it changes every command and skill name for all installed users.
+The `name` field in `plugin.json` is a plugin identifier used for marketplace/update
+operations — **not** the prefix for skill invocations. Keep it stable.
 
 ### Skills
 
@@ -92,19 +89,25 @@ contain a `SKILL.md` file with YAML frontmatter:
 ---
 name: skill-name
 description: "When Claude should invoke this skill (max 1024 characters)"
+user-invocable: true
 ---
 ```
 
 The `description` field is critical — Claude uses it to decide when to activate the
 skill. Write it as a trigger condition, not a summary.
 
+Set `user-invocable: true` to make the skill appear in the `/` menu so users can invoke
+it directly (e.g., `/pr-sdlc`). Set it to `false` for internal skills that should only
+be invoked by Claude automatically or by other skills — not by users directly.
+
 Supporting files (`.md` templates, checklists, scripts) live alongside `SKILL.md` in
 the same directory. Reference them with relative paths like `./supporting-file.md`.
 
-### Commands
+### Commands (legacy)
 
 Commands are `.md` files under `plugins/<plugin>/commands/`. The filename (without `.md`)
-becomes the slash command name. Each file has YAML frontmatter:
+becomes the slash command name, prefixed with the plugin name. Each file has YAML
+frontmatter:
 
 ```yaml
 ---
@@ -113,7 +116,9 @@ allowed-tools: [Read, Write, Edit, Glob, Grep, Bash]
 ---
 ```
 
-For example, `commands/pr.md` creates the `/pr` command (resolved to `/sdlc:pr`).
+**The skills-primary model is preferred.** New functionality should be added as skills
+with `user-invocable: true` rather than as commands. Commands remain supported for
+backwards compatibility but are no longer the recommended entry point.
 
 ### Hooks
 
@@ -141,4 +146,4 @@ To add another plugin to this marketplace:
    }
    ```
 
-3. Follow the same structure: `skills/`, `commands/`, `hooks/` (and optionally `scripts/`)
+3. Follow the same structure: `skills/`, `hooks/` (and optionally `scripts/`, `commands/`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | — | This is a Claude Code plugin marketplace |
 | Node.js | >= 16 | For helper scripts. Uses built-in modules, no `npm install` needed |
 | git | — | Required for diff and commit analysis |
-| gh (GitHub CLI) | — | Required for `/sdlc:pr`. Falls back to showing the description if unavailable |
+| gh (GitHub CLI) | — | Required for `/pr-sdlc`. Falls back to showing the description if unavailable |
 
 ## Installation
 
@@ -24,7 +24,7 @@
 /plugin install sdlc@sdlc-marketplace
 ```
 
-> **Note:** Commands and skills are namespaced with the plugin name. The `pr` command becomes `/sdlc:pr`. See [Architecture](architecture.md#name-resolution) for details.
+> **Note:** Skills are invoked directly by name with no prefix. The `pr-sdlc` skill is invoked as `/pr-sdlc`. See [Architecture](architecture.md#name-resolution) for details.
 
 ## Updating
 
@@ -48,7 +48,7 @@ The plugin provides a project-customizable multi-dimension code review system.
 **Step 1 — Create review dimensions** (one-time per project):
 
 ```text
-/sdlc:review-init
+/review-init-sdlc
 ```
 
 Scans your tech stack and proposes tailored dimension files (security, API contracts, test coverage, etc.) in `.claude/review-dimensions/`. Run with `--add` to expand an existing set.
@@ -56,7 +56,7 @@ Scans your tech stack and proposes tailored dimension files (security, API contr
 **Step 2 — Run reviews** (on any feature branch):
 
 ```text
-/sdlc:review
+/review-sdlc
 ```
 
 Matches dimensions to your changed files, dispatches parallel review subagents, deduplicates findings, and posts a consolidated comment to the PR.
@@ -64,7 +64,7 @@ Matches dimensions to your changed files, dispatches parallel review subagents, 
 ### Creating a pull request
 
 ```text
-/sdlc:pr
+/pr-sdlc
 ```
 
 Generates a structured PR description from your commits and diffs, then opens the PR via `gh`.
@@ -73,13 +73,13 @@ Generates a structured PR description from your commits and diffs, then opens th
 
 | File / Directory | Purpose |
 | --- | --- |
-| `.claude/review-dimensions/` | Per-project code review dimension files (created by `/sdlc:review-init`) |
-| `.claude/pr-template.md` | Project PR template (created by `/sdlc:pr-customize`) |
-| `.claude/version.json` | Release configuration (created by `/sdlc:version --init`) |
+| `.claude/review-dimensions/` | Per-project code review dimension files (created by `/review-init-sdlc`) |
+| `.claude/pr-template.md` | Project PR template (created by `/pr-customize-sdlc`) |
+| `.claude/version.json` | Release configuration (created by `/version-sdlc --init`) |
 
 ## Next Steps
 
 - Read [Architecture](architecture.md) to understand how the plugin works
 - Read [Adding Skills](adding-skills.md) to create project-specific skills
-- Read [Adding Commands](adding-commands.md) to create custom slash commands
+- Read [Adding Commands](adding-commands.md) to create custom slash commands (legacy — prefer skills)
 - Read [Adding Hooks](adding-hooks.md) to set up automated actions

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -7,7 +7,7 @@ on disk, how they are discovered at session start, and how scripts are resolved 
 
 ## Overview
 
-The full lifecycle from GitHub repository to working slash commands:
+The full lifecycle from GitHub repository to working skills:
 
 ```
 GitHub: rnagrodzki/sdlc-marketplace
@@ -21,13 +21,13 @@ Copies plugin files to ~/.claude/plugins/
     │
     ▼  Session start
 Claude Code scans ~/.claude/plugins/ for plugin.json files
-Registers /<plugin-name>:<command> slash commands
+Registers user-invocable skills in the / menu (e.g. /pr-sdlc)
 Loads skill descriptions for auto-invocation matching
 Attaches hooks from hooks.json
     │
-    ▼  Runtime (e.g. /sdlc:pr)
-Command script uses find to locate helper scripts:
-  find ~/.claude/plugins -name "pr-prepare.js" -path "*/scripts/*"
+    ▼  Runtime (e.g. /pr-sdlc)
+Skill uses find to locate helper scripts:
+  find ~/.claude/plugins -name "pr-prepare.js"
 ```
 
 ---
@@ -62,7 +62,7 @@ The `plugins` array lists every plugin in this marketplace. Each entry has:
 
 | Field | Description |
 |-------|-------------|
-| `name` | Plugin identifier used in slash commands (`sdlc` → `/sdlc:pr`) |
+| `name` | Plugin identifier used for marketplace/update operations |
 | `source` | Relative path from the repo root to the plugin directory |
 
 The marketplace is cached at:
@@ -119,14 +119,14 @@ The full path includes marketplace, plugin name, and version:
 ~/.claude/plugins/cache/
 └── <marketplace>/               # e.g. sdlc-marketplace
     └── <plugin>/                # e.g. sdlc
-        └── <version>/           # e.g. 0.7.0
+        └── <version>/           # e.g. 0.8.1
             ├── .claude-plugin/
             │   └── plugin.json        # Plugin identity and version
-            ├── commands/
-            │   └── pr.md              # Defines /sdlc:pr
             ├── skills/
-            │   └── sdlc-creating-pull-requests/
-            │       └── SKILL.md       # Skill instructions + supporting files
+            │   ├── pr-sdlc/
+            │   │   └── SKILL.md       # Invoked as /pr-sdlc
+            │   └── review-sdlc/
+            │       └── SKILL.md       # Invoked as /review-sdlc
             ├── scripts/
             │   ├── pr-prepare.js      # Helper scripts (found at runtime via find)
             │   └── lib/
@@ -136,7 +136,7 @@ The full path includes marketplace, plugin name, and version:
                 └── review-orchestrator.md
 ```
 
-Example actual path: `~/.claude/plugins/cache/sdlc-marketplace/sdlc/0.7.0/scripts/pr-prepare.js`
+Example actual path: `~/.claude/plugins/cache/sdlc-marketplace/sdlc/0.8.1/scripts/pr-prepare.js`
 
 Because scripts are nested 4 levels deep under `~/.claude/plugins/`, a recursive
 `find` (without `-path` filters) is required — path-based filtering is fragile and
@@ -150,8 +150,8 @@ When Claude Code starts a session, it scans `~/.claude/plugins/` for installed p
 For each directory containing `.claude-plugin/plugin.json`, it:
 
 1. **Reads `plugin.json`** to get the plugin `name`, `description`, and `version`
-2. **Registers commands** — every `.md` file in `commands/` becomes a slash command,
-   prefixed with the plugin name: `commands/pr.md` → `/sdlc:pr`
+2. **Registers user-invocable skills** — every `SKILL.md` with `user-invocable: true`
+   is added to the `/` menu by its directory name: `skills/pr-sdlc/` → `/pr-sdlc`
 3. **Loads skill descriptions** — every `SKILL.md` frontmatter `description` is registered
    for automatic invocation matching (Claude invokes skills when the description matches)
 4. **Attaches hooks** — the `hooks/hooks.json` configuration is read and hook handlers
@@ -163,17 +163,17 @@ For each directory containing `.claude-plugin/plugin.json`, it:
 
 ## Name Resolution
 
-Slash commands and skills are namespaced by the plugin name from `plugin.json`:
+User-invocable skills are registered by their directory name with no prefix:
 
-| Plugin file | `plugin.json` `name` | Resolved name |
-|-------------|----------------------|---------------|
-| `commands/pr.md` | `sdlc` | `/sdlc:pr` |
-| `commands/review.md` | `sdlc` | `/sdlc:review` |
-| `skills/sdlc-creating-pull-requests/` | `sdlc` | `sdlc:sdlc-creating-pull-requests` |
+| Plugin directory         | Invocation        |
+|--------------------------|-------------------|
+| `skills/pr-sdlc/`        | `/pr-sdlc`        |
+| `skills/review-sdlc/`    | `/review-sdlc`    |
+| `skills/version-sdlc/`   | `/version-sdlc`   |
 
-The plugin `name` in `plugin.json` is the namespace prefix, not the directory name.
-**Renaming this field changes every command and skill name for all installed users** —
-treat it as a stable identifier.
+The plugin `name` in `plugin.json` is used for marketplace and update operations, not
+for skill invocation names. **Renaming skill directories changes the invocation names
+for all installed users** — treat directory names as stable identifiers.
 
 ### Name consistency requirement
 
@@ -231,8 +231,8 @@ Then restart Claude Code and reinstall:
 
 ## Script Resolution at Runtime
 
-Commands are thin wrappers that delegate immediately to skills. Skills own script
-resolution — they locate and run helper scripts themselves using this two-step pattern:
+Skills own script resolution — they locate and run helper scripts themselves using this
+two-step pattern:
 
 ```bash
 # Step 1: Search installed plugin (recursive find — scripts are 4 levels deep under cache/)
@@ -251,7 +251,7 @@ SCRIPT=$(find ~/.claude/plugins -name "pr-prepare.js" 2>/dev/null | head -1)
 repository to run commands directly without installing the plugin globally. The fallback
 uses a literal `[ -f "..." ]` check with no globbing — impossible to corrupt.
 
-**Why skills, not commands?** Commands are natural language instructions that LLMs interpret and may paraphrase. Moving all bash logic into skills — and adding a `VERBATIM` directive before each bash block — reduces the risk of LLM paraphrasing breaking script resolution.
+**Why skills?** Skills are the primary entry point in the skills-primary model. Skills add a `VERBATIM` directive before each bash block, reducing the risk of LLM paraphrasing breaking script resolution. Skills also own argument parsing and preparation directly.
 
 ---
 
@@ -288,5 +288,5 @@ See the [README troubleshooting section](../README.md#troubleshooting) for solut
 - [Architecture](architecture.md) — repository structure, plugin manifest fields, name resolution
 - [Getting Started](getting-started.md) — first-use walkthrough and what gets created
 - [Adding Skills](adding-skills.md) — how to create new skills
-- [Adding Commands](adding-commands.md) — how to create slash commands
+- [Adding Commands](adding-commands.md) — how to create slash commands (legacy)
 - [Adding Hooks](adding-hooks.md) — how to configure session hooks

--- a/docs/plugin-sdlc-utilities.md
+++ b/docs/plugin-sdlc-utilities.md
@@ -2,13 +2,13 @@
 
 `sdlc-utilities` automates common SDLC tasks. See the [README](../README.md) for installation.
 
-## Commands
+## Skills
 
-| Command | Description |
+| Skill | Description |
 | --- | --- |
-| [`/sdlc:pr`](commands/pr.md) | Create a PR with an auto-generated structured description |
-| [`/sdlc:pr-customize`](commands/pr-customize.md) | Create or edit a project-specific PR template interactively |
-| [`/sdlc:review`](commands/review.md) | Run multi-dimension code review on the current branch |
-| [`/sdlc:review-init`](commands/review-init.md) | Scan the project and create tailored review dimension files |
-| [`/sdlc:version`](commands/version.md) | Bump version, create git tag, optionally generate CHANGELOG, and push |
-| [`/sdlc:plugin-check`](commands/plugin-check.md) | Validate the plugin discovery chain — manifests, commands, skills, scripts, hooks, and agents |
+| [`/pr-sdlc`](skills/pr-sdlc.md) | Create a PR with an auto-generated structured description |
+| [`/pr-customize-sdlc`](skills/pr-customize-sdlc.md) | Create or edit a project-specific PR template interactively |
+| [`/review-sdlc`](skills/review-sdlc.md) | Run multi-dimension code review on the current branch |
+| [`/review-init-sdlc`](skills/review-init-sdlc.md) | Scan the project and create tailored review dimension files |
+| [`/version-sdlc`](skills/version-sdlc.md) | Bump version, create git tag, optionally generate CHANGELOG, and push |
+| [`/plugin-check-sdlc`](skills/plugin-check-sdlc.md) | Validate the plugin discovery chain — manifests, skills, scripts, hooks, and agents |

--- a/docs/skill-doc-template.md
+++ b/docs/skill-doc-template.md
@@ -1,15 +1,15 @@
-# `/sdlc:<name>` — Short Purpose
+# `/<name>-sdlc` — Short Purpose
 
 ## Overview
 
-What this command does in 2–3 sentences. What problem it solves, what it produces, and when to reach for it.
+What this skill does in 2–3 sentences. What problem it solves, what it produces, and when to reach for it.
 
 ---
 
 ## Usage
 
 ```text
-/sdlc:<name>
+/<name>-sdlc
 ```
 
 ---
@@ -27,7 +27,7 @@ What this command does in 2–3 sentences. What problem it solves, what it produ
 ### Basic usage
 
 ```text
-/sdlc:<name>
+/<name>-sdlc
 ```
 
 Expected output or behavior.
@@ -35,7 +35,7 @@ Expected output or behavior.
 ### With flags
 
 ```text
-/sdlc:<name> --flag value
+/<name>-sdlc --flag value
 ```
 
 Expected output or behavior.
@@ -44,10 +44,10 @@ Expected output or behavior.
 
 ## Prerequisites
 
-What must be in place before running this command:
+What must be in place before running this skill:
 
 - **Tool name** — why it's needed and what happens when it's absent
-- **Config file** — path and how to create it (link to setup command if applicable)
+- **Config file** — path and how to create it (link to setup skill if applicable)
 
 ---
 
@@ -59,6 +59,6 @@ What must be in place before running this command:
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:other`](other.md) — brief reason to use it together or as a follow-up
+- [`/other-sdlc`](other-sdlc.md) — brief reason to use it together or as a follow-up

--- a/docs/skills/plugin-check-sdlc.md
+++ b/docs/skills/plugin-check-sdlc.md
@@ -1,10 +1,10 @@
-# `/sdlc:plugin-check` — Plugin Discovery Validation
+# `/plugin-check-sdlc` — Plugin Discovery Validation
 
 ## Overview
 
 Validates the full plugin discovery and cross-reference chain so that the plugin
 works correctly after installation from GitHub. Checks 16 structural properties
-across marketplace manifests, plugin manifests, commands, skills, scripts, hooks,
+across marketplace manifests, plugin manifests, skills, scripts, hooks,
 and agents — catching broken references before users encounter runtime failures.
 
 ---
@@ -12,7 +12,7 @@ and agents — catching broken references before users encounter runtime failure
 ## Usage
 
 ```text
-/sdlc:plugin-check
+/plugin-check-sdlc
 ```
 
 Run from the root of the `sdlc-marketplace` repository.
@@ -32,7 +32,7 @@ Run from the root of the `sdlc-marketplace` repository.
 ### All checks pass
 
 ```text
-/sdlc:plugin-check
+/plugin-check-sdlc
 ```
 
 Expected output:
@@ -46,7 +46,7 @@ pass: 16/16
 ### Issues found
 
 ```text
-/sdlc:plugin-check
+/plugin-check-sdlc
 ```
 
 Example output when a name mismatch exists:
@@ -102,12 +102,12 @@ The skill then guides you through fixing the mismatch and re-runs validation.
 This command is read-only. It does not create or modify any files.
 
 If issues are found, the skill guides you through targeted edits to the files that
-failed their checks. Re-run `/sdlc:plugin-check` after fixing to confirm.
+failed their checks. Re-run `/plugin-check-sdlc` after fixing to confirm.
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:version`](version.md) — bumps the version validated by PD7
-- [`/sdlc:review-init`](review-init.md) — creates review dimensions referenced at runtime
+- [`/version-sdlc`](version-sdlc.md) — bumps the version validated by PD7
+- [`/review-init-sdlc`](review-init-sdlc.md) — creates review dimensions referenced at runtime
 - [`validate-plugin-consistency`](.claude/skills/validate-plugin-consistency/SKILL.md) — complementary check for internal code conventions (script resolution order, temp file usage)

--- a/docs/skills/pr-customize-sdlc.md
+++ b/docs/skills/pr-customize-sdlc.md
@@ -1,15 +1,15 @@
-# `/sdlc:pr-customize` — PR Template Setup
+# `/pr-customize-sdlc` — PR Template Setup
 
 ## Overview
 
-Guides you through creating or editing a project-specific PR description template. Scans your project for conventions (existing GitHub PR templates, recent PR patterns, JIRA usage), proposes a tailored starter, then lets you customize it interactively. The result is saved to `.claude/pr-template.md` and used automatically by `/sdlc:pr`.
+Guides you through creating or editing a project-specific PR description template. Scans your project for conventions (existing GitHub PR templates, recent PR patterns, JIRA usage), proposes a tailored starter, then lets you customize it interactively. The result is saved to `.claude/pr-template.md` and used automatically by `/pr-sdlc`.
 
 ---
 
 ## Usage
 
 ```text
-/sdlc:pr-customize
+/pr-customize-sdlc
 ```
 
 No flags.
@@ -21,7 +21,7 @@ No flags.
 ### Create a template for the first time
 
 ```text
-/sdlc:pr-customize
+/pr-customize-sdlc
 ```
 
 ```text
@@ -47,18 +47,18 @@ Does this look right? (yes / edit sections / start fresh)
 > yes
 
 ✓ Written: .claude/pr-template.md
-  /sdlc:pr will use this template for all future PRs on this project.
+  /pr-sdlc will use this template for all future PRs on this project.
 ```
 
 ### Edit an existing template
 
-Running `/sdlc:pr-customize` again when `.claude/pr-template.md` exists opens the existing template for editing rather than starting over.
+Running `/pr-customize-sdlc` again when `.claude/pr-template.md` exists opens the existing template for editing rather than starting over.
 
 ---
 
 ## Prerequisites
 
-- **Git repository** — the command scans commits and project files.
+- **Git repository** — the skill scans commits and project files.
 - No additional tools required.
 
 ---
@@ -67,7 +67,7 @@ Running `/sdlc:pr-customize` again when `.claude/pr-template.md` exists opens th
 
 | File / Artifact | Description |
 |-----------------|-------------|
-| `.claude/pr-template.md` | Project PR template used by `/sdlc:pr` |
+| `.claude/pr-template.md` | Project PR template used by `/pr-sdlc` |
 
 ---
 
@@ -91,6 +91,6 @@ A PR template is a plain markdown file with `## Section` headings. Text under ea
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:pr`](pr.md) — uses `.claude/pr-template.md` when present
+- [`/pr-sdlc`](pr-sdlc.md) — uses `.claude/pr-template.md` when present

--- a/docs/skills/pr-sdlc.md
+++ b/docs/skills/pr-sdlc.md
@@ -1,4 +1,4 @@
-# `/sdlc:pr` — Pull Request Creation
+# `/pr-sdlc` — Pull Request Creation
 
 ## Overview
 
@@ -9,7 +9,7 @@ Analyzes all commits and the diff on the current branch, generates a structured 
 ## Usage
 
 ```text
-/sdlc:pr
+/pr-sdlc
 ```
 
 ---
@@ -29,7 +29,7 @@ Analyzes all commits and the diff on the current branch, generates a structured 
 ### Create a PR
 
 ```text
-/sdlc:pr
+/pr-sdlc
 ```
 
 Generates and displays a structured description, then prompts:
@@ -67,20 +67,20 @@ Create this PR? (yes / edit / cancel)
 ### Create a draft PR targeting a specific branch
 
 ```text
-/sdlc:pr --draft --base release/2
+/pr-sdlc --draft --base release/2
 ```
 
 ### Update an existing PR description
 
 ```text
-/sdlc:pr --update
+/pr-sdlc --update
 ```
 
 ---
 
 ## Custom PR Templates
 
-By default, `/sdlc:pr` uses an 8-section template (Summary, JIRA Ticket, Business Context, Business Benefits, Technical Design, Technical Impact, Changes Overview, Testing). Replace it with a project-specific template by creating `.claude/pr-template.md`.
+By default, `/pr-sdlc` uses an 8-section template (Summary, JIRA Ticket, Business Context, Business Benefits, Technical Design, Technical Impact, Changes Overview, Testing). Replace it with a project-specific template by creating `.claude/pr-template.md`.
 
 A template is a plain markdown file with `## Section` headings. The text under each heading is a fill instruction for the LLM:
 
@@ -98,14 +98,14 @@ A template is a plain markdown file with `## Section` headings. The text under e
 [How was this verified? Manual steps, automated tests, edge cases.]
 ```
 
-Run `/sdlc:pr-customize` to create or edit the template interactively.
+Run `/pr-customize-sdlc` to create or edit the template interactively.
 
 ---
 
 ## Prerequisites
 
 - **`gh` CLI** — required to open or update the PR (`gh auth login`). Falls back to printing the description for manual use if unavailable.
-- **Active branch with commits** — the command diffs against the target base branch.
+- **Active branch with commits** — the skill diffs against the target base branch.
 
 ---
 
@@ -117,7 +117,7 @@ Run `/sdlc:pr-customize` to create or edit the template interactively.
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:pr-customize`](pr-customize.md) — create or edit a project-specific PR template
-- [`/sdlc:review`](review.md) — run code review on the branch before opening the PR
+- [`/pr-customize-sdlc`](pr-customize-sdlc.md) — create or edit a project-specific PR template
+- [`/review-sdlc`](review-sdlc.md) — run code review on the branch before opening the PR

--- a/docs/skills/review-init-sdlc.md
+++ b/docs/skills/review-init-sdlc.md
@@ -1,15 +1,15 @@
-# `/sdlc:review-init` — Review Dimension Setup
+# `/review-init-sdlc` — Review Dimension Setup
 
 ## Overview
 
-Scans the project's tech stack, dependencies, and file structure, then proposes and creates tailored review dimension files in `.claude/review-dimensions/`. Each dimension file defines a lens (security, API contracts, test coverage, etc.) that `/sdlc:review` uses to focus its analysis. Covers 31 dimension types across technical code concerns, pipeline/config/docs review, project architecture patterns, and more. Run once per project, then use `--add` to expand as the codebase evolves.
+Scans the project's tech stack, dependencies, and file structure, then proposes and creates tailored review dimension files in `.claude/review-dimensions/`. Each dimension file defines a lens (security, API contracts, test coverage, etc.) that `/review-sdlc` uses to focus its analysis. Covers 31 dimension types across technical code concerns, pipeline/config/docs review, project architecture patterns, and more. Run once per project, then use `--add` to expand as the codebase evolves.
 
 ---
 
 ## Usage
 
 ```text
-/sdlc:review-init
+/review-init-sdlc
 ```
 
 ---
@@ -28,7 +28,7 @@ Scans the project's tech stack, dependencies, and file structure, then proposes 
 ### Initial setup
 
 ```text
-/sdlc:review-init
+/review-init-sdlc
 ```
 
 ```text
@@ -77,10 +77,10 @@ Generated Copilot instruction files:
 ### Add dimensions to an existing setup
 
 ```text
-/sdlc:review-init --add
+/review-init-sdlc --add
 ```
 
-Proposes only dimensions not yet present in `.claude/review-dimensions/`. In `--add` mode, the command also runs `review-prepare.js` on the current branch and uses any `uncovered_suggestions` (files not covered by installed dimensions) as additional evidence for proposals — citing the specific files found.
+Proposes only dimensions not yet present in `.claude/review-dimensions/`. In `--add` mode, the skill also runs `review-prepare.js` on the current branch and uses any `uncovered_suggestions` (files not covered by installed dimensions) as additional evidence for proposals — citing the specific files found.
 
 ---
 
@@ -178,7 +178,7 @@ Proposes only dimensions not yet present in `.claude/review-dimensions/`. In `--
 
 ## Prerequisites
 
-- **Git repository** — the command scans the project structure and git history.
+- **Git repository** — the skill scans the project structure and git history.
 
 ---
 
@@ -186,7 +186,7 @@ Proposes only dimensions not yet present in `.claude/review-dimensions/`. In `--
 
 | File / Artifact                          | Description                                                                  |
 |------------------------------------------|------------------------------------------------------------------------------|
-| `.claude/review-dimensions/*.md`         | One file per dimension, used by `/sdlc:review`                               |
+| `.claude/review-dimensions/*.md`         | One file per dimension, used by `/review-sdlc`                               |
 | `.github/instructions/*.instructions.md` | GitHub Copilot path-specific review instructions (opt-in, one per dimension) |
 
 ---
@@ -311,6 +311,6 @@ Use `--no-copilot` to skip this prompt if you manage Copilot instructions separa
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:review`](review.md) — run the review using dimension files created by this command
+- [`/review-sdlc`](review-sdlc.md) — run the review using dimension files created by this skill

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -1,15 +1,15 @@
-# `/sdlc:review` — Multi-Dimension Code Review
+# `/review-sdlc` — Multi-Dimension Code Review
 
 ## Overview
 
-Loads project review dimensions from `.claude/review-dimensions/`, matches them to changed files via glob patterns, dispatches parallel review subagents for each matching dimension, deduplicates findings, and posts a consolidated comment to the PR. By default reviews committed branch changes plus staged changes. Requires at least one dimension file — run `/sdlc:review-init` first if none exist.
+Loads project review dimensions from `.claude/review-dimensions/`, matches them to changed files via glob patterns, dispatches parallel review subagents for each matching dimension, deduplicates findings, and posts a consolidated comment to the PR. By default reviews committed branch changes plus staged changes. Requires at least one dimension file — run `/review-init-sdlc` first if none exist.
 
 ---
 
 ## Usage
 
 ```text
-/sdlc:review
+/review-sdlc
 ```
 
 ---
@@ -36,57 +36,57 @@ Loads project review dimensions from `.claude/review-dimensions/`, matches them 
 ### Run a full review (committed + staged changes)
 
 ```text
-/sdlc:review
+/review-sdlc
 ```
 
 ### Review staged changes before committing
 
 ```text
-/sdlc:review --staged
+/review-sdlc --staged
 ```
 
 ### Review all local changes (staged + unstaged)
 
 ```text
-/sdlc:review --working
+/review-sdlc --working
 ```
 
 ### Review only committed changes (exclude staged)
 
 ```text
-/sdlc:review --committed
+/review-sdlc --committed
 ```
 
 ### Review against a non-default base branch
 
 ```text
-/sdlc:review --base develop
+/review-sdlc --base develop
 ```
 
 ### Run specific dimensions only
 
 ```text
-/sdlc:review --dimensions security-review,api-review
+/review-sdlc --dimensions security-review,api-review
 ```
 
 ### Review full working tree including unstaged changes
 
 ```text
-/sdlc:review --worktree
+/review-sdlc --worktree
 ```
 
 ### Save a scope as the project default, then run
 
 ```text
-/sdlc:review --set-default --worktree
+/review-sdlc --set-default --worktree
 ```
 
-Saves `worktree` to `.claude/review.json` and runs the review. Subsequent `/sdlc:review` calls will use `worktree` automatically.
+Saves `worktree` to `.claude/review.json` and runs the review. Subsequent `/review-sdlc` calls will use `worktree` automatically.
 
 ### Preview what would be reviewed without running
 
 ```text
-/sdlc:review --dry-run
+/review-sdlc --dry-run
 ```
 
 ---
@@ -108,7 +108,7 @@ The default scope can be persisted in `.claude/review.json`:
 Use `--set-default` to create or update this file without editing it manually:
 
 ```text
-/sdlc:review --set-default --staged
+/review-sdlc --set-default --staged
 ```
 
 Valid scope values: `all`, `committed`, `staged`, `working`, `worktree`.
@@ -166,7 +166,7 @@ Suggested new dimensions for uncovered files:
   configuration-management-review — 3 configuration files not covered
     Files: src/config/db.ts, src/config/auth.ts, .env.example
 
-Run `/sdlc:review-init --add` to create these dimensions.
+Run `/review-init-sdlc --add` to create these dimensions.
 ```
 
 Files that cannot be mapped to any known dimension type are listed separately:
@@ -178,13 +178,13 @@ Files that cannot be mapped to any known dimension type are listed separately:
 Consider creating a custom dimension or broadening existing trigger patterns.
 ```
 
-These suggestions are informational during a review run. To act on them, run `/sdlc:review-init --add`.
+These suggestions are informational during a review run. To act on them, run `/review-init-sdlc --add`.
 
 ---
 
 ## Prerequisites
 
-- **`.claude/review-dimensions/`** — at least one dimension file must exist. Run `/sdlc:review-init` to create them.
+- **`.claude/review-dimensions/`** — at least one dimension file must exist. Run `/review-init-sdlc` to create them.
 - **`gh` CLI** — recommended for posting the PR comment. Falls back to terminal output if unavailable.
 
 ---
@@ -197,7 +197,7 @@ These suggestions are informational during a review run. To act on them, run `/s
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:review-init`](review-init.md) — create review dimension files for this project
-- [`/sdlc:pr`](pr.md) — open the PR that this command reviews
+- [`/review-init-sdlc`](review-init-sdlc.md) — create review dimension files for this project
+- [`/pr-sdlc`](pr-sdlc.md) — open the PR that this skill reviews

--- a/docs/skills/version-sdlc.md
+++ b/docs/skills/version-sdlc.md
@@ -1,4 +1,4 @@
-# `/sdlc:version` — Semantic Versioning & Release Management
+# `/version-sdlc` — Semantic Versioning & Release Management
 
 ## Overview
 
@@ -9,7 +9,7 @@ Manages the full semantic release workflow: detects the version source, bumps th
 ## Usage
 
 ```text
-/sdlc:version [major|minor|patch] [flags]
+/version-sdlc [major|minor|patch] [flags]
 ```
 
 ---
@@ -32,7 +32,7 @@ Manages the full semantic release workflow: detects the version source, bumps th
 ### First-time setup (run once per project)
 
 ```text
-/sdlc:version --init
+/version-sdlc --init
 ```
 
 ```text
@@ -52,28 +52,28 @@ Does this look right? (yes / tag-only / changelog / cancel)
 ### Bump the version
 
 ```text
-/sdlc:version patch          # 1.2.3 → 1.2.4
-/sdlc:version minor          # 1.2.3 → 1.3.0
-/sdlc:version major          # 1.2.3 → 2.0.0
-/sdlc:version                # auto-detect bump type from conventional commits
+/version-sdlc patch          # 1.2.3 → 1.2.4
+/version-sdlc minor          # 1.2.3 → 1.3.0
+/version-sdlc major          # 1.2.3 → 2.0.0
+/version-sdlc                # auto-detect bump type from conventional commits
 ```
 
 ### Release with a CHANGELOG entry
 
 ```text
-/sdlc:version minor --changelog
+/version-sdlc minor --changelog
 ```
 
 ### Tag locally without pushing
 
 ```text
-/sdlc:version patch --no-push
+/version-sdlc patch --no-push
 ```
 
 ### Hotfix release (DORA metrics tracking)
 
 ```text
-/sdlc:version patch --hotfix
+/version-sdlc patch --hotfix
 ```
 
 ```text
@@ -99,16 +99,16 @@ Proceed? (yes / edit / cancel)
 ### Pre-release workflow
 
 ```text
-/sdlc:version minor --pre beta    # 1.2.3 → 1.3.0-beta.1
-/sdlc:version --pre beta          # 1.3.0-beta.1 → 1.3.0-beta.2
-/sdlc:version --pre rc            # 1.3.0-beta.2 → 1.3.0-rc.1  (label change resets counter)
-/sdlc:version minor               # 1.3.0-rc.1 → 1.3.0         (graduate to release)
+/version-sdlc minor --pre beta    # 1.2.3 → 1.3.0-beta.1
+/version-sdlc --pre beta          # 1.3.0-beta.1 → 1.3.0-beta.2
+/version-sdlc --pre rc            # 1.3.0-beta.2 → 1.3.0-rc.1  (label change resets counter)
+/version-sdlc minor               # 1.3.0-rc.1 → 1.3.0         (graduate to release)
 ```
 
 ### Example release session
 
 ```text
-/sdlc:version minor
+/version-sdlc minor
 ```
 
 ```text
@@ -268,6 +268,6 @@ Auto-detected in this priority order:
 
 ---
 
-## Related Commands
+## Related Skills
 
-- [`/sdlc:pr`](pr.md) — open the PR before or after tagging a release
+- [`/pr-sdlc`](pr-sdlc.md) — open the PR before or after tagging a release


### PR DESCRIPTION
## Summary

- Renames `docs/commands/` to `docs/skills/` with `-sdlc` suffix on all filenames (e.g. `pr.md` → `pr-sdlc.md`)
- Updates all invocation examples from `/sdlc:name` syntax to `/name-sdlc` syntax throughout all docs
- Removes `commands/` layer from directory layouts in architecture, plugin-installation, and AGENTS.md
- Adds guidance on `user-invocable: true` frontmatter and `-sdlc` naming convention in `adding-skills.md`
- Marks `adding-commands.md` as the legacy approach with a prominent note pointing to skills
- Renames `docs/command-template.md` → `docs/skill-doc-template.md` and updates AGENTS.md to reference it
- Updates `docs/plugin-sdlc-utilities.md` capabilities table from Commands to Skills section

## Test plan

- [ ] Verify all links in README.md Skills table point to `docs/skills/*.md` files that exist
- [ ] Verify `docs/skills/` directory contains 6 files, each with updated skill invocation syntax
- [ ] Confirm `docs/commands/` directory no longer exists
- [ ] Confirm `docs/command-template.md` no longer exists and `docs/skill-doc-template.md` is present
- [ ] Check `AGENTS.md` references `docs/skills/` and `docs/skill-doc-template.md`
- [ ] Check `docs/architecture.md` Name Resolution section describes no-prefix skill invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)