### PR TITLE
feat: add internal validation skills and revert version-sdlc --auto

### DIFF
--- a/.claude/skills/validate-plugin-consistency/SKILL.md
+++ b/.claude/skills/validate-plugin-consistency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-plugin-consistency
-description: "Use after modifying any file under plugins/sdlc-utilities/ (skills/*/SKILL.md, scripts/*.js). Runs the consistency validation script to catch structural issues before they reach users: wrong script resolution order, skills missing prepare-script execution, missing mktemp or exit-code handling, missing frontmatter fields, missing user-invocable flags."
+description: "Use after modifying any file under plugins/sdlc-utilities/ (skills/*/SKILL.md, scripts/*.js). Runs the consistency validation script to catch structural issues before they reach users: wrong script resolution order, skills missing prepare-script execution, missing mktemp or exit-code handling, missing frontmatter fields, missing user-invocable flags, missing docs/skills/ documentation, missing skills-meta.ts entries, missing README table rows, temp file cleanup gaps."
 user-invocable: true
 ---
 
@@ -93,8 +93,32 @@ user-invocable: true
 ---
 ```
 
-The 6 user-facing skills that must have this flag are: `pr-sdlc`, `pr-customize-sdlc`,
-`review-sdlc`, `review-init-sdlc`, `version-sdlc`, `jira-sdlc`.
+The 11 user-facing skills that must have this flag are: `plan-sdlc`, `execute-plan-sdlc`,
+`pr-sdlc`, `pr-customize-sdlc`, `review-sdlc`, `review-init-sdlc`, `received-review-sdlc`,
+`commit-sdlc`, `version-sdlc`, `jira-sdlc`, `ship-sdlc`.
+
+### `docs-skill-existence` (error)
+
+A skill directory exists under `plugins/sdlc-utilities/skills/<name>/` but has no matching
+documentation file at `docs/skills/<name>.md`. Create the doc file using `docs/skill-doc-template.md`
+as the starting point.
+
+### `skills-meta-existence` (error)
+
+A user-invocable skill has no matching `slug` entry in `site/src/data/skills-meta.ts`. Add an
+entry to the `skillsMeta` array with the correct slug, command, category, tagline, pipeline,
+and connections. See existing entries for the format.
+
+### `readme-skills-table` (warning)
+
+A user-invocable skill is not listed in the README.md skills table. Add a row following the
+format: `| [\`/<name>\`](docs/skills/<name>.md) | description |`
+
+### `temp-file-cleanup` (warning)
+
+A skill uses `mktemp` to create a temp file but has no cleanup reference (`rm -f`, `rm -rf`,
+or "clean" in narrative). Add cleanup instructions to the skill, ensuring temp files are removed
+on all exit paths (success, error, cancellation).
 
 ## Step 3 — Re-run Validation
 

--- a/.claude/skills/validate-plugin-consistency/check-consistency.js
+++ b/.claude/skills/validate-plugin-consistency/check-consistency.js
@@ -20,11 +20,18 @@
  *                                 in the node "$SCRIPT" $ARGUMENTS call
  *   6. frontmatter-field-names  — all skills must use user-invocable (not user-invokable)
  *   7. user-invocable-flag      — the 6 user-facing skills must have user-invocable: true
+ *   8. docs-skill-existence     — every skill directory must have a matching docs/skills/<name>.md
+ *   9. skills-meta-existence    — every user-invocable skill must have a slug entry in
+ *                                 site/src/data/skills-meta.ts
+ *  10. readme-skills-table      — every user-invocable skill must appear in README.md's
+ *                                 skills table (warning)
+ *  11. temp-file-cleanup        — skills that use mktemp must also contain a cleanup
+ *                                 reference (rm -f / rm -rf / clean) (warning)
  *
  * Usage:
  *   node check-consistency.js [--project-root <path>] [--json]
  *
- * Exit codes: 0 = all pass, 1 = issues found, 2 = script error
+ * Exit codes: 0 = all pass (or warnings only), 1 = errors found, 2 = script error
  * Output: human-readable report (default) or JSON array of findings
  */
 
@@ -108,9 +115,11 @@ const SCRIPT_TO_SKILL = {
   'version-prepare.js':          'version-sdlc',
   'jira-prepare.js':             'jira-sdlc',
   'received-review-prepare.js':  'received-review-sdlc',
+  'commit-prepare.js':           'commit-sdlc',
+  'ship-prepare.js':             'ship-sdlc',
 };
 
-// All 10 skills that must declare user-invocable: true
+// All 11 skills that must declare user-invocable: true
 const USER_INVOCABLE_SKILLS = [
   'plan-sdlc',
   'execute-plan-sdlc',
@@ -122,6 +131,7 @@ const USER_INVOCABLE_SKILLS = [
   'commit-sdlc',
   'version-sdlc',
   'jira-sdlc',
+  'ship-sdlc',
 ];
 
 // ---------------------------------------------------------------------------
@@ -353,6 +363,120 @@ function checkUserInvocableFlag(skills, findings) {
   }
 }
 
+/**
+ * Rule 8 — docs-skill-existence
+ * Every skill directory must have a matching docs/skills/<name>.md file.
+ */
+function checkDocsSkillExistence(skills, projectRoot, findings) {
+  for (const skill of skills) {
+    const docPath = path.join(projectRoot, 'docs/skills', skill.name + '.md');
+    if (!isFile(docPath)) {
+      findings.push({
+        rule: 'docs-skill-existence',
+        severity: 'error',
+        file: `docs/skills/${skill.name}.md`,
+        message: `Missing documentation file for skill '${skill.name}'. Expected: docs/skills/${skill.name}.md`,
+      });
+    }
+  }
+}
+
+/**
+ * Rule 9 — skills-meta-existence
+ * Every user-invocable skill must have a matching slug entry in site/src/data/skills-meta.ts.
+ */
+function checkSkillsMetaExistence(projectRoot, findings) {
+  const metaPath = path.join(projectRoot, 'site/src/data/skills-meta.ts');
+  const content  = readFile(metaPath);
+  if (!content) {
+    findings.push({
+      rule: 'skills-meta-existence',
+      severity: 'error',
+      file: 'site/src/data/skills-meta.ts',
+      message: 'Could not read site/src/data/skills-meta.ts. File missing or unreadable.',
+    });
+    return;
+  }
+
+  const slugs = new Set();
+  const slugRe = /slug:\s*'([^']+)'/g;
+  let m;
+  while ((m = slugRe.exec(content)) !== null) {
+    slugs.add(m[1]);
+  }
+
+  for (const skillName of USER_INVOCABLE_SKILLS) {
+    if (!slugs.has(skillName)) {
+      findings.push({
+        rule: 'skills-meta-existence',
+        severity: 'error',
+        file: 'site/src/data/skills-meta.ts',
+        message: `No slug entry found for user-invocable skill '${skillName}'. Add: slug: '${skillName}'`,
+      });
+    }
+  }
+}
+
+/**
+ * Rule 10 — readme-skills-table
+ * Every user-invocable skill must appear in the README.md skills table.
+ */
+function checkReadmeSkillsTable(projectRoot, findings) {
+  const readmePath = path.join(projectRoot, 'README.md');
+  const content    = readFile(readmePath);
+  if (!content) {
+    findings.push({
+      rule: 'readme-skills-table',
+      severity: 'warning',
+      file: 'README.md',
+      message: 'Could not read README.md. File missing or unreadable.',
+    });
+    return;
+  }
+
+  const tableLines = content.split('\n').filter(l => l.trimStart().startsWith('|'));
+
+  for (const skillName of USER_INVOCABLE_SKILLS) {
+    const present = tableLines.some(l => l.includes(`/${skillName}`));
+    if (!present) {
+      findings.push({
+        rule: 'readme-skills-table',
+        severity: 'warning',
+        file: 'README.md',
+        message: `Skill '${skillName}' not found in README.md skills table. Add a row referencing /${skillName}.`,
+      });
+    }
+  }
+}
+
+/**
+ * Rule 11 — temp-file-cleanup
+ * Skills that use mktemp must also contain a cleanup reference (rm -f, rm -rf, or clean).
+ */
+function checkTempFileCleanup(skills, scriptNames, findings) {
+  for (const [scriptName, skillName] of Object.entries(SCRIPT_TO_SKILL)) {
+    if (!scriptNames.includes(scriptName)) continue;
+
+    const skill = skills.find(s => s.name === skillName);
+    if (!skill) continue;
+
+    const content = readFile(skill.file);
+    if (!content) continue;
+
+    if (!content.includes('mktemp')) continue;
+
+    const hasCleanup = /rm\s+-[rf]f?/.test(content) || /clean/i.test(content);
+    if (!hasCleanup) {
+      findings.push({
+        rule: 'temp-file-cleanup',
+        severity: 'warning',
+        file: path.relative(process.cwd(), skill.file),
+        message: `Skill '${skillName}' uses mktemp but has no cleanup reference (rm -f, rm -rf, or clean). Temp files should be cleaned up after use.`,
+      });
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -379,16 +503,20 @@ function main() {
   checkSkillPassesArguments(skills, scriptNames, findings);
   checkFrontmatterFieldNames(skills, findings);
   checkUserInvocableFlag(skills, findings);
+  checkDocsSkillExistence(skills, projectRoot, findings);
+  checkSkillsMetaExistence(projectRoot, findings);
+  checkReadmeSkillsTable(projectRoot, findings);
+  checkTempFileCleanup(skills, scriptNames, findings);
 
-  if (jsonOutput) {
-    process.stdout.write(JSON.stringify(findings, null, 2) + '\n');
-    process.exit(findings.length > 0 ? 1 : 0);
-  }
-
-  // Human-readable output
   const errors   = findings.filter(f => f.severity === 'error');
   const warnings = findings.filter(f => f.severity === 'warning');
 
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify(findings, null, 2) + '\n');
+    process.exit(errors.length > 0 ? 1 : 0);
+  }
+
+  // Human-readable output
   if (findings.length === 0) {
     process.stdout.write('✓ All consistency checks passed.\n');
     process.exit(0);
@@ -402,7 +530,7 @@ function main() {
     process.stdout.write(`${icon} [${f.rule}] ${f.file}${loc}\n  ${f.message}\n\n`);
   }
 
-  process.exit(findings.length > 0 ? 1 : 0);
+  process.exit(errors.length > 0 ? 1 : 0);
 }
 
 main();

--- a/.claude/skills/validate-skill-docs/SKILL.md
+++ b/.claude/skills/validate-skill-docs/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: validate-skill-docs
+description: "Use after modifying plugin skills, docs/skills/ pages, or site/src/data/skills-meta.ts. Validates content consistency between SKILL.md files and their documentation surfaces: skills-meta.ts field accuracy, connection validity, doc template compliance, and flag documentation."
+---
+
+# Validate Skill Docs
+
+After modifying skill workflows, flags, or documentation surfaces, run this validation
+to catch content drift between SKILL.md files and their docs/skills-meta.ts/README representations.
+
+## When to Use
+
+Invoke this skill when you have modified any of:
+
+- `plugins/sdlc-utilities/skills/*/SKILL.md` (workflow steps or flags changed)
+- `docs/skills/*.md` (documentation content)
+- `site/src/data/skills-meta.ts` (metadata entries)
+
+## Step 1 — Run the Validation Script
+
+```bash
+node .claude/skills/validate-skill-docs/check-docs-consistency.js
+```
+
+If the script exits 0: all checks pass — proceed.
+
+If the script exits 1: fix each issue before finishing the task (see Step 2).
+
+If the script exits 2: run from the repository root or pass `--project-root <path>`.
+
+## Step 2 — Fix Issues Found
+
+For each finding, apply the appropriate fix:
+
+### `user-invocable-match` (error)
+
+The `userInvocable` boolean in skills-meta.ts does not match the `user-invocable` frontmatter
+value in the skill's SKILL.md. Update one to match the other — the SKILL.md frontmatter is
+the source of truth.
+
+### `connections-valid` (error)
+
+A `connections[].to` value in skills-meta.ts references a slug that does not exist in the
+skillsMeta array. Fix the typo or add the missing skill entry.
+
+### `doc-template-sections` (warning)
+
+A `docs/skills/<name>.md` file is missing one or more required sections from the doc template.
+Add the missing sections using `docs/skill-doc-template.md` as the reference.
+
+Required sections: Overview, Usage, Examples, Prerequisites, What It Creates or Modifies,
+Related Skills. The Flags section is optional.
+
+### `doc-flags-present` (warning)
+
+A skill has `--` flags in its `argument-hint` but the corresponding `docs/skills/<name>.md`
+Flags table does not mention any of them. Add the missing flags to the Flags table.
+
+## Step 3 — Re-run Validation
+
+After fixing all issues:
+
+```bash
+node .claude/skills/validate-skill-docs/check-docs-consistency.js
+```
+
+Confirm exit 0 before marking work complete.

--- a/.claude/skills/validate-skill-docs/check-docs-consistency.js
+++ b/.claude/skills/validate-skill-docs/check-docs-consistency.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * check-docs-consistency.js
+ * Validates content consistency between SKILL.md files and their documentation surfaces.
+ *
+ * Rules checked:
+ *   1. user-invocable-match   — userInvocable in skills-meta.ts matches user-invocable
+ *                               frontmatter in SKILL.md (for skills present in both)
+ *   2. connections-valid      — every connections[].to slug in skills-meta.ts exists
+ *                               as a slug entry in the same file
+ *   3. doc-template-sections  — every docs/skills/<name>.md contains the required
+ *                               template sections (Overview, Usage, Examples, Prerequisites,
+ *                               What It Creates or Modifies, Related Skills)
+ *   4. doc-flags-present      — skills with --flags in argument-hint have at least one
+ *                               flag mentioned in their docs/skills/<name>.md
+ *
+ * Usage:
+ *   node check-docs-consistency.js [--project-root <path>] [--json]
+ *
+ * Exit codes: 0 = all pass (or warnings only), 1 = errors found, 2 = script error
+ * Output: human-readable report (default) or JSON array of findings
+ */
+
+'use strict';
+
+const fs   = require('node:fs');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let projectRoot = process.cwd();
+  let jsonOutput  = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--project-root' && args[i + 1]) {
+      projectRoot = path.resolve(args[++i]);
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    }
+  }
+  return { projectRoot, jsonOutput };
+}
+
+// ---------------------------------------------------------------------------
+// File reading helpers
+// ---------------------------------------------------------------------------
+
+function readFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function listDir(dirPath) {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function isDir(p) {
+  try { return fs.statSync(p).isDirectory(); } catch { return false; }
+}
+
+function isFile(p) {
+  try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+function discoverSkills(root) {
+  const dir = path.join(root, 'plugins/sdlc-utilities/skills');
+  return listDir(dir)
+    .filter(d => isDir(path.join(dir, d)))
+    .map(d => ({ name: d, file: path.join(dir, d, 'SKILL.md') }))
+    .filter(s => isFile(s.file));
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key   = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    fm[key] = value;
+  }
+  return fm;
+}
+
+// ---------------------------------------------------------------------------
+// skills-meta.ts parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse skills-meta.ts and return:
+ *   - slugs: Set of all slug values
+ *   - entries: Map of slug -> { userInvocable, connections: [{to}] }
+ *
+ * Strategy: scan sequentially; when we see a slug, open a new entry.
+ * Associate userInvocable and to: values with the most recently opened entry.
+ */
+function parseSkillsMeta(content) {
+  const slugs   = new Set();
+  const entries = new Map(); // slug -> { userInvocable, connections }
+
+  const slugRe          = /slug:\s*'([^']+)'/g;
+  const userInvocableRe = /userInvocable:\s*(true|false)/g;
+  const toRe            = /to:\s*'([^']+)'/g;
+
+  // Collect all slug positions
+  const slugMatches = [];
+  let m;
+  while ((m = slugRe.exec(content)) !== null) {
+    slugMatches.push({ slug: m[1], index: m.index });
+    slugs.add(m[1]);
+  }
+
+  // For each slug, determine the range of content that belongs to it
+  // (from its position to the start of the next slug, or end of file)
+  for (let i = 0; i < slugMatches.length; i++) {
+    const { slug, index } = slugMatches[i];
+    const end = i + 1 < slugMatches.length ? slugMatches[i + 1].index : content.length;
+    const chunk = content.slice(index, end);
+
+    // Extract userInvocable from this chunk
+    userInvocableRe.lastIndex = 0;
+    const uiMatch = userInvocableRe.exec(chunk);
+    const userInvocable = uiMatch ? uiMatch[1] === 'true' : null;
+
+    // Extract all to: values from this chunk
+    const connections = [];
+    toRe.lastIndex = 0;
+    let toMatch;
+    while ((toMatch = toRe.exec(chunk)) !== null) {
+      connections.push({ to: toMatch[1] });
+    }
+
+    entries.set(slug, { userInvocable, connections });
+  }
+
+  return { slugs, entries };
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1 — user-invocable-match
+// ---------------------------------------------------------------------------
+
+/**
+ * For skills present in both skills-meta.ts and plugins/sdlc-utilities/skills/,
+ * verify that userInvocable in skills-meta.ts matches user-invocable in SKILL.md frontmatter.
+ */
+function checkUserInvocableMatch(skills, _metaPath, metaEntries, findings) {
+  for (const skill of skills) {
+    if (!metaEntries.has(skill.name)) continue; // not in skills-meta.ts — skip
+
+    const content = readFile(skill.file);
+    if (!content) continue;
+
+    const fm = parseFrontmatter(content);
+    const fmValue = fm['user-invocable'];
+    if (fmValue === undefined) continue; // no user-invocable field — skip
+
+    const fmBool   = fmValue === 'true';
+    const metaEntry = metaEntries.get(skill.name);
+    if (metaEntry.userInvocable === null) continue; // could not parse from meta
+
+    if (fmBool !== metaEntry.userInvocable) {
+      findings.push({
+        rule: 'user-invocable-match',
+        severity: 'error',
+        file: path.relative(process.cwd(), skill.file),
+        message: `Skill '${skill.name}': user-invocable is '${fmValue}' in SKILL.md but userInvocable is ${metaEntry.userInvocable} in skills-meta.ts. Sync them — SKILL.md frontmatter is the source of truth.`,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2 — connections-valid
+// ---------------------------------------------------------------------------
+
+/**
+ * Every connections[].to slug in skills-meta.ts must exist as a slug in the same file.
+ */
+function checkConnectionsValid(metaPath, slugs, entries, findings) {
+  for (const [slug, entry] of entries) {
+    for (const conn of entry.connections) {
+      if (!slugs.has(conn.to)) {
+        findings.push({
+          rule: 'connections-valid',
+          severity: 'error',
+          file: path.relative(process.cwd(), metaPath),
+          message: `Skill '${slug}' has a connection to '${conn.to}' which is not a known slug in skillsMeta. Fix the typo or add the missing entry.`,
+        });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3 — doc-template-sections
+// ---------------------------------------------------------------------------
+
+const REQUIRED_SECTIONS = [
+  'Overview',
+  'Usage',
+  'Examples',
+  'Prerequisites',
+  'What It Creates or Modifies',
+  'Related Skills',
+];
+
+/**
+ * Every docs/skills/<name>.md must contain the required template section headings.
+ * Flags is NOT required — some skills have no flags.
+ */
+function checkDocTemplateSections(projectRoot, findings) {
+  const docsDir = path.join(projectRoot, 'docs/skills');
+  const files   = listDir(docsDir).filter(f => f.endsWith('.md'));
+
+  for (const fname of files) {
+    const filePath = path.join(docsDir, fname);
+    const content  = readFile(filePath);
+    if (!content) continue;
+
+    // Extract all h2 headings
+    const headingRe = /^##\s+(.+)$/gm;
+    const headings  = new Set();
+    let hm;
+    while ((hm = headingRe.exec(content)) !== null) {
+      headings.add(hm[1].trim().toLowerCase());
+    }
+
+    for (const required of REQUIRED_SECTIONS) {
+      if (!headings.has(required.toLowerCase())) {
+        findings.push({
+          rule: 'doc-template-sections',
+          severity: 'warning',
+          file: path.relative(process.cwd(), filePath),
+          message: `Missing required section '## ${required}'. Add it using docs/skill-doc-template.md as reference.`,
+        });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule 4 — doc-flags-present
+// ---------------------------------------------------------------------------
+
+/**
+ * For each skill with --flags in argument-hint, at least one flag must appear
+ * in the corresponding docs/skills/<name>.md.
+ */
+function checkDocFlagsPresent(skills, projectRoot, findings) {
+  const docsDir = path.join(projectRoot, 'docs/skills');
+
+  for (const skill of skills) {
+    const content = readFile(skill.file);
+    if (!content) continue;
+
+    const fm = parseFrontmatter(content);
+    const hint = fm['argument-hint'];
+    if (!hint) continue;
+
+    // Extract --flag tokens from argument-hint
+    const flagRe = /--[\w-]+/g;
+    const flags  = [];
+    let fm2;
+    while ((fm2 = flagRe.exec(hint)) !== null) {
+      flags.push(fm2[0]);
+    }
+    if (flags.length === 0) continue; // no -- flags — skip
+
+    const docPath    = path.join(docsDir, skill.name + '.md');
+    const docContent = readFile(docPath);
+    if (!docContent) continue; // doc missing — handled by docs-skill-existence in other script
+
+    const anyFlagPresent = flags.some(flag => docContent.includes(flag));
+    if (!anyFlagPresent) {
+      findings.push({
+        rule: 'doc-flags-present',
+        severity: 'warning',
+        file: path.relative(process.cwd(), docPath),
+        message: `Skill '${skill.name}' has flags [${flags.join(', ')}] in argument-hint but none appear in the doc. Add a Flags table using docs/skill-doc-template.md as reference.`,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const { projectRoot, jsonOutput } = parseArgs(process.argv);
+
+  const pluginRoot = path.join(projectRoot, 'plugins/sdlc-utilities');
+  if (!isDir(pluginRoot)) {
+    process.stderr.write(`ERROR: Plugin directory not found: ${pluginRoot}\n`);
+    process.stderr.write(`Run this script from the sdlc-marketplace repository root, or pass --project-root.\n`);
+    process.exit(2);
+  }
+
+  const metaPath = path.join(projectRoot, 'site/src/data/skills-meta.ts');
+  const metaContent = readFile(metaPath);
+  if (!metaContent) {
+    process.stderr.write(`ERROR: Could not read ${metaPath}\n`);
+    process.exit(2);
+  }
+
+  const skills             = discoverSkills(projectRoot);
+  const { slugs, entries } = parseSkillsMeta(metaContent);
+
+  const findings = [];
+
+  checkUserInvocableMatch(skills, metaPath, entries, findings);
+  checkConnectionsValid(metaPath, slugs, entries, findings);
+  checkDocTemplateSections(projectRoot, findings);
+  checkDocFlagsPresent(skills, projectRoot, findings);
+
+  const errors   = findings.filter(f => f.severity === 'error');
+  const warnings = findings.filter(f => f.severity === 'warning');
+
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify(findings, null, 2) + '\n');
+    process.exit(errors.length > 0 ? 1 : 0);
+  }
+
+  // Human-readable output
+  if (findings.length === 0) {
+    process.stdout.write('✓ All doc consistency checks passed.\n');
+    process.exit(0);
+  }
+
+  process.stdout.write(`Doc consistency check: ${errors.length} error(s), ${warnings.length} warning(s)\n\n`);
+
+  for (const f of findings) {
+    const loc  = f.line ? `:${f.line}` : '';
+    const icon = f.severity === 'error' ? '✗' : '⚠';
+    process.stdout.write(`${icon} [${f.rule}] ${f.file}${loc}\n  ${f.message}\n\n`);
+  }
+
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/.claude/skills/validate-skill-tests/SKILL.md
+++ b/.claude/skills/validate-skill-tests/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: validate-skill-tests
+description: "Use after creating or modifying a plugin skill to verify promptfoo test coverage. Checks dataset existence, fixture reference validity, new behavior coverage, and assertion quality."
+---
+
+# Validate Skill Tests
+
+After creating a new plugin skill or modifying a skill's workflow or flags, run through
+this checklist to verify promptfoo test coverage is adequate.
+
+## When to Use
+
+Invoke this skill when you have:
+
+- Created a new skill under `plugins/sdlc-utilities/skills/`
+- Modified a skill's workflow steps or flags (argument-hint changed)
+- Changed a skill's behavioral output (different format, new branches)
+
+## Step 1 — Identify Modified Skills
+
+Check which skills were modified in the current changeset:
+
+```bash
+git diff --name-only HEAD | grep 'plugins/sdlc-utilities/skills/.*/SKILL.md'
+```
+
+Extract skill names from the paths.
+
+## Step 2 — Dataset Existence
+
+For each modified skill, check whether a test dataset exists:
+
+```
+tests/promptfoo/datasets/<skill-name>.yaml
+```
+
+If the dataset does not exist, create one using `tests/promptfoo/datasets/review-sdlc.yaml`
+as the canonical reference for structure and assertion patterns.
+
+Each test case must include:
+- `description` — identifies skill and specific behavior (e.g., `"commit-sdlc: --auto flag skips confirmation"`)
+- `vars.skill_path` — path to the SKILL.md being tested
+- `vars.project_context` — path to a fixture file in `tests/promptfoo/fixtures/`
+- `assert` — array of assertions
+
+## Step 3 — Fixture Reference Validity
+
+For each test case in the dataset, verify:
+
+1. Every `file://fixtures/<name>.md` reference points to an existing file under `tests/promptfoo/fixtures/`
+2. Every `file://fixtures-fs/<name>/` reference points to an existing directory under `tests/promptfoo/fixtures-fs/`
+
+Report any broken references.
+
+## Step 4 — New Behavior Coverage
+
+If the skill gained a new flag (compare `argument-hint` in the SKILL.md before/after) or
+a new workflow step:
+
+1. Check whether any existing test case exercises the new behavior
+2. If not, suggest adding a test case with:
+   - A descriptive name referencing the new flag/step
+   - A fixture that exercises the new code path
+   - Both structural and behavioral assertions
+
+## Step 5 — Assertion Quality
+
+Review each test case's assertions for completeness:
+
+| Required | Type | Purpose |
+|----------|------|---------|
+| At least 1 | `icontains` or `regex` | Structural — verifies specific output strings |
+| At least 1 | `llm-rubric` | Behavioral — verifies semantic correctness |
+
+Flag test cases that have only structural OR only behavioral assertions.
+Well-written `llm-rubric` assertions are specific enough to distinguish pass from fail
+(e.g., "The commit message follows conventional commits format and references the changed files"
+not "The output looks correct").
+
+## Step 6 — Report Findings
+
+Present findings in this format:
+
+| Skill | Check | Status | Detail |
+|-------|-------|--------|--------|
+| `<name>` | Dataset exists | ✓/✗ | path or "missing" |
+| `<name>` | Fixture refs valid | ✓/✗ | broken refs listed |
+| `<name>` | New behavior covered | ✓/✗/N/A | uncovered flags/steps |
+| `<name>` | Assertion quality | ✓/✗ | test cases with gaps |
+
+## DO NOT
+
+- Run `promptfoo eval` automatically — evaluation runs must always be initiated by the user
+- Create test cases that test implementation details rather than observable behavior
+- Write assertions that match on volatile output (timestamps, random IDs, file paths with user dirs)


### PR DESCRIPTION
## Summary

Adds three internal validation skills (expanded validate-plugin-consistency, new validate-skill-docs, new validate-skill-tests) and reverts the version-sdlc `--auto` flag introduced in 0.16.4, restoring the mandatory release approval prompt.

## Business Context

The `--auto` flag on version-sdlc allowed automated pipelines to skip the release approval consent gate. Release tagging is a high-consequence action that benefits from explicit human approval even in automated flows. Separately, no automated checks existed for documentation consistency, skills-meta.ts accuracy, or test coverage adequacy — structural drift accumulated silently.

## Business Benefits

Restores a safety gate for release tagging, reducing risk of accidental releases in automated pipelines. New validation skills catch structural and documentation drift before it reaches users, improving plugin quality and reducing manual review burden.

## Github Issue

Not detected

## Technical Design

The validation expansion adds four new rules to check-consistency.js (docs-skill-existence, skills-meta-existence, readme-skills-table, temp-file-cleanup) and introduces two new validation skills: validate-skill-docs with a dedicated check-docs-consistency.js script, and validate-skill-tests as a structured checklist. The version-sdlc revert cleanly removes the `--auto` flag from argument parsing, context output, SKILL.md workflow steps, and the changelog-workflow sub-document. Exit code semantics changed: warnings alone now exit 0 (previously exit 1).

## Technical Impact

Plugin version rolled back from 0.16.4 to 0.16.3. ship-sdlc `--auto` mode now has two mandatory pause points instead of one (received-review-sdlc and version-sdlc). The version-prepare.js `parseArgs` return shape no longer includes `auto`. The 0.16.4 CHANGELOG entry is removed.

## Changes Overview

- Expanded plugin consistency checker with four new validation rules: doc file existence, skills-meta.ts entry coverage, README skills table presence, and temp file cleanup verification
- Added validate-skill-docs skill with a dedicated validation script that checks content sync between SKILL.md files and their documentation surfaces (user-invocable match, connection validity, template sections, flag documentation)
- Added validate-skill-tests skill as a manual checklist for verifying promptfoo test coverage after skill changes
- Reverted version-sdlc `--auto` flag: removed from argument parsing, context JSON, SKILL.md workflow, changelog workflow, and ship-sdlc forwarding logic
- Rolled back plugin version to 0.16.3 and removed the 0.16.4 CHANGELOG entry
- Updated ship-sdlc documentation to reflect two mandatory pause points in auto mode
- Changed exit code semantics: warnings-only findings now exit 0 instead of 1

## Testing

No new automated tests added. The validate-skill-docs and validate-plugin-consistency skills include runnable validation scripts (`check-docs-consistency.js`, `check-consistency.js`). The deleted `version-prepare-auto.test.js` covered the removed `--auto` functionality.


🤖 Generated with [Claude Code](https://claude.com/claude-code)