### PR TITLE
feat(#143): step-emitter - add architecture and spec contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.11] - 2026-04-04
+
+### Added
+- Step-emitter architecture with shared `lib/stepper.js` module that inverts control between SDLC skill scripts and the LLM (#143)
+- P-STEP, P-TRANS, and C-STEP requirement fields added to all 9 skill specifications (#143)
+
 ## [0.17.10] - 2026-04-04
 
 ### Added

--- a/docs/adding-skills.md
+++ b/docs/adding-skills.md
@@ -89,6 +89,28 @@ See `./templates.md` for language-specific templates.
 See `./checklist.md` for the full verification checklist.
 ```
 
+## Prepare Script Patterns
+
+Skills that use a prepare script can follow one of two patterns:
+
+### One-Shot (Current Default)
+
+The script runs once, returns flat JSON, and the LLM follows SKILL.md instructions to execute the full workflow. Suitable for simple skills where the LLM can handle all sequencing.
+
+### Step-Emitter (Recommended for Complex Skills)
+
+The script becomes a multi-step workflow controller using the universal step-emitter protocol. Each invocation returns a single step for the LLM to execute. After the LLM completes the step, it calls the script again with the result. The script controls sequencing, conditional logic, and error recovery deterministically.
+
+Step-emitter scripts use `lib/stepper.js` for:
+- **`parseArgs()`** — parse `--after`, `--result`, `--result-file`, `--state` from CLI
+- **`createEnvelope(status, step, options)`** — build the universal output envelope
+- **`initState(skill)`** — create and persist initial state
+- **`transition(stateFile, afterStepId, result, nextStepId)`** — process step transitions
+
+SKILL.md for a step-emitter skill contains an execution loop and domain-specific sections keyed by `step.id` rather than a linear workflow.
+
+See [Step-Emitter Architecture](step-emitter-architecture.md) for the full protocol reference and migration guide.
+
 ## Error Recovery (Required)
 
 Every skill that runs a script or calls an external tool **must** include an `## Error Recovery` section. This section ensures that failures are surfaced cleanly and routed to `error-report-sdlc` when appropriate.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,17 @@ To add another plugin to this marketplace:
 
 3. Follow the same structure: `skills/`, `hooks/` (and optionally `scripts/`, `commands/`)
 
+## Step-Emitter Script Architecture
+
+Skills can use the **step-emitter pattern** where prepare scripts become multi-step workflow controllers. Instead of running once and returning flat JSON, a step-emitter script emits one step at a time via a universal envelope protocol. The LLM executes each step using domain knowledge, then calls the script again with the result. The script controls sequencing; the LLM provides judgment.
+
+Key components:
+- **`lib/stepper.js`** — shared utility for envelope creation, state management, and CLI argument parsing
+- **Universal envelope** — every script invocation returns `{ status, step, llm_decision, state_file, progress, ext }`
+- **Two-call protocol** — initial call returns the first step; subsequent calls use `--after <step_id> --result-file <path> --state <state_file>`
+
+See [Step-Emitter Architecture](step-emitter-architecture.md) for the full protocol reference, migration guide, and testing patterns.
+
 ## Testing
 
 All testing uses [promptfoo](https://promptfoo.dev/) — a framework for evaluating LLM outputs. Two configurations cover different test types:

--- a/docs/specs/commit-sdlc.md
+++ b/docs/specs/commit-sdlc.md
@@ -93,6 +93,20 @@
 - C10: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C11: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/commit.js` — provides all pre-computed context (diff, history, config)

--- a/docs/specs/jira-sdlc.md
+++ b/docs/specs/jira-sdlc.md
@@ -89,6 +89,20 @@
 - C11: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C12: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/jira.js` — manages cache file operations (check, load, save, init-templates)

--- a/docs/specs/plan-sdlc.md
+++ b/docs/specs/plan-sdlc.md
@@ -94,6 +94,20 @@
 - C11: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C12: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/plan.js` — context detection (OpenSpec, guardrails, branch matching)

--- a/docs/specs/pr-sdlc.md
+++ b/docs/specs/pr-sdlc.md
@@ -102,6 +102,20 @@
 - C11: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C12: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/pr.js` — provides all pre-computed PR context

--- a/docs/specs/received-review-sdlc.md
+++ b/docs/specs/received-review-sdlc.md
@@ -101,6 +101,20 @@ Critique #2 (responses):
 - C12: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C13: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/received-review.js` — pre-computes PR thread state with incremental processing

--- a/docs/specs/review-sdlc.md
+++ b/docs/specs/review-sdlc.md
@@ -74,6 +74,20 @@
 - C7: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C8: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/review.js` — produces the review manifest with all git data

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -92,6 +92,20 @@
 - C9: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C10: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/setup.js` — detects current config state and legacy files

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -106,6 +106,20 @@
 - C13: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C14: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/ship.js` — pre-computes flags, context, step statuses, and invocations

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -93,6 +93,20 @@
 - C9: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C10: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
+## Step-Emitter Contract
+
+> Added as foundation for step-emitter migration. P-TRANS-1 transition map to be defined during script migration.
+
+- P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`, `state_file`, `progress`, and `ext` fields on every invocation
+- P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>` for subsequent invocations after the initial call
+- P-STEP-3: State file is created on first invocation, updated after each step, and cleaned up when status is `"done"`
+- P-TRANS-1: Step transition map — TBD (to be defined during script migration)
+- P-TRANS-2: Every `step.id` in the transition map has a corresponding `When step.id == X` section in SKILL.md
+- C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence — the script controls progression
+- C-STEP-2: The LLM MUST NOT read or modify the state file directly — it passes the path back to the script via `--state`
+- C-STEP-3: When `llm_decision` is null, the LLM executes the step without asking the user or making judgment calls
+- C-STEP-4: When `llm_decision` is non-null, the LLM MUST resolve it (via domain knowledge or user interaction) before proceeding
+
 ## Integration
 
 - I1: `skill/version.js` — provides all pre-computed version context

--- a/docs/step-emitter-architecture.md
+++ b/docs/step-emitter-architecture.md
@@ -1,0 +1,363 @@
+# Step-Emitter Architecture
+
+## Overview
+
+The step-emitter pattern inverts control between SDLC skill scripts and the LLM. Instead of running once and returning flat JSON for the LLM to interpret, scripts become workflow controllers that emit one step at a time. The LLM executes each step using domain knowledge (critique, content generation, user interaction), then calls the script again with the result. The script decides what happens next.
+
+**Principle:** Scripts do sequencing. The LLM does judgment.
+
+## Universal Protocol
+
+Every step-emitter script speaks a two-call protocol.
+
+### Initial Call
+
+```bash
+node skill.js [--flags ...]
+```
+
+Returns the first step to execute.
+
+### Subsequent Calls
+
+```bash
+node skill.js --after <step_id> --result-file <path> --state <state_file>
+```
+
+The LLM passes back the step it just executed (`--after`), the result of that execution (`--result-file` pointing to a JSON file, or `--result` with inline JSON), and the state file path (`--state`). The script reads the result, updates its internal state, and returns the next step.
+
+## Universal Output Envelope
+
+Every script invocation returns this structure:
+
+```json
+{
+  "status": "step | done | error",
+  "step": {
+    "id": "unique_step_identifier",
+    "action": "Human-readable instruction for the LLM",
+    "tool_hints": ["Agent", "Bash", "AskUserQuestion"],
+    "data": {}
+  },
+  "llm_decision": null,
+  "state_file": "/tmp/skill-abc123.json",
+  "progress": { "completed": 2, "total": 7 },
+  "ext": {}
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `status` | `"step"` = do this next, `"done"` = workflow complete, `"error"` = unrecoverable |
+| `step.id` | Unique identifier passed back via `--after` |
+| `step.action` | What the LLM should do — human-readable, not a command |
+| `step.tool_hints` | Which tools the LLM will likely need (guidance, not enforcement) |
+| `step.data` | All pre-computed data for this step (diffs, file lists, classifications) |
+| `llm_decision` | If non-null, the LLM must make a judgment call or ask the user. Result goes back via `--result` |
+| `state_file` | Path to accumulated state — the LLM passes it back, never reads or modifies it directly |
+| `progress` | Step counter for progress reporting |
+| `ext` | Skill-specific extension fields (review dimensions, wave structure, pipeline table, etc.) |
+
+### Result Envelope (LLM to Script)
+
+When calling `--after`, the LLM passes back:
+
+```json
+{
+  "step_id": "echoes the step.id that was executed",
+  "success": true,
+  "output": {},
+  "error": null
+}
+```
+
+The `output` field is skill-step-specific. Examples:
+- After `generate_message`: `{ "message": "feat: add widget parser" }`
+- After `run_review`: `{ "verdict": "APPROVED_WITH_NOTES", "notes": [...] }`
+- After `execute_wave_1`: `{ "T1": "done", "T2": "failed", "T2_error": "..." }`
+
+### State File
+
+Owned entirely by the script. The LLM never reads or modifies it — just passes the path. Structure:
+
+```json
+{
+  "skill": "skill-name",
+  "started_at": "2026-04-04T10:00:00Z",
+  "current_step": "step_id",
+  "history": [
+    { "step": "classify", "result": "success", "data": {}, "timestamp": "..." }
+  ],
+  "ext": {}
+}
+```
+
+## Writing a Step-Emitter Script
+
+### Using `lib/stepper.js`
+
+All step-emitter scripts use the shared `lib/stepper.js` module:
+
+```javascript
+const path = require('node:path');
+const LIB = path.join(__dirname, '..', 'lib');
+const {
+  parseArgs,
+  createEnvelope,
+  initState,
+  transition,
+  readState,
+  writeState,
+  cleanupState,
+} = require(path.join(LIB, 'stepper'));
+```
+
+### Script Structure
+
+```javascript
+const { after, result, stateFile, rest } = parseArgs();
+
+if (!after) {
+  // Initial call — compute first step
+  const { state, stateFile: sf } = initState('my-skill');
+  // ... compute step data ...
+  console.log(JSON.stringify(createEnvelope('step', {
+    id: 'first_step',
+    action: 'Do something',
+    tool_hints: ['Edit'],
+    data: { /* pre-computed */ },
+  }, { stateFile: sf, progress: { completed: 0, total: 3 } })));
+  return;
+}
+
+// Subsequent call — route based on completed step
+const state = transition(stateFile, after, result, 'next_step_id');
+
+switch (after) {
+  case 'first_step':
+    console.log(JSON.stringify(createEnvelope('step', {
+      id: 'second_step',
+      action: 'Do the next thing',
+      data: { /* uses result.output from first_step */ },
+    }, { stateFile, progress: { completed: 1, total: 3 } })));
+    break;
+
+  case 'second_step':
+    cleanupState(stateFile);
+    console.log(JSON.stringify(createEnvelope('done', null, {
+      ext: { summary: { /* final results */ } },
+    })));
+    break;
+}
+```
+
+### Defining Step Transitions
+
+Document all valid transitions as a map in the script header:
+
+```javascript
+// Transition map:
+//   init → generate_message → confirm_and_commit → done
+//   init → generate_message → confirm_and_commit (cancel) → done (aborted)
+//   Any step (error) → error
+```
+
+Every step.id must have a handler in the switch statement. Unrecognized step IDs should return an error envelope.
+
+### Handling Errors
+
+Return an error envelope when the script cannot continue:
+
+```javascript
+console.log(JSON.stringify(createEnvelope('error', null, {
+  error: 'Descriptive error message',
+  stateFile, // preserve state for debugging
+})));
+```
+
+### LLM Decisions
+
+When the script needs the LLM to make a judgment call or ask the user:
+
+```javascript
+console.log(JSON.stringify(createEnvelope('step', {
+  id: 'confirm_action',
+  action: 'Present options to user and get approval',
+  data: { options: ['yes', 'edit', 'cancel'] },
+}, {
+  llmDecision: {
+    question: 'Approve this action?',
+    options: ['yes', 'edit', 'cancel'],
+    default: 'yes',
+  },
+  stateFile,
+  progress: { completed: 1, total: 3 },
+})));
+```
+
+When `llm_decision` is non-null, the LLM must resolve it before proceeding. When null, the LLM executes the step without asking.
+
+## SKILL.md Executor Pattern
+
+A step-emitter SKILL.md contains an execution loop and domain-specific sections keyed by `step.id`.
+
+### Execution Loop
+
+```markdown
+## Execution Loop
+
+1. Run prepare script: `node $SCRIPT $ARGUMENTS`
+2. Read output JSON
+3. While output.status == "step":
+   a. If output.llm_decision is non-null, apply domain knowledge or ask user
+   b. Execute output.step using domain instructions (see sections below)
+   c. Capture result as { step_id, success, output, error }
+   d. Call: node $SCRIPT --after <step.id> --result-file <path> --state <state_file>
+   e. Read new output
+4. If output.status == "done", present ext.summary
+5. If output.status == "error", present error and stop
+```
+
+### Domain Instruction Sections
+
+Below the loop, SKILL.md contains sections keyed by step.id:
+
+```markdown
+### When step.id == "critique_wave"
+Apply these quality criteria: [quality gate table]
+
+### When step.id == "generate_commit_message"
+Follow conventional commits format, match recent history style...
+
+### When step.id == "present_review"
+Format findings by dimension, severity-sort, include file:line references...
+```
+
+The script controls WHAT happens WHEN. SKILL.md controls HOW the LLM does its part.
+
+## State Management
+
+### What Goes in State
+
+- `skill` — skill name (immutable after init)
+- `started_at` — ISO timestamp (immutable after init)
+- `current_step` — the step about to be executed
+- `history` — append-only log of completed steps and their results
+- `ext` — skill-specific accumulated data (e.g., review findings, wave results)
+
+### What Goes in `ext` (Envelope)
+
+Per-step extension data that the LLM needs for the current response but does not need to persist across steps. Examples: review dimension scores, pipeline stage table, diff statistics.
+
+### State File Lifecycle
+
+1. **Created** on first invocation via `initState(skill)`
+2. **Updated** after each step via `transition()` or `writeState()`
+3. **Cleaned up** when status is `"done"` via `cleanupState()`
+4. **Preserved** on error for debugging or resume
+
+## Testing
+
+### Script Execution Tests (`promptfooconfig-exec.yaml`)
+
+Test step transitions as deterministic functions. Each test case invokes the script with specific inputs and asserts on the output envelope:
+
+```yaml
+- description: "skill stepper: init returns first step"
+  vars:
+    script_path: "plugins/sdlc-utilities/scripts/skill/example.js"
+    script_args: ""
+    fixture_dir: "fixtures-fs/example-basic"
+  assert:
+    - type: javascript
+      value: "output.status === 'step' && output.step.id === 'first_step'"
+    - type: javascript
+      value: "output.progress.total >= 2"
+```
+
+**What to cover per skill:**
+- Every step transition (step A to step B given result X)
+- Conditional branching (different results lead to different next steps)
+- Error and recovery paths
+- State file creation, accumulation, and cleanup
+- Envelope schema compliance (universal base fields always present)
+
+### Behavioral Tests (`promptfooconfig.yaml`)
+
+Test the LLM's execution of the step loop:
+
+```yaml
+- description: "skill: executes step-emitter loop correctly"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/example/SKILL.md"
+    project_context: "file://fixtures/example-stepper-context.md"
+    user_request: "/example"
+  assert:
+    - type: llm-rubric
+      value: "The assistant ran the prepare script, read the step envelope, executed the step action, then called the script again with --after and --result flags"
+```
+
+## Migration Guide
+
+To convert an existing one-shot prepare script to step-emitter:
+
+1. **Map the workflow** — identify every decision point in the current SKILL.md where the LLM makes a sequencing choice (not a judgment call). These become step boundaries.
+
+2. **Define the transition map** — document all step transitions including error and conditional branches.
+
+3. **Implement the script** — use `lib/stepper.js`. The initial call computes what the old script returned in one shot. Subsequent calls read the prior result and compute the next step.
+
+4. **Update SKILL.md** — replace the linear workflow with the execution loop template. Move domain-specific instructions into `When step.id == "..."` sections.
+
+5. **Update the spec** — add P-STEP, P-TRANS, and C-STEP requirements (see spec template below).
+
+6. **Write tests** — add exec test cases for every step transition. Update behavioral tests to assert on the step-emitter loop pattern.
+
+### Spec Field Templates
+
+Add to existing skill specs under a new `### Step-Emitter Contract` section:
+
+```markdown
+### Step-Emitter Contract
+
+P-STEP-1: Script returns universal envelope with `status`, `step`, `llm_decision`,
+          `state_file`, `progress`, and `ext` fields on every invocation.
+
+P-STEP-2: Script accepts `--after <step_id> --result-file <path> --state <state_file>`
+          for subsequent invocations after the initial call.
+
+P-STEP-3: State file is created on first invocation, updated after each step,
+          and cleaned up when status is "done".
+
+P-TRANS-1: Step transition map (skill-specific):
+           init -> step_a -> step_b -> done
+           (with error branches documented)
+
+P-TRANS-2: Every step.id in the transition map has a corresponding
+           "When step.id == X" section in SKILL.md.
+
+C-STEP-1: The LLM MUST NOT skip steps or reorder the sequence.
+          The script controls progression.
+
+C-STEP-2: The LLM MUST NOT read or modify the state file directly.
+          It passes the path back to the script via --state.
+
+C-STEP-3: When llm_decision is null, the LLM executes the step
+          without asking the user or making judgment calls.
+
+C-STEP-4: When llm_decision is non-null, the LLM MUST resolve it
+          (via domain knowledge or user interaction) before proceeding.
+```
+
+## What Changes vs What Stays
+
+| Aspect | Before (One-Shot) | After (Step-Emitter) |
+|---|---|---|
+| Script invocation | Once (prepare phase) | Multiple (per step) |
+| Workflow sequencing | LLM follows SKILL.md | Script emits next step |
+| Conditional logic | LLM interprets conditions | Script evaluates deterministically |
+| State management | LLM tracks in context | Script persists to file |
+| SKILL.md content | Full workflow + domain knowledge | Domain knowledge only (keyed by step.id) |
+| Output format | Per-skill flat JSON | Universal envelope + ext |
+| Error recovery | LLM decides strategy | Script computes (model escalation, retry budget) |
+| Shared utilities | `lib/output.js` (write helper) | `lib/stepper.js` (full step lifecycle) |

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/README.md
+++ b/plugins/sdlc-utilities/scripts/README.md
@@ -46,6 +46,7 @@ scripts/
 | `openspec.js` | `detectActiveChanges`, `validateChange` | OpenSpec change detection |
 | `output.js` | `writeOutput` | Structured JSON output helpers |
 | `state.js` | `readState`, `writeState`, `initState` | Execution state file I/O |
+| `stepper.js` | `parseArgs`, `createEnvelope`, `initState`, `transition`, `readState`, `writeState`, `addHistory`, `cleanupState` | Step-emitter protocol utilities (envelope creation, state lifecycle, CLI parsing) |
 | `version.js` | `detectVersionFile`, `readVersion`, `computeNextVersions` | Semantic versioning utilities |
 
 ## Script Resolution

--- a/plugins/sdlc-utilities/scripts/lib/stepper.js
+++ b/plugins/sdlc-utilities/scripts/lib/stepper.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * stepper.js
+ * Shared step-emitter utility library for SDLC skill scripts.
+ *
+ * Provides the universal two-call protocol: scripts emit one step at a time,
+ * the LLM executes each step, and calls the script again with the result.
+ * The script controls workflow sequencing; the LLM provides domain knowledge.
+ *
+ * Zero npm dependencies — Node.js built-ins only.
+ */
+
+const fs     = require('fs');
+const os     = require('os');
+const path   = require('path');
+const crypto = require('crypto');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse step-emitter CLI arguments from process.argv.
+ *
+ * Recognizes:
+ *   --after <step_id>        Step that was just executed
+ *   --result <json>          Result JSON string (inline)
+ *   --result-file <path>     Result JSON file path (preferred for large payloads)
+ *   --state <state_file>     Path to accumulated state file
+ *
+ * All other argv entries are returned in `rest` for skill-specific parsing.
+ *
+ * @returns {{ after: string|null, result: object|null, stateFile: string|null, rest: string[] }}
+ */
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  let after = null;
+  let result = null;
+  let stateFile = null;
+  const rest = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--after':
+        after = argv[++i] || null;
+        break;
+      case '--result':
+        try { result = JSON.parse(argv[++i]); }
+        catch (_) { result = null; }
+        break;
+      case '--result-file': {
+        const filePath = argv[++i];
+        if (filePath) {
+          try { result = JSON.parse(fs.readFileSync(filePath, 'utf8')); }
+          catch (_) { result = null; }
+        }
+        break;
+      }
+      case '--state':
+        stateFile = argv[++i] || null;
+        break;
+      default:
+        rest.push(argv[i]);
+    }
+  }
+
+  return { after, result, stateFile, rest };
+}
+
+// ---------------------------------------------------------------------------
+// Envelope creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a universal output envelope.
+ *
+ * @param {"step"|"done"|"error"} status
+ * @param {object|null} step  Step descriptor (required when status is "step")
+ *   @param {string} step.id       Unique step identifier
+ *   @param {string} step.action   Human-readable instruction for the LLM
+ *   @param {string[]} [step.tool_hints]  Tools the LLM will likely need
+ *   @param {object} [step.data]   Pre-computed data for this step
+ * @param {object} [options]
+ *   @param {object|null} [options.llmDecision]   Decision the LLM must make
+ *   @param {string|null} [options.stateFile]     Path to state file
+ *   @param {{ completed: number, total: number }} [options.progress]
+ *   @param {object} [options.ext]  Skill-specific extension fields
+ *   @param {string} [options.error]  Error message (when status is "error")
+ * @returns {object} Universal envelope
+ */
+function createEnvelope(status, step, options = {}) {
+  const envelope = {
+    status,
+    step: step || null,
+    llm_decision: options.llmDecision || null,
+    state_file: options.stateFile || null,
+    progress: options.progress || null,
+    ext: options.ext || {},
+  };
+
+  if (status === 'error' && options.error) {
+    envelope.error = options.error;
+  }
+
+  return envelope;
+}
+
+// ---------------------------------------------------------------------------
+// State management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a unique temporary file path for state storage.
+ *
+ * @param {string} skill  Skill name used as filename prefix
+ * @returns {string} Absolute path to a new temp file
+ */
+function createStateFile(skill) {
+  const hash = crypto.randomBytes(6).toString('hex');
+  return path.join(os.tmpdir(), `${skill}-${hash}.json`);
+}
+
+/**
+ * Read and parse a state file.
+ *
+ * @param {string} stateFile  Absolute path to the state file
+ * @returns {object} Parsed state
+ * @throws {Error} If file does not exist or contains invalid JSON
+ */
+function readState(stateFile) {
+  const raw = fs.readFileSync(stateFile, 'utf8');
+  return JSON.parse(raw);
+}
+
+/**
+ * Write state to a file (atomic write via temp + rename).
+ *
+ * @param {string} stateFile  Absolute path to the state file
+ * @param {object} state      State object to persist
+ */
+function writeState(stateFile, state) {
+  const dir    = path.dirname(stateFile);
+  const suffix = crypto.randomBytes(4).toString('hex');
+  const tmp    = path.join(dir, path.basename(stateFile) + '.' + suffix + '.tmp');
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
+  fs.renameSync(tmp, stateFile);
+}
+
+/**
+ * Append a completed step to the state history array.
+ *
+ * @param {object} state   State object (must have a `history` array)
+ * @param {string} stepId  The step.id that was executed
+ * @param {object} result  The result envelope from the LLM
+ */
+function addHistory(state, stepId, result) {
+  if (!Array.isArray(state.history)) {
+    state.history = [];
+  }
+  state.history.push({
+    step: stepId,
+    result: result.success !== undefined ? (result.success ? 'success' : 'failed') : 'unknown',
+    data: result.output || {},
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Clean up (delete) a state file. Silently ignores missing files.
+ *
+ * @param {string} stateFile  Absolute path to the state file
+ */
+function cleanupState(stateFile) {
+  try { fs.unlinkSync(stateFile); } catch (_) { /* ignored */ }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: initial state scaffold
+// ---------------------------------------------------------------------------
+
+/**
+ * Create and persist an initial state object for a skill.
+ *
+ * @param {string} skill     Skill name (e.g., "commit-sdlc")
+ * @param {object} [extra]   Additional fields to merge into the initial state
+ * @returns {{ state: object, stateFile: string }}
+ */
+function initState(skill, extra = {}) {
+  const stateFile = createStateFile(skill);
+  const state = {
+    skill,
+    started_at: new Date().toISOString(),
+    current_step: null,
+    history: [],
+    ext: {},
+    ...extra,
+  };
+  writeState(stateFile, state);
+  return { state, stateFile };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: step transition helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a step transition: read state, add history, update current step,
+ * persist, and return the updated state. Combines the common pattern of
+ * readState + addHistory + writeState into a single call.
+ *
+ * @param {string} stateFile   Path to state file
+ * @param {string} afterStepId The step.id that was just completed
+ * @param {object} result      The result envelope from the LLM
+ * @param {string} nextStepId  The next step.id (set as current_step)
+ * @returns {object} Updated state
+ */
+function transition(stateFile, afterStepId, result, nextStepId) {
+  const state = readState(stateFile);
+  addHistory(state, afterStepId, result);
+  state.current_step = nextStepId;
+  writeState(stateFile, state);
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  parseArgs,
+  createEnvelope,
+  createStateFile,
+  readState,
+  writeState,
+  addHistory,
+  cleanupState,
+  initState,
+  transition,
+};


### PR DESCRIPTION
## Summary
Introduces the step-emitter pattern — a new execution model where SDLC skill scripts become multi-step workflow controllers that emit one step at a time for the LLM to execute, inverting control so scripts handle sequencing while the LLM provides domain judgment. Adds the shared `lib/stepper.js` library, full architecture documentation, and step-emitter requirement fields (P-STEP, P-TRANS, C-STEP) to all 9 skill specifications.

## Business Context
Current SDLC skills use a one-shot model where scripts return flat JSON and the LLM interprets the entire workflow from SKILL.md. This limits deterministic control over complex multi-step workflows — the LLM can skip steps, reorder sequences, or drift from the intended flow. The step-emitter pattern addresses this by giving scripts explicit control over workflow progression while preserving the LLM's strengths in judgment and content generation.

## Business Benefits
- Enables more reliable and predictable skill execution for complex multi-step workflows like PR creation, code review, and release management
- Reduces LLM drift and step-skipping by making the script the single authority on workflow sequencing
- Establishes a shared library and protocol that all future skill scripts can adopt, reducing per-skill implementation cost

## Github Issue
Closes #143

## Technical Design
The architecture introduces a two-call protocol: the initial script invocation returns the first step via a universal envelope (`{ status, step, llm_decision, state_file, progress, ext }`), and subsequent invocations receive `--after <step_id> --result-file <path> --state <state_file>` to advance the workflow. State is persisted atomically via temp-file-and-rename in the OS temp directory.

Key decisions:
- **Zero npm dependencies** — stepper.js uses only Node.js built-ins (fs, os, path, crypto)
- **Universal envelope** — all step-emitter scripts share the same output structure, enabling consistent SKILL.md execution loops
- **Spec-first rollout** — P-STEP/P-TRANS/C-STEP requirements are added to all 9 specs now with transition maps marked TBD, so actual script migration can proceed incrementally

## Technical Impact
None. This is an additive change — no existing script behavior, skill interface, or hook payload is modified. The stepper.js module is new and unused until individual skills migrate to the step-emitter pattern. Version bumped to v0.17.11 (patch).

## Changes Overview
- New shared step-emitter utility library providing CLI argument parsing, envelope creation, state management (init, read, write, cleanup), and step-transition helpers
- Full architecture documentation covering the universal protocol, envelope schema, state lifecycle, execution loop pattern, migration guide, and testing strategies
- Step-emitter contract requirements (P-STEP-1 through P-STEP-3, P-TRANS-1/2, C-STEP-1 through C-STEP-4) added to all 9 skill specifications as foundation for incremental migration
- Existing docs (architecture overview, adding-skills guide, scripts README) updated with step-emitter references and pattern descriptions
- CHANGELOG entry and version bump to v0.17.11

## Testing
No automated tests added in this PR. The stepper.js library is a new shared module with no existing callers — test coverage will be added alongside the first skill migration that exercises the step-emitter protocol. The library's functions are pure and deterministic, suitable for promptfoo exec-mode tests when migration begins.