### PR TITLE
fix(#129): setup-sdlc - centralize initialization and fix structural bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.13] - 2026-04-04
+
+### Fixed
+- setup-sdlc centralized initialization via new `setup-init.js` utility script for unified config and local config writing (#129, #134)
+- setup-sdlc dimension scanning now uses Glob tool; permission constraints applied per spec (#129, #135, #133)
+- ship-sdlc fabrication guard and coherent flag handling (#136)
+- ship-sdlc auto workspace handling (#146)
+
 ## [0.17.12] - 2026-04-04
 
 ### Fixed

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -26,13 +26,15 @@
 - R3: Migration logic: detect legacy config files (version.json, ship-config.json, review.json), offer merge into unified config, optionally delete originals
 - R4: Config builder walks through missing sections interactively: version, ship, jira, review, commit patterns, PR title patterns
 - R5: Idempotent: re-run safe via read-merge-write (`writeProjectConfig`, `writeLocalConfig` from `lib/config.js`)
-- R6: Config writes go through `lib/config.js` functions via inline Node.js — never use Edit/Write tools directly on config files
+- R6: Config writes go through `util/setup-init.js` which calls `lib/config.js` functions. The script deterministically creates `.sdlc/` directory, `.sdlc/.gitignore`, and config files — never use Edit/Write tools directly on config files
 - R7: Early exit when everything is configured, no migration needed, and `--force` not passed
 - R8: Ship config is developer-local (`.sdlc/local.json`, gitignored), not project-level
 - R9: Content setup sub-flows: review dimensions (`setup-dimensions.md`), PR template (`setup-pr-template.md`), plan guardrails (`setup-guardrails.md`), execution guardrails (`setup-execution-guardrails.md`)
 - R10: Project scan phase runs before content sub-flows to collect signals (dependencies, framework, CI, DB, tests, etc.)
 - R11: Version section requires `mode` field (required by schema): `"file"` when version file detected, `"tag"` when not
 - R12: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R13: Content sub-flows (setup-dimensions, setup-pr-template, setup-guardrails) inherit the parent skill's permission mode. Sub-flows MUST NOT call ExitPlanMode, change permission settings, or exit any mode.
+- R14: Scan phase (R10) MUST use the Glob tool for all file/directory existence checks. Bash MUST NOT be used with glob patterns — zsh errors on unmatched globs. Bash is permitted only for `git`, `gh`, and `which` commands.
 
 ## Workflow Phases
 

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -16,6 +16,7 @@
 - A6: `--dry-run` — display pipeline plan without executing (default: false)
 - A7: `--resume` — resume pipeline from saved state file (default: false)
 - A8: `--workspace branch|worktree|prompt` — workspace isolation mode (default: from config or prompt)
+- A8a: In `--auto` mode, `workspace: "prompt"` is overridden to `"branch"` when the source is not `'cli'`. Explicit CLI `--workspace prompt` with `--auto` is preserved (intentional override).
 - A9: `--init-config` — run interactive config wizard, no pipeline execution (default: false)
 
 ## Core Requirements
@@ -24,7 +25,7 @@
 - R2: All sub-skills dispatched as Agents (never Skill tool) to maintain context isolation — each Agent loads its SKILL.md independently
 - R3: Pipeline plan is a binding contract: steps with `status: "will_run"` must execute; LLM cannot override
 - R4: Step statuses computed by `skill/ship.js`: `will_run`, `skipped`, `conditional`
-- R5: Skip set provenance tracked via `skipSource`: `cli`, `config`, `auto`, `condition`, `none`; fabrication guard warns on `default` source
+- R5: Skip set provenance tracked via `skipSource`: `cli`, `config`, `auto`, `condition`, `none`; fabrication guard blocks (error, exit code 1) on `default` source
 - R6: Review verdict conditional logic: CHANGES REQUESTED (critical or ≥3 high) → pause, invoke received-review; APPROVED WITH NOTES (high or ≥5 medium) → invoke received-review if high exists; APPROVED → continue
 - R7: `--auto` forwarding audit: only forwarded to commit-sdlc, received-review-sdlc, version-sdlc, pr-sdlc (not execute-plan-sdlc, not review-sdlc)
 - R8: Staging gap between execute and commit: `git add -A -- ':!.sdlc/'` required
@@ -63,7 +64,7 @@
 - G2: Not on default branch — warn if on main/master (do not block)
 - G3: Skip values valid — all `--skip` values are recognized step names
 - G4: At least one step will run — pipeline is not entirely skipped
-- G5: Flag coherence — `--bump` without version step produces warning
+- G5: Flag coherence — `--bump` without version step produces error (exit code 1, blocking)
 - G6: Pipeline contract — every `will_run` step was dispatched as Agent
 - G7: Staging gap filled — `git add -A -- ':!.sdlc/'` ran between execute and commit
 - G8: Rebase attempted — rebase ran after commits, before version (when applicable)

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.12",
+  "version": "0.17.13",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/config.js
+++ b/plugins/sdlc-utilities/scripts/lib/config.js
@@ -417,6 +417,30 @@ function migrateConfig(projectRoot) {
 }
 
 // ---------------------------------------------------------------------------
+// ensureSdlcGitignore
+// ---------------------------------------------------------------------------
+
+/**
+ * Create .sdlc/ directory and .sdlc/.gitignore with content `*\n`.
+ * Idempotent: if .gitignore already exists, returns 'existed'.
+ *
+ * @param {string} projectRoot
+ * @returns {'created'|'existed'}
+ */
+function ensureSdlcGitignore(projectRoot) {
+  const sdlcDir = path.join(projectRoot, '.sdlc');
+  fs.mkdirSync(sdlcDir, { recursive: true });
+
+  const gitignorePath = path.join(sdlcDir, '.gitignore');
+  if (fs.existsSync(gitignorePath)) {
+    return 'existed';
+  }
+
+  fs.writeFileSync(gitignorePath, '*\n', 'utf8');
+  return 'created';
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
@@ -428,6 +452,7 @@ module.exports = {
   writeLocalConfig,
   writeSection,
   migrateConfig,
+  ensureSdlcGitignore,
   // Preset normalization
   normalizePreset,
   PRESET_NAMES,

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -399,7 +399,7 @@ function runValidation(flags, flagSources, steps, context) {
   // Fabrication guard: skip values present but source is 'default' means the
   // LLM may have hallucinated --skip arguments that were never actually passed.
   if (flags.skip.length > 0 && flagSources.skip === 'default') {
-    warnings.push("Skip flags present but source is 'default' — verify --skip arguments were intentional.");
+    errors.push("Skip flags present but source is 'default' — likely fabricated. Remove --skip or pass explicitly via CLI.");
   }
 
   // At least one non-conditional step must run (conditional steps only
@@ -413,7 +413,7 @@ function runValidation(flags, flagSources, steps, context) {
   let coherentFlags = true;
   const versionStep = steps.find(s => s.name === 'version');
   if (flags.bump && versionStep && versionStep.status === 'skipped') {
-    warnings.push(`--bump "${flags.bump}" specified but version step is skipped.`);
+    errors.push(`--bump "${flags.bump}" specified but version step is skipped — resolve by removing --bump or removing "version" from skip set.`);
     coherentFlags = false;
   }
 
@@ -495,10 +495,10 @@ function main() {
   // Merge flags
   const { merged: flags, sources: flagSources } = mergeFlags(cli, fileConfig);
 
-  // Auto mode: override workspace default from 'prompt' to 'branch'
-  if (flags.auto && flags.workspace === 'prompt' && flagSources.workspace === 'default') {
+  // Auto mode: override workspace default/config from 'prompt' to 'branch'
+  if (flags.auto && flags.workspace === 'prompt' && flagSources.workspace !== 'cli') {
     flags.workspace = 'branch';
-    flagSources.workspace = 'default (auto)';
+    flagSources.workspace = `${flagSources.workspace} (auto)`;
   }
 
   // Check git state

--- a/plugins/sdlc-utilities/scripts/util/setup-init.js
+++ b/plugins/sdlc-utilities/scripts/util/setup-init.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * setup-init.js
+ * Deterministically creates the .sdlc/ directory structure and config files.
+ * The LLM runs the interactive walkthrough, then calls this script with
+ * the collected answers as flags.
+ *
+ * Usage:
+ *   node setup-init.js [options]
+ *
+ * Options:
+ *   --project-config '<json>'  JSON object for .claude/sdlc.json sections
+ *   --local-config '<json>'    JSON object for .sdlc/local.json sections
+ *   --output-file              Write JSON to temp file (path on stdout)
+ *
+ * Exit codes:
+ *   0 = success, JSON on stdout
+ *   1 = validation error, JSON with non-empty errors[] on stdout
+ *   2 = unexpected script crash, message on stderr
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const LIB = path.join(__dirname, '..', 'lib');
+
+const {
+  readProjectConfig,
+  readLocalConfig,
+  writeProjectConfig,
+  writeLocalConfig,
+  ensureSdlcGitignore,
+} = require(path.join(LIB, 'config'));
+const { writeOutput } = require(path.join(LIB, 'output'));
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let projectConfig = null;
+  let localConfig   = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--project-config' && args[i + 1]) {
+      projectConfig = args[++i];
+    } else if (a === '--local-config' && args[i + 1]) {
+      localConfig = args[++i];
+    }
+  }
+
+  return { projectConfig, localConfig };
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function validate(parsed) {
+  const errors = [];
+
+  if (parsed.projectConfig !== null) {
+    try {
+      JSON.parse(parsed.projectConfig);
+    } catch (e) {
+      errors.push(`--project-config is not valid JSON: ${e.message}`);
+    }
+  }
+
+  if (parsed.localConfig !== null) {
+    try {
+      JSON.parse(parsed.localConfig);
+    } catch (e) {
+      errors.push(`--local-config is not valid JSON: ${e.message}`);
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const projectRoot = process.cwd();
+  const cli = parseArgs(process.argv);
+
+  const errors   = [];
+  const warnings = [];
+
+  // Validate inputs
+  const validationErrors = validate(cli);
+  if (validationErrors.length > 0) {
+    errors.push(...validationErrors);
+    writeOutput({ errors, warnings }, 'setup-init', 1);
+    return;
+  }
+
+  // 1. Create .sdlc/ directory and .gitignore
+  const gitignoreAction = ensureSdlcGitignore(projectRoot);
+  if (gitignoreAction === 'existed') {
+    warnings.push('.sdlc/.gitignore already exists — skipped');
+  }
+
+  // 2. Write project config (.claude/sdlc.json) if sections provided
+  let projectConfigAction = 'skipped';
+  if (cli.projectConfig !== null) {
+    const config = JSON.parse(cli.projectConfig);
+    if (Object.keys(config).length > 0) {
+      const existing = readProjectConfig(projectRoot);
+      projectConfigAction = existing.config ? 'overwritten' : 'created';
+      writeProjectConfig(projectRoot, config);
+    }
+  }
+
+  // 3. Write local config (.sdlc/local.json) if sections provided
+  let localConfigAction = 'skipped';
+  if (cli.localConfig !== null) {
+    const config = JSON.parse(cli.localConfig);
+    if (Object.keys(config).length > 0) {
+      const existing = readLocalConfig(projectRoot);
+      localConfigAction = existing.config ? 'overwritten' : 'created';
+      writeLocalConfig(projectRoot, config);
+    }
+  }
+
+  const result = {
+    errors,
+    warnings,
+    created: {
+      directory: '.sdlc/',
+      gitignore:     { path: '.sdlc/.gitignore',  action: gitignoreAction },
+      projectConfig: { path: '.claude/sdlc.json',  action: projectConfigAction },
+      localConfig:   { path: '.sdlc/local.json',   action: localConfigAction },
+    },
+  };
+
+  writeOutput(result, 'setup-init', 0);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    process.stderr.write(`setup-init.js error: ${err.message}\n${err.stack}\n`);
+    process.exit(2);
+  }
+}
+
+module.exports = { parseArgs, validate };

--- a/plugins/sdlc-utilities/scripts/util/ship-init.js
+++ b/plugins/sdlc-utilities/scripts/util/ship-init.js
@@ -31,7 +31,7 @@ const fs   = require('fs');
 const path = require('path');
 const LIB = path.join(__dirname, '..', 'lib');
 
-const { readSection, writeSection, normalizePreset, PRESET_NAMES } = require(path.join(LIB, 'config'));
+const { readSection, writeSection, normalizePreset, PRESET_NAMES, ensureSdlcGitignore } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
 
 // ---------------------------------------------------------------------------
@@ -133,15 +133,10 @@ function main() {
   // Create .sdlc/ directory
   fs.mkdirSync(sdlcDir, { recursive: true });
 
-  // Write .sdlc/.gitignore — skip if already exists
-  const gitignorePath = path.join(sdlcDir, '.gitignore');
-  let gitignoreAction;
-  if (fs.existsSync(gitignorePath)) {
-    gitignoreAction = 'existed';
+  // Write .sdlc/.gitignore via shared helper
+  const gitignoreAction = ensureSdlcGitignore(projectRoot);
+  if (gitignoreAction === 'existed') {
     warnings.push('.sdlc/.gitignore already exists — skipped');
-  } else {
-    fs.writeFileSync(gitignorePath, '*\n!.gitignore\n', 'utf8');
-    gitignoreAction = 'created';
   }
 
   // Build config object (no $schema or version — handled by unified config system)

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -432,7 +432,13 @@ echo "INIT_OUTPUT_FILE=$INIT_OUTPUT_FILE"
 echo "EXIT_CODE=$EXIT_CODE"
 ```
 
-Parse the output JSON: display created files, check for errors. The `setup-init.js` script deterministically creates `.sdlc/` directory, `.sdlc/.gitignore`, and writes config files via `writeProjectConfig` and `writeLocalConfig` (read-merge-write, so existing sections are preserved).
+Parse the output JSON from `$INIT_OUTPUT_FILE`, then clean up the temp file:
+
+```bash
+rm -f "$INIT_OUTPUT_FILE"
+```
+
+Display created files, check for errors. The `setup-init.js` script deterministically creates `.sdlc/` directory, `.sdlc/.gitignore`, and writes config files via `writeProjectConfig` and `writeLocalConfig` (read-merge-write, so existing sections are preserved).
 
 ### Step 3b -- Validate Written Config
 

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -417,34 +417,22 @@ Store the assembled `pr` config for use in the "Writing config files" step.
 
 #### Writing config files
 
-After collecting all answers, write project config and local config in a single Bash call:
+After collecting all answers, write project config and local config via `util/setup-init.js`:
 
 ```bash
-SCRIPT_DIR=$(find ~/.claude/plugins -name "config.js" -path "*/sdlc*/lib/config.js" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
-[ -z "$SCRIPT_DIR" ] && [ -f "plugins/sdlc-utilities/scripts/lib/config.js" ] && SCRIPT_DIR="plugins/sdlc-utilities/scripts/lib"
-[ -z "$SCRIPT_DIR" ] && { echo "ERROR: Could not locate lib/config.js" >&2; exit 2; }
+INIT_SCRIPT=$(find ~/.claude/plugins -name "setup-init.js" -path "*/sdlc*/scripts/util/setup-init.js" 2>/dev/null | head -1)
+[ -z "$INIT_SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/util/setup-init.js" ] && INIT_SCRIPT="plugins/sdlc-utilities/scripts/util/setup-init.js"
+[ -z "$INIT_SCRIPT" ] && { echo "ERROR: Could not locate util/setup-init.js" >&2; exit 2; }
 
-node -e "
-const { writeProjectConfig, writeLocalConfig } = require('$SCRIPT_DIR/config.js');
-const projectRoot = process.cwd();
-
-// Only include sections that were configured (not skipped)
-const projectConfig = {};
-// ... add version, jira, commit, pr sections as collected ...
-
-if (Object.keys(projectConfig).length > 0) {
-  writeProjectConfig(projectRoot, projectConfig);
-  console.log('Wrote .claude/sdlc.json');
-}
-
-const localConfig = { review: { scope: 'committed' } }; // use actual collected value
-// ... add ship section to localConfig as collected ...
-writeLocalConfig(projectRoot, localConfig);
-console.log('Wrote .sdlc/local.json');
-"
+# Replace <PROJECT_CONFIG_JSON> and <LOCAL_CONFIG_JSON> with the actual config objects
+# assembled from Steps 3a–3f. Only include sections that were configured (not skipped).
+INIT_OUTPUT_FILE=$(node "$INIT_SCRIPT" --output-file --project-config '<PROJECT_CONFIG_JSON>' --local-config '<LOCAL_CONFIG_JSON>')
+EXIT_CODE=$?
+echo "INIT_OUTPUT_FILE=$INIT_OUTPUT_FILE"
+echo "EXIT_CODE=$EXIT_CODE"
 ```
 
-Replace the placeholder values with the actual collected answers. The `writeProjectConfig` and `writeLocalConfig` functions handle read-merge-write, so existing sections are preserved.
+Parse the output JSON: display created files, check for errors. The `setup-init.js` script deterministically creates `.sdlc/` directory, `.sdlc/.gitignore`, and writes config files via `writeProjectConfig` and `writeLocalConfig` (read-merge-write, so existing sections are preserved).
 
 ### Step 3b -- Validate Written Config
 
@@ -466,22 +454,26 @@ If validation fails (sections missing or file unreadable), warn the user and off
 
 #### Scan Phase
 
-Before presenting the content menu, collect all project signals needed by the sub-flows. Run the following in a single Bash block (or parallel where noted):
+Before presenting the content menu, collect all project signals needed by the sub-flows:
 
-- **Dependency manifests:** Read `package.json`, `requirements.txt`, `Pipfile`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle` if present.
-- **Framework config:** Check for `.eslintrc*`, `tsconfig.json`, `openapi.yaml`/`openapi.json`, `.prettierrc*`, `jest.config.*`, `vitest.config.*`.
-- **Directory structure:** List top-level dirs and check for `src/`, `lib/`, `controllers/`, `services/`, `middleware/`, `models/`, `routes/`, `api/`, `pkg/`, `cmd/`, `internal/`.
-- **CI/CD config:** Check for `.github/workflows/`, `Jenkinsfile`, `.circleci/`, `.gitlab-ci.yml`.
-- **Database presence:** Check for ORM config files (`prisma/`, `migrations/`, `alembic.ini`, `db/migrate/`, `sequelize`, `typeorm`, `sqlalchemy`).
-- **Test structure:** Check for `test/`, `tests/`, `spec/`, `__tests__/`, `cypress/`, `playwright.config.*`.
-- **Existing review dimensions:** List files in `.claude/review-dimensions/` (count and names).
-- **Existing guardrails:** Read `sdlc.json` → `plan.guardrails` array if present.
-- **GitHub hosting detection:** Check `git remote -v` for `github.com`, check if `gh` CLI is available, check for `.github/` directory.
-- **CLAUDE.md / AGENTS.md:** Read if present at project root or `.claude/`.
-- **GitHub PR template:** Check for `.github/PULL_REQUEST_TEMPLATE.md` or `.github/pull_request_template.md`.
-- **Recent PRs:** Run `gh pr list --limit 5 --json title,body` if `gh` CLI is available.
-- **Existing PR template:** Check for `.claude/pr-template.md`.
-- **JIRA evidence:** Check current branch name and recent commit subjects for ticket patterns (e.g., `[A-Z]{2,10}-\d+`).
+> **Shell safety:** Use the **Glob** tool for all file/directory existence checks.
+> Do NOT use Bash `ls` with glob patterns — zsh (macOS default) errors on unmatched globs.
+> Use Bash only for `git` commands, `gh` CLI, and `which`.
+
+- **Dependency manifests:** Use Glob for `package.json`, `requirements.txt`, `Pipfile`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`. Read each found file.
+- **Framework config:** Use Glob for `**/jest.config.*`, `**/vitest.config.*`, `**/.eslintrc*`, `**/tsconfig.json`, `**/openapi.yaml`, `**/openapi.json`, `**/.prettierrc*`.
+- **Directory structure:** Use Glob for `src/`, `lib/`, `controllers/`, `services/`, `middleware/`, `models/`, `routes/`, `api/`, `pkg/`, `cmd/`, `internal/` and patterns from `@scan-patterns.md`.
+- **CI/CD config:** Use Glob for `.github/workflows/*.yml`, `Jenkinsfile`, `.circleci/config.yml`, `.gitlab-ci.yml`.
+- **Database presence:** Use Glob for `prisma/`, `migrations/`, `alembic.ini`, `db/migrate/`, `**/sequelize*`, `**/typeorm*`, `**/sqlalchemy*`.
+- **Test structure:** Use Glob for `test/`, `tests/`, `spec/`, `__tests__/`, `cypress/`, `**/playwright.config.*`.
+- **Existing review dimensions:** Use Glob for `.claude/review-dimensions/*` (count and names).
+- **Existing guardrails:** Use Read on `.claude/sdlc.json` → `plan.guardrails` array if present.
+- **GitHub hosting detection:** Bash for `git remote -v` and `gh repo view` (safe). Use Glob for `.github/`.
+- **CLAUDE.md / AGENTS.md:** Use Read on `CLAUDE.md`, `AGENTS.md`, `.claude/CLAUDE.md` if present.
+- **PR template:** Use Glob for `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`.
+- **Recent PRs:** Bash for `gh pr list --limit 5 --json title,body` (safe).
+- **Existing PR template:** Use Glob for `.claude/pr-template.md`.
+- **JIRA evidence:** Bash for `git log --oneline -20` and `git rev-parse --abbrev-ref HEAD` (safe).
 
 Collect all signals into a "Scan Input" object to pass to sub-flows.
 

--- a/plugins/sdlc-utilities/skills/setup-sdlc/setup-dimensions.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/setup-dimensions.md
@@ -9,6 +9,11 @@ and validates with the validation script.
 > complete above", "see my previous response", or any similar deferral. If no files can be
 > written (simulation context), still emit the full proposed dimension YAML/Markdown inline.
 
+> **Permission context:** This sub-flow inherits the parent skill's permission mode.
+> Do NOT call ExitPlanMode, change permission settings, or exit any mode during this sub-flow.
+> Do NOT ask the user to approve file writes individually — the parent (setup-sdlc) manages mode transitions.
+> Write all dimension files in a single Bash block or rapid sequence to minimize permission prompts.
+
 Supporting references (dimension format spec, 5 example dimensions) are in
 `review-sdlc/REFERENCE.md` and `review-sdlc/EXAMPLES.md`. Locate them using Glob
 with `path: ~/.claude` and pattern `**/review-sdlc/REFERENCE.md`. If not found, retry

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -76,7 +76,7 @@ Parse the output JSON from `$PREPARE_OUTPUT_FILE`. If `errors` is non-empty, dis
 **Gitignore warning:** If `context.sdlcGitignored` is `false` in the output, print:
 ```
 ⚠ Warning: .sdlc/ is not gitignored. Run --init-config to fix, or manually create .sdlc/.gitignore:
-  printf '*\n!.gitignore\n' > .sdlc/.gitignore
+  printf '*\n' > .sdlc/.gitignore
 ```
 
 ### 1d. Parse flags

--- a/tests/promptfoo/datasets/setup-init-exec.yaml
+++ b/tests/promptfoo/datasets/setup-init-exec.yaml
@@ -38,7 +38,7 @@
     - type: icontains
       value: '"localConfig"'
     - type: not-icontains
-      value: '"skipped"'
+      value: '"action": "skipped"'
 
 - description: "setup-init: invalid JSON produces error and exit code 1"
   vars:

--- a/tests/promptfoo/datasets/setup-init-exec.yaml
+++ b/tests/promptfoo/datasets/setup-init-exec.yaml
@@ -1,0 +1,53 @@
+# Script execution tests for setup-init.js.
+# These tests run setup-init.js directly against fixture directories (no LLM).
+# Covers: deterministic .sdlc/ initialization (issue #134).
+
+- description: "setup-init: creates .sdlc/.gitignore with * content"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/util/setup-init.js"
+    script_args: "--project-config '{}' --local-config '{\"review\":{\"scope\":\"committed\"}}'"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: icontains
+      value: '"gitignore"'
+    - type: icontains
+      value: '"action": "created"'
+
+- description: "setup-init: idempotent re-run reports existed for gitignore"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/util/setup-init.js"
+    script_args: "--project-config '{}' --local-config '{\"review\":{\"scope\":\"committed\"}}'"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: '"existed"'
+    - type: icontains
+      value: ".sdlc/.gitignore already exists"
+
+- description: "setup-init: writes both project and local config"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/util/setup-init.js"
+    script_args: "--project-config '{\"version\":{\"mode\":\"tag\"}}' --local-config '{\"review\":{\"scope\":\"committed\"}}'"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: icontains
+      value: '"projectConfig"'
+    - type: icontains
+      value: '"localConfig"'
+    - type: not-icontains
+      value: '"skipped"'
+
+- description: "setup-init: invalid JSON produces error and exit code 1"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/util/setup-init.js"
+    script_args: "--project-config 'not-json'"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: icontains
+      value: "not valid JSON"
+    - type: javascript
+      value: "output.includes('\"errors\"') && !output.includes('\"errors\": []')"

--- a/tests/promptfoo/datasets/setup-sdlc-dimensions.yaml
+++ b/tests/promptfoo/datasets/setup-sdlc-dimensions.yaml
@@ -206,3 +206,22 @@
         skips or does not mention the GitHub Copilot instructions generation step
         (Step 8 in the skill). It does NOT create .github/instructions/ files. The
         dimension creation and validation proceed as normal despite --no-copilot.
+
+- description: "setup-sdlc --dimensions: does not exit plan mode or change permissions during file writes"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/project-with-tech-stack.md"
+    user_request: >
+      Run /setup-sdlc --dimensions on this project. Write the dimension files.
+      Show me the exact steps you would take to create the dimension files.
+  assert:
+    - type: not-icontains
+      value: "ExitPlanMode"
+    - type: not-regex
+      value: "(exit.*plan.*mode|change.*permission|switch.*mode)"
+    - type: llm-rubric
+      value: >
+        The response creates dimension files without calling ExitPlanMode, changing
+        permission settings, or exiting any mode. The dimension creation workflow
+        inherits the parent skill's permission mode and does not attempt to manage
+        permissions independently. File writes are batched or done in rapid sequence.

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -83,3 +83,45 @@
   assert:
     - type: icontains
       value: '"preset": "balanced"'
+
+# Auto-mode workspace override for config source (issue #133)
+
+- description: "ship-prepare: --auto with config workspace=prompt overrides to branch"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --auto"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-ship-config-workspace-prompt"
+  assert:
+    - type: icontains
+      value: '"workspace": "branch"'
+    - type: icontains
+      value: "config (auto)"
+
+# Fabrication guard blocking error (issue #129)
+
+- description: "ship-prepare: fabricated --skip flags produce error and exit code 1"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --skip version"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: "likely fabricated"
+    - type: javascript
+      value: "output.includes('\"errors\"') && !output.includes('\"errors\": []')"
+
+# Bump+skip contradiction blocking error (issue #146)
+
+- description: "ship-prepare: --bump with skipped version step produces error"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --bump minor --skip version"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: "version step is skipped"
+    - type: icontains
+      value: "resolve by removing"

--- a/tests/promptfoo/fixtures-fs/project-setup-empty/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-setup-empty/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git commit -q --allow-empty -m "init"

--- a/tests/promptfoo/fixtures-fs/project-ship-config-workspace-prompt/.sdlc/local.json
+++ b/tests/promptfoo/fixtures-fs/project-ship-config-workspace-prompt/.sdlc/local.json
@@ -1,0 +1,1 @@
+{ "ship": { "workspace": "prompt" } }

--- a/tests/promptfoo/fixtures-fs/project-ship-config-workspace-prompt/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-ship-config-workspace-prompt/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -24,3 +24,4 @@ tests:
   - file://datasets/pr-prepare-exec.yaml
   - file://datasets/ship-prepare-exec.yaml
   - file://datasets/guardrails-prepare-exec.yaml
+  - file://datasets/setup-init-exec.yaml


### PR DESCRIPTION
## Summary
Centralizes `.sdlc/` directory initialization into a new `setup-init.js` utility script and fixes six structural bugs across setup-sdlc and ship-sdlc skills, including promoting fabrication guards from warnings to blocking errors and rewriting the scan phase to use Glob instead of shell globs.

## Business Context
Several bugs in the setup and ship pipelines caused silent failures or allowed invalid states to propagate: fabricated `--skip` flags passed through as warnings instead of blocking, the scan phase broke on zsh due to unmatched glob patterns, and `.sdlc/` initialization was duplicated across multiple scripts with inconsistent behavior. These issues degraded reliability for plugin users on macOS (default zsh shell) and reduced trust in the ship pipeline's guardrails.

## Business Benefits
- Ship pipeline now blocks on fabricated flags and contradictory options, preventing invalid releases
- Setup workflow is reliable on macOS zsh (the most common developer environment for this plugin)
- Single initialization path eliminates inconsistencies when creating `.sdlc/` directory structure
- Sub-flow permission constraints prevent unexpected mode exits during setup, reducing user confusion

## Github Issue
Closes #129, #133, #134, #135, #136, #146

## Technical Design
- New `setup-init.js` utility script provides a single entry point for `.sdlc/` directory creation, `.gitignore` setup, and config file writing via CLI flags (`--project-config`, `--local-config`)
- Shared `ensureSdlcGitignore()` helper extracted into `lib/config.js` and consumed by both `setup-init.js` and `ship-init.js`, replacing duplicated inline logic
- ship.js validation promotes `fabrication guard` (skip source is `'default'`) and `bump+skip contradiction` from `warnings[]` to `errors[]`, making them exit code 1 blockers
- Auto-mode workspace override condition changed from `flagSources.workspace === 'default'` to `!== 'cli'`, so config-sourced `"prompt"` is also overridden (only explicit CLI `--workspace prompt` is preserved)
- Scan phase in setup-sdlc SKILL.md rewritten to mandate Glob tool for all file/directory checks; Bash restricted to `git`, `gh`, and `which`
- Permission constraint (R13) added to `setup-dimensions.md` preventing sub-flows from calling ExitPlanMode

## Technical Impact
- **ship.js API change:** Two validation conditions that previously produced warnings now produce errors (exit code 1). Callers that tolerated these warnings will now see pipeline failures — this is intentional (the warnings indicated invalid state).
- **setup-init.js:** New script added to the plugin. No breaking change — additive only.
- **ensureSdlcGitignore:** `.sdlc/.gitignore` content simplified from `*\n!.gitignore\n` to `*\n` (the `!.gitignore` exception was unnecessary since `.gitignore` is inside the ignored directory).

## Changes Overview
- New `setup-init.js` utility script for deterministic `.sdlc/` initialization with JSON-based config input
- Shared `ensureSdlcGitignore` helper in config library, replacing duplicated gitignore creation in `ship-init.js`
- Fabrication guard in ship pipeline promoted from warning to blocking error
- Bump-without-version-step contradiction promoted from warning to blocking error
- Auto-mode workspace override now fires for config-sourced values, not just defaults
- Setup-sdlc scan phase rewritten to use Glob tool instead of Bash glob patterns for zsh compatibility
- Permission constraint added to setup-dimensions sub-flow preventing mode/permission exits
- Specs updated for setup-sdlc (R6, R13, R14) and ship-sdlc (R5, A8a, G5)
- New promptfoo test datasets for setup-init execution tests and expanded ship-prepare tests
- New test fixture for config-sourced workspace prompt scenario

## Testing
- Four new promptfoo exec tests for `setup-init.js`: gitignore creation, idempotent re-run, dual config write, and invalid JSON error handling
- Three new promptfoo exec tests for `ship.js`: auto-mode config workspace override, fabricated skip flag blocking, bump+skip contradiction blocking
- One new behavioral test for setup-sdlc dimensions: verifies sub-flow does not exit plan mode or change permissions
- New filesystem fixtures added for empty project setup and config-workspace-prompt scenarios