### PR TITLE
fix: pin pnpm version in site/package.json to fix Pages deployment

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sdlc-marketplace-docs",
+  "packageManager": "pnpm@10.28.1",
   "type": "module",
   "version": "0.1.0",
   "scripts": {


### PR DESCRIPTION
## Summary
Pins the pnpm package manager version in `site/package.json` so GitHub Actions can reliably install pnpm during the Pages deployment workflow.

## Business Context
The Astro documentation site was added in the previous PR, but the GitHub Pages deployment was broken because the CI environment had no pinned package manager version. Without the `packageManager` field, Corepack/GitHub Actions cannot deterministically install the correct pnpm version.

## Business Benefits
- Restores automated deployment of the documentation site to GitHub Pages.
- Eliminates ambiguity in CI package manager resolution, preventing similar failures on future pnpm version upgrades.

## Technical Design
Added the `packageManager` field to `site/package.json` specifying `pnpm@10.28.1`. This field is consumed by Corepack (Node.js built-in) and GitHub Actions `pnpm/action-setup` to install the exact pnpm version without relying on environment defaults or implicit assumptions.

## Technical Impact
None. This is a configuration-only addition with no changes to plugin manifests, skill interfaces, hook payloads, or script APIs.

## Changes Overview
- `site/package.json` — added `"packageManager": "pnpm@10.28.1"` to pin the pnpm version for CI

## Testing
The fix will be verified by the GitHub Actions Pages deployment workflow on push. No unit tests apply to a package.json metadata field.