### PR TITLE
feat(#148): hooks - add pipeline safety validation scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.14] - 2026-04-06
+
+### Added
+- Pipeline safety validation hooks: stop-state-save, post-failure-error-report, pre-tool-git-guard, and validate-plan-format (#148)
+
 ## [0.17.13] - 2026-04-04
 
 ### Fixed

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/hooks.json
+++ b/plugins/sdlc-utilities/hooks/hooks.json
@@ -35,6 +35,41 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-state-save.js\"",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/post-failure-error-report.js\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-git-guard.js\"",
+            "timeout": 1000
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/sdlc-utilities/hooks/post-failure-error-report.js
+++ b/plugins/sdlc-utilities/hooks/post-failure-error-report.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * post-failure-error-report.js
+ * PostToolUseFailure hook — detects prepare script crashes (exit code 2)
+ * and surfaces a reminder to invoke error-report-sdlc.
+ *
+ * Fires on Bash tool failures. Reads JSON from stdin to extract the
+ * command and exit code. Only triggers on skill script crashes.
+ *
+ * Exit codes:
+ *   0 = no crash detected or non-skill command (safe to continue)
+ *   2 = crash detected, feedback surfaced to Claude
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+
+// ---------------------------------------------------------------------------
+// Read stdin
+// ---------------------------------------------------------------------------
+
+let input = {};
+try {
+  const raw = fs.readFileSync('/dev/stdin', 'utf8');
+  if (raw.trim()) {
+    input = JSON.parse(raw);
+  }
+} catch {
+  // Unparseable or missing stdin — exit silently
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Extract command and check for skill script
+// ---------------------------------------------------------------------------
+
+const toolInput = input.tool_input || {};
+const command   = toolInput.command || '';
+
+if (!command) {
+  process.exit(0);
+}
+
+// Match skill script pattern: scripts/skill/<name>.js
+const SKILL_SCRIPT_RE = /scripts\/skill\/([a-z-]+)\.js/;
+const skillMatch = command.match(SKILL_SCRIPT_RE);
+
+if (!skillMatch) {
+  // Not a skill script — exit silently
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Check for exit code 2 (crash)
+// ---------------------------------------------------------------------------
+
+const exitCode = input.exit_code;
+
+if (exitCode !== 2) {
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Extract skill name and build reminder
+// ---------------------------------------------------------------------------
+
+const scriptName = skillMatch[1]; // e.g., "commit"
+const skillName  = scriptName + '-sdlc'; // e.g., "commit-sdlc"
+
+// Extract error excerpt from stderr or stdout
+const stderr = (input.stderr || input.stdout || '').trim();
+const errorExcerpt = stderr.length > 200 ? stderr.slice(0, 200) + '...' : stderr;
+
+const message = [
+  'Prepare script crashed (exit 2). Invoke error-report-sdlc:',
+  `- skill: ${skillName}`,
+  `- step: Step 0 — skill/${scriptName}.js execution`,
+  `- error: ${errorExcerpt || '(no error output captured)'}`,
+].join('\n');
+
+process.stderr.write(message + '\n');
+process.exit(2);

--- a/plugins/sdlc-utilities/hooks/post-tool-validate.js
+++ b/plugins/sdlc-utilities/hooks/post-tool-validate.js
@@ -10,6 +10,7 @@
  * Patterns:
  *   .claude/review-dimensions/*.ya?ml → validate-dimensions.js
  *   .claude/pr-template.md            → validate-pr-template.js
+ *   plans/*.md                        → validate-plan-format.js
  *
  * Exit codes:
  *   0 = clean or no match (always safe to continue)
@@ -55,13 +56,15 @@ if (!filePath) {
 // Pattern matching
 // ---------------------------------------------------------------------------
 
-const DIMENSION_RE  = /[/\\]\.claude[/\\]review-dimensions[/\\][^/\\]+\.ya?ml$/;
+const DIMENSION_RE   = /[/\\]\.claude[/\\]review-dimensions[/\\][^/\\]+\.ya?ml$/;
 const PR_TEMPLATE_RE = /[/\\]\.claude[/\\]pr-template\.md$/;
+const PLAN_RE        = /[/\\]plans[/\\][^/\\]+\.md$/;
 
 const isDimension  = DIMENSION_RE.test(filePath);
 const isPrTemplate = PR_TEMPLATE_RE.test(filePath);
+const isPlan       = PLAN_RE.test(filePath);
 
-if (!isDimension && !isPrTemplate) {
+if (!isDimension && !isPrTemplate && !isPlan) {
   process.exit(0);
 }
 
@@ -71,9 +74,14 @@ if (!isDimension && !isPrTemplate) {
 
 const scriptsDir = path.resolve(__dirname, '..', 'scripts');
 
-const validatorScript = isDimension
-  ? path.join(scriptsDir, 'validate-dimensions.js')
-  : path.join(scriptsDir, 'validate-pr-template.js');
+let validatorScript;
+if (isDimension) {
+  validatorScript = path.join(scriptsDir, 'ci', 'validate-dimensions.js');
+} else if (isPrTemplate) {
+  validatorScript = path.join(scriptsDir, 'ci', 'validate-pr-template.js');
+} else {
+  validatorScript = path.join(scriptsDir, 'ci', 'validate-plan-format.js');
+}
 
 // Use the project root from cwd (where Claude runs the hook)
 const projectRoot = process.cwd();
@@ -83,7 +91,8 @@ const projectRoot = process.cwd();
 // ---------------------------------------------------------------------------
 
 try {
-  const cmd = `node "${validatorScript}" --project-root "${projectRoot}" --markdown`;
+  const fileArg = isPlan ? ` --file "${filePath}"` : '';
+  const cmd = `node "${validatorScript}" --project-root "${projectRoot}" --markdown${fileArg}`;
   execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
   // Exit 0 from validator — all good
   process.exit(0);

--- a/plugins/sdlc-utilities/hooks/pre-tool-git-guard.js
+++ b/plugins/sdlc-utilities/hooks/pre-tool-git-guard.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * pre-tool-git-guard.js
+ * PreToolUse hook — intercepts dangerous git commands before Bash execution.
+ *
+ * Fires on every Bash tool invocation. Fast-bails if the command does not
+ * contain "git " to minimize overhead on the hot path.
+ *
+ * BLOCK (exit 2 + stderr):
+ *   git push --force / -f (but NOT --force-with-lease)
+ *   git reset --hard
+ *   git checkout . / git checkout -- .
+ *   git clean -f
+ *
+ * WARN but ALLOW (exit 0 + stderr):
+ *   git push targeting main/master
+ *
+ * Exit codes:
+ *   0 = allowed (silently or with warning)
+ *   2 = blocked (feedback surfaced to Claude)
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+
+// ---------------------------------------------------------------------------
+// Read stdin
+// ---------------------------------------------------------------------------
+
+let input = {};
+try {
+  const raw = fs.readFileSync('/dev/stdin', 'utf8');
+  if (raw.trim()) {
+    input = JSON.parse(raw);
+  }
+} catch {
+  // Unparseable or missing stdin — exit silently
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Extract command
+// ---------------------------------------------------------------------------
+
+const toolInput = input.tool_input || {};
+const command   = toolInput.command || '';
+
+// Fast bail — not a git command
+if (!command.includes('git ')) {
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Dangerous command patterns
+// ---------------------------------------------------------------------------
+
+const BLOCKED = [
+  {
+    // git push --force or git push -f (but NOT --force-with-lease)
+    test: (cmd) => {
+      // Match "git push" with --force or -f flag, excluding --force-with-lease
+      const pushForceRe = /\bgit\s+push\b[^;&|]*(?:--force(?!-with-lease)|-f\b)/;
+      return pushForceRe.test(cmd);
+    },
+    message: 'Blocked: git push --force can destroy remote history. Use --force-with-lease for a safer alternative.',
+  },
+  {
+    test: (cmd) => /\bgit\s+reset\s+--hard\b/.test(cmd),
+    message: 'Blocked: git reset --hard discards all uncommitted changes. Use git stash or git reset --soft instead.',
+  },
+  {
+    test: (cmd) => /\bgit\s+checkout\s+(--\s+)?\./.test(cmd),
+    message: 'Blocked: git checkout . discards all uncommitted changes. Use git stash to preserve changes.',
+  },
+  {
+    test: (cmd) => /\bgit\s+clean\s+[^;&|]*-f\b/.test(cmd),
+    message: 'Blocked: git clean -f permanently deletes untracked files. Use git clean -n for a dry run first.',
+  },
+];
+
+const WARNINGS = [
+  {
+    // git push targeting main or master
+    test: (cmd) => {
+      // Match "git push" with "main" or "master" as a target, but skip if --force is present (already blocked)
+      return /\bgit\s+push\b[^;&|]*\b(main|master)\b/.test(cmd);
+    },
+    message: 'Warning: pushing directly to main/master. Consider using a feature branch and pull request.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scan command (handles multi-command strings like "git add . && git push --force")
+// ---------------------------------------------------------------------------
+
+for (const rule of BLOCKED) {
+  if (rule.test(command)) {
+    process.stderr.write(rule.message + '\n');
+    process.exit(2);
+  }
+}
+
+for (const rule of WARNINGS) {
+  if (rule.test(command)) {
+    process.stderr.write(rule.message + '\n');
+  }
+}
+
+process.exit(0);

--- a/plugins/sdlc-utilities/hooks/stop-state-save.js
+++ b/plugins/sdlc-utilities/hooks/stop-state-save.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * stop-state-save.js
+ * Stop hook — saves a compact recovery summary of active pipeline state
+ * when Claude finishes responding. Safety net for session crashes between
+ * compactions.
+ *
+ * Writes to: <mainWorktree>/.sdlc/execution/.compact-recovery.json
+ *
+ * Does NOT read stdin (Stop provides no tool data).
+ *
+ * Exit codes:
+ *   0 = always (graceful degradation on errors)
+ */
+
+'use strict';
+
+const fs   = require('node:fs');
+const path = require('node:path');
+
+try {
+  const { findStateFile, readState, slugifyBranch, resolveMainWorktree } = require('../scripts/lib/state');
+  const { exec } = require('../scripts/lib/git');
+
+  const branch = exec('git branch --show-current');
+  if (!branch) process.exit(0);
+
+  const branchSlug = slugifyBranch(branch);
+
+  // Fast bail — no active pipeline means no work to do
+  const shipFound    = findStateFile('ship', branchSlug);
+  const executeFound = findStateFile('execute', branchSlug);
+  if (!shipFound && !executeFound) process.exit(0);
+
+  let recovery = null;
+
+  // Ship state takes priority
+  if (shipFound) {
+    const shipState = readState('ship', branchSlug);
+    if (shipState && shipState.data) {
+      const data = shipState.data;
+      let currentStep = null;
+      let reviewVerdict = null;
+      let deferredFindings = 0;
+
+      if (Array.isArray(data.steps)) {
+        const inProgress = data.steps.find(s => s.status === 'in_progress');
+        const lastCompleted = [...data.steps].reverse().find(s => s.status === 'completed');
+        const step = inProgress || lastCompleted;
+        if (step) {
+          currentStep = step.name || step.id || null;
+        }
+
+        for (const s of data.steps) {
+          if (s.output && s.output.deferredFindings) {
+            deferredFindings = s.output.deferredFindings;
+          }
+          if (s.output && s.output.verdict) {
+            reviewVerdict = s.output.verdict;
+          }
+        }
+      }
+
+      recovery = {
+        savedAt: new Date().toISOString(),
+        pipeline: 'ship-sdlc',
+        branch: data.branch || branch,
+        currentStep,
+        reviewVerdict,
+        deferredFindings,
+        flags: {
+          preset: (data.flags && data.flags.preset) || null,
+          auto: (data.flags && data.flags.auto) || false,
+          skip: (data.flags && data.flags.skip) || [],
+        },
+      };
+    }
+  }
+
+  // Fall back to execute state
+  if (!recovery && executeFound) {
+    const executeState = readState('execute', branchSlug);
+    if (executeState && executeState.data) {
+      const data = executeState.data;
+      let completedWaves = 0;
+      let totalWaves = 0;
+
+      if (Array.isArray(data.waves)) {
+        totalWaves = data.waves.length;
+        completedWaves = data.waves.filter(w => w.status === 'completed').length;
+      }
+
+      recovery = {
+        savedAt: new Date().toISOString(),
+        pipeline: 'execute-plan-sdlc',
+        branch: data.branch || branch,
+        completedWaves,
+        totalWaves,
+        preset: (data.preset) || null,
+      };
+    }
+  }
+
+  // No active pipeline — nothing to save
+  if (!recovery) process.exit(0);
+
+  // Write recovery file
+  const mainWorktree = resolveMainWorktree();
+  const recoveryDir = path.join(mainWorktree, '.sdlc', 'execution');
+  fs.mkdirSync(recoveryDir, { recursive: true });
+
+  const recoveryPath = path.join(recoveryDir, '.compact-recovery.json');
+  fs.writeFileSync(recoveryPath, JSON.stringify(recovery, null, 2), 'utf8');
+} catch {
+  // Graceful degradation — exit cleanly on any error
+}
+
+process.exit(0);

--- a/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
+++ b/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * validate-plan-format.js
+ * Validates plan files against the canonical plan format reference.
+ *
+ * Usage:
+ *   node validate-plan-format.js [options]
+ *
+ * Options:
+ *   --project-root <path>   Project root (default: cwd)
+ *   --file <path>           Plan file to validate (required)
+ *   --json                  JSON output to stdout (default)
+ *   --markdown              Formatted markdown output to stdout
+ *
+ * Exit codes: 0 = all pass, 1 = issues found, 2 = script error
+ *
+ * Checks:
+ *   PF1 — Header fields (Goal, Architecture, Source, Verification)
+ *   PF2 — Task numbering (contiguous from 0 or 1)
+ *   PF3 — Required metadata (Complexity, Risk, Depends on, Verify)
+ *   PF4 — Dependency validity (valid refs, no cycles)
+ *   PF5 — Task body (Description, Acceptance criteria)
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const fs   = require('node:fs');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let projectRoot  = process.cwd();
+  let filePath     = null;
+  let outputFormat = 'json';
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--project-root' && args[i + 1]) {
+      projectRoot = path.resolve(args[++i]);
+    } else if (a === '--file' && args[i + 1]) {
+      filePath = path.resolve(args[++i]);
+    } else if (a === '--json') {
+      outputFormat = 'json';
+    } else if (a === '--markdown') {
+      outputFormat = 'markdown';
+    }
+  }
+
+  return { projectRoot, filePath, outputFormat };
+}
+
+// ---------------------------------------------------------------------------
+// Plan parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract text after a bold field marker like **Goal:** from the content.
+ * Returns the trimmed value or null if not found.
+ */
+function extractField(content, fieldName) {
+  const re = new RegExp(`\\*\\*${fieldName}:\\*\\*\\s*(.+?)(?:\\n|$)`);
+  const match = content.match(re);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Split plan content into task blocks.
+ * Returns array of { number, title, body } objects.
+ */
+function extractTasks(content) {
+  const tasks = [];
+  const taskRe = /^### Task (\d+):\s*(.+)$/gm;
+  let match;
+
+  const matches = [];
+  while ((match = taskRe.exec(content)) !== null) {
+    matches.push({ number: parseInt(match[1], 10), title: match[2].trim(), index: match.index });
+  }
+
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].index;
+    const end   = i + 1 < matches.length ? matches[i + 1].index : content.length;
+    const body  = content.slice(start, end);
+    tasks.push({ number: matches[i].number, title: matches[i].title, body });
+  }
+
+  return tasks;
+}
+
+// ---------------------------------------------------------------------------
+// Validation checks
+// ---------------------------------------------------------------------------
+
+function checkPF1(content) {
+  const fields = ['Goal', 'Architecture', 'Source', 'Verification'];
+  const missing = [];
+
+  for (const field of fields) {
+    const value = extractField(content, field);
+    if (!value) {
+      missing.push(field);
+    }
+  }
+
+  if (missing.length > 0) {
+    return { id: 'PF1', status: 'fail', message: `Missing or empty header field(s): ${missing.join(', ')}` };
+  }
+  return { id: 'PF1', status: 'pass', message: 'All header fields present' };
+}
+
+function checkPF2(tasks) {
+  if (tasks.length === 0) {
+    return { id: 'PF2', status: 'fail', message: 'No tasks found (expected ### Task N: format)' };
+  }
+
+  const numbers = tasks.map(t => t.number).sort((a, b) => a - b);
+  const start   = numbers[0];
+
+  // Must start at 0 or 1
+  if (start !== 0 && start !== 1) {
+    return { id: 'PF2', status: 'fail', message: `Task numbering must start at 0 or 1, found: ${start}` };
+  }
+
+  // Check contiguous
+  const gaps = [];
+  for (let i = 1; i < numbers.length; i++) {
+    if (numbers[i] !== numbers[i - 1] + 1) {
+      gaps.push(`gap between Task ${numbers[i - 1]} and Task ${numbers[i]}`);
+    }
+  }
+
+  // Check duplicates
+  const dupes = [];
+  for (let i = 1; i < numbers.length; i++) {
+    if (numbers[i] === numbers[i - 1]) {
+      dupes.push(numbers[i]);
+    }
+  }
+
+  const issues = [];
+  if (gaps.length > 0) issues.push(`non-contiguous numbering: ${gaps.join(', ')}`);
+  if (dupes.length > 0) issues.push(`duplicate task number(s): ${dupes.join(', ')}`);
+
+  if (issues.length > 0) {
+    return { id: 'PF2', status: 'fail', message: `Task numbering issues: ${issues.join('; ')}` };
+  }
+
+  return { id: 'PF2', status: 'pass', message: `${tasks.length} task(s) numbered contiguously from ${start}` };
+}
+
+function checkPF3(tasks) {
+  const VALID_COMPLEXITY = ['Trivial', 'Standard', 'Complex'];
+  const VALID_RISK       = ['Low', 'Medium', 'High'];
+  const VALID_VERIFY     = ['tests', 'build', 'lint', 'manual'];
+
+  const issues = [];
+
+  for (const task of tasks) {
+    const prefix = `Task ${task.number}`;
+
+    // Complexity
+    const complexity = extractField(task.body, 'Complexity');
+    if (!complexity) {
+      issues.push(`${prefix}: missing **Complexity:**`);
+    } else if (!VALID_COMPLEXITY.includes(complexity)) {
+      issues.push(`${prefix}: invalid Complexity "${complexity}" (expected: ${VALID_COMPLEXITY.join('|')})`);
+    }
+
+    // Risk
+    const risk = extractField(task.body, 'Risk');
+    if (!risk) {
+      issues.push(`${prefix}: missing **Risk:**`);
+    } else if (!VALID_RISK.includes(risk)) {
+      issues.push(`${prefix}: invalid Risk "${risk}" (expected: ${VALID_RISK.join('|')})`);
+    }
+
+    // Depends on
+    const dependsOn = extractField(task.body, 'Depends on');
+    if (!dependsOn) {
+      issues.push(`${prefix}: missing **Depends on:**`);
+    }
+
+    // Verify
+    const verify = extractField(task.body, 'Verify');
+    if (!verify) {
+      issues.push(`${prefix}: missing **Verify:**`);
+    } else {
+      const values = verify.split(/,\s*/).map(v => v.trim());
+      const invalid = values.filter(v => !VALID_VERIFY.includes(v));
+      if (invalid.length > 0) {
+        issues.push(`${prefix}: invalid Verify value(s): ${invalid.join(', ')} (expected: ${VALID_VERIFY.join('|')})`);
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    return { id: 'PF3', status: 'fail', message: issues.join('; ') };
+  }
+  return { id: 'PF3', status: 'pass', message: 'All tasks have valid metadata' };
+}
+
+function checkPF4(tasks) {
+  const taskNumbers = new Set(tasks.map(t => t.number));
+  const issues      = [];
+  const depGraph    = new Map(); // number -> [dependency numbers]
+
+  for (const task of tasks) {
+    const dependsOn = extractField(task.body, 'Depends on');
+    if (!dependsOn || dependsOn.toLowerCase() === 'none') {
+      depGraph.set(task.number, []);
+      continue;
+    }
+
+    const refs = [];
+    const refRe = /Task\s+(\d+)/gi;
+    let match;
+    while ((match = refRe.exec(dependsOn)) !== null) {
+      const refNum = parseInt(match[1], 10);
+      refs.push(refNum);
+      if (!taskNumbers.has(refNum)) {
+        issues.push(`Task ${task.number}: depends on nonexistent Task ${refNum}`);
+      }
+    }
+    depGraph.set(task.number, refs);
+  }
+
+  // Cycle detection using DFS
+  const visited  = new Set();
+  const inStack  = new Set();
+
+  function hasCycle(node, path) {
+    if (inStack.has(node)) {
+      const cycleStart = path.indexOf(node);
+      const cycle = path.slice(cycleStart).concat(node);
+      issues.push(`Circular dependency: ${cycle.map(n => 'Task ' + n).join(' -> ')}`);
+      return true;
+    }
+    if (visited.has(node)) return false;
+
+    visited.add(node);
+    inStack.add(node);
+
+    const deps = depGraph.get(node) || [];
+    for (const dep of deps) {
+      if (hasCycle(dep, [...path, node])) return true;
+    }
+
+    inStack.delete(node);
+    return false;
+  }
+
+  for (const num of taskNumbers) {
+    if (!visited.has(num)) {
+      hasCycle(num, []);
+    }
+  }
+
+  if (issues.length > 0) {
+    return { id: 'PF4', status: 'fail', message: issues.join('; ') };
+  }
+  return { id: 'PF4', status: 'pass', message: 'All dependencies valid, no cycles' };
+}
+
+function checkPF5(tasks) {
+  const issues = [];
+
+  for (const task of tasks) {
+    const prefix = `Task ${task.number}`;
+
+    // Check Description
+    const descMatch = task.body.match(/\*\*Description:\*\*\s*\n([\s\S]*?)(?=\n\*\*|$)/);
+    if (!descMatch || !descMatch[1].trim()) {
+      issues.push(`${prefix}: missing or empty **Description:**`);
+    }
+
+    // Check Acceptance criteria with at least one checkbox
+    const acMatch = task.body.match(/\*\*Acceptance criteria:\*\*\s*\n([\s\S]*?)(?=\n### |\n---|\n## |$)/);
+    if (!acMatch) {
+      issues.push(`${prefix}: missing **Acceptance criteria:**`);
+    } else {
+      const checkboxCount = (acMatch[1].match(/- \[ \]/g) || []).length;
+      if (checkboxCount === 0) {
+        issues.push(`${prefix}: **Acceptance criteria:** has no checkbox items (expected at least one "- [ ]")`);
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    return { id: 'PF5', status: 'fail', message: issues.join('; ') };
+  }
+  return { id: 'PF5', status: 'pass', message: 'All tasks have Description and Acceptance criteria' };
+}
+
+// ---------------------------------------------------------------------------
+// Output formatters
+// ---------------------------------------------------------------------------
+
+function formatJson(report) {
+  return JSON.stringify(report, null, 2);
+}
+
+function formatMarkdown(report) {
+  const lines = [];
+  lines.push('# Plan Format Validation Report');
+  lines.push('');
+  lines.push(`**Overall:** ${report.passed ? 'PASS' : 'FAIL'} | ${report.summary.passed}/${report.summary.total} checks passed`);
+  lines.push('');
+
+  lines.push('| Check | Status | Message |');
+  lines.push('|-------|--------|---------|');
+  for (const check of report.checks) {
+    const icon = check.status === 'pass' ? 'PASS' : 'FAIL';
+    lines.push(`| ${check.id} | ${icon} | ${check.message} |`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+try {
+  const { projectRoot, filePath, outputFormat } = parseArgs(process.argv);
+
+  if (!filePath) {
+    process.stderr.write('validate-plan-format.js error: --file <path> is required\n');
+    process.exit(2);
+  }
+
+  if (!fs.existsSync(filePath)) {
+    process.stderr.write(`validate-plan-format.js error: file not found: ${filePath}\n`);
+    process.exit(2);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  const tasks   = extractTasks(content);
+
+  const checks = [
+    checkPF1(content),
+    checkPF2(tasks),
+    checkPF3(tasks),
+    checkPF4(tasks),
+    checkPF5(tasks),
+  ];
+
+  const passed = checks.every(c => c.status === 'pass');
+  const report = {
+    passed,
+    checks,
+    summary: {
+      total:  checks.length,
+      passed: checks.filter(c => c.status === 'pass').length,
+      failed: checks.filter(c => c.status === 'fail').length,
+    },
+  };
+
+  if (outputFormat === 'markdown') {
+    process.stdout.write(formatMarkdown(report) + '\n');
+  } else {
+    process.stdout.write(formatJson(report) + '\n');
+  }
+
+  process.exit(passed ? 0 : 1);
+} catch (err) {
+  process.stderr.write(`validate-plan-format.js error: ${err.message}\n`);
+  process.exit(2);
+}

--- a/tests/promptfoo/datasets/hook-error-report-exec.yaml
+++ b/tests/promptfoo/datasets/hook-error-report-exec.yaml
@@ -1,0 +1,75 @@
+# Script execution tests for post-failure-error-report.js.
+# These tests pipe JSON via stdin using the hook-runner provider (no LLM, no fixtures).
+# They validate that the error report hook detects skill script crashes.
+
+- description: "error report: non-skill Bash failure exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: '{"tool_input":{"command":"npm test"},"exit_code":1,"stderr":"test failed"}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "error-report-sdlc"
+
+- description: "error report: skill script crash (exit 2) produces reminder"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: '{"tool_input":{"command":"node scripts/skill/commit.js --project-root /tmp/test"},"exit_code":2,"stderr":"TypeError: Cannot read properties of undefined"}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "error-report-sdlc"
+    - type: icontains
+      value: "commit-sdlc"
+    - type: icontains
+      value: "skill/commit.js"
+
+- description: "error report: skill script non-crash (exit 0) exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: '{"tool_input":{"command":"node scripts/skill/review.js --project-root /tmp"},"exit_code":0}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "error-report-sdlc"
+
+- description: "error report: invalid stdin exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: "garbage data {{"
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "error-report-sdlc"
+
+- description: "error report: skill script exit 1 (non-crash) exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: '{"tool_input":{"command":"node scripts/skill/pr.js --auto"},"exit_code":1,"stderr":"validation failed"}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "error-report-sdlc"
+
+- description: "error report: extracts correct skill name from path"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/post-failure-error-report.js"
+    script_stdin: '{"tool_input":{"command":"node /long/path/to/scripts/skill/ship-prepare.js --flag"},"exit_code":2,"stderr":"ENOENT"}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "ship-prepare-sdlc"
+    - type: icontains
+      value: "skill/ship-prepare.js"

--- a/tests/promptfoo/datasets/hook-git-guard-exec.yaml
+++ b/tests/promptfoo/datasets/hook-git-guard-exec.yaml
@@ -1,0 +1,143 @@
+# Script execution tests for pre-tool-git-guard.js.
+# These tests pipe JSON via stdin using the hook-runner provider (no LLM, no fixtures).
+# They validate that the git guard blocks dangerous commands and allows safe ones.
+
+- description: "git guard: non-git command exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"npm install express"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: icontains
+      value: '"stderr": ""'
+
+- description: "git guard: git status exits 0 silently"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git status"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: icontains
+      value: '"stderr": ""'
+
+- description: "git guard: blocks git push --force"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git push --force origin main"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+    - type: icontains
+      value: "--force-with-lease"
+
+- description: "git guard: blocks git push -f"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git push -f origin feat/branch"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+
+- description: "git guard: allows git push --force-with-lease"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git push --force-with-lease origin feat/branch"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "Blocked"
+
+- description: "git guard: blocks git reset --hard"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git reset --hard HEAD~1"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+    - type: icontains
+      value: "git stash"
+
+- description: "git guard: blocks git checkout ."
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git checkout ."}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+
+- description: "git guard: blocks git checkout -- ."
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git checkout -- ."}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+
+- description: "git guard: blocks git clean -f"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git clean -fd"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"
+    - type: icontains
+      value: "dry run"
+
+- description: "git guard: warns on git push origin main"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git push origin main"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: icontains
+      value: "Warning"
+    - type: icontains
+      value: "main/master"
+
+- description: "git guard: empty/invalid stdin exits 0"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: "not valid json"
+  assert:
+    - type: icontains
+      value: '"exitCode": 0'
+    - type: not-icontains
+      value: "Blocked"
+
+- description: "git guard: multi-command with force push blocked"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-git-guard.js"
+    script_stdin: '{"tool_input":{"command":"git add . && git push --force origin main"}}'
+  assert:
+    - type: icontains
+      value: '"exitCode": 2'
+    - type: icontains
+      value: "Blocked"

--- a/tests/promptfoo/datasets/plan-format-exec.yaml
+++ b/tests/promptfoo/datasets/plan-format-exec.yaml
@@ -1,0 +1,88 @@
+# Script execution tests for validate-plan-format.js.
+# These tests run validate-plan-format.js directly against fixture plan files (no LLM).
+# They validate that plan format validation produces correct output for PF1-PF5 checks.
+#
+# Fixture appropriateness:
+#   project-valid-plan    -- CORRECT: valid 3-task plan should pass all checks
+#   project-invalid-plan  -- CORRECT: plan with multiple deliberate errors (PF1-PF5)
+
+- description: "plan-format: valid plan passes all checks (JSON)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/test-plan.md --json"
+    project_root: "file://fixtures-fs/project-valid-plan"
+  assert:
+    - type: icontains
+      value: '"passed": true'
+    - type: regex
+      value: '"failed":\s*0'
+    - type: icontains
+      value: '"status": "pass"'
+
+- description: "plan-format: valid plan passes all checks (markdown)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/test-plan.md --markdown"
+    project_root: "file://fixtures-fs/project-valid-plan"
+  assert:
+    - type: icontains
+      value: "Plan Format Validation Report"
+    - type: icontains
+      value: "PASS"
+
+- description: "plan-format: missing Verification header triggers PF1 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/bad-plan.md --json"
+    project_root: "file://fixtures-fs/project-invalid-plan"
+  assert:
+    - type: icontains
+      value: '"passed": false'
+    - type: icontains
+      value: "PF1"
+    - type: icontains
+      value: "Verification"
+
+- description: "plan-format: non-contiguous numbering triggers PF2 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/bad-plan.md --json"
+    project_root: "file://fixtures-fs/project-invalid-plan"
+  assert:
+    - type: icontains
+      value: "PF2"
+    - type: icontains
+      value: "non-contiguous"
+
+- description: "plan-format: invalid Complexity value triggers PF3 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/bad-plan.md --json"
+    project_root: "file://fixtures-fs/project-invalid-plan"
+  assert:
+    - type: icontains
+      value: "PF3"
+    - type: icontains
+      value: "Easy"
+
+- description: "plan-format: invalid dependency triggers PF4 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/bad-plan.md --json"
+    project_root: "file://fixtures-fs/project-invalid-plan"
+  assert:
+    - type: icontains
+      value: "PF4"
+    - type: icontains
+      value: "Task 7"
+
+- description: "plan-format: missing checkbox triggers PF5 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/bad-plan.md --json"
+    project_root: "file://fixtures-fs/project-invalid-plan"
+  assert:
+    - type: icontains
+      value: "PF5"
+    - type: icontains
+      value: "no checkbox"

--- a/tests/promptfoo/fixtures-fs/project-invalid-plan/plans/bad-plan.md
+++ b/tests/promptfoo/fixtures-fs/project-invalid-plan/plans/bad-plan.md
@@ -1,0 +1,41 @@
+# Bad Plan
+
+**Goal:** This plan has multiple format errors.
+**Architecture:** Testing validation.
+**Source:** conversation context
+
+---
+
+### Task 1: First task
+
+**Complexity:** Easy
+**Risk:** Low
+**Depends on:** none
+**Verify:** tests
+
+**Files:**
+- Create: `src/foo.js`
+
+**Description:**
+Do something.
+
+**Acceptance criteria:**
+- First item without checkbox format
+
+---
+
+### Task 3: Third task (skips 2)
+
+**Complexity:** Standard
+**Risk:** Medium
+**Depends on:** Task 7
+**Verify:** tests
+
+**Files:**
+- Create: `src/bar.js`
+
+**Description:**
+Do something else.
+
+**Acceptance criteria:**
+- [ ] Has a checkbox

--- a/tests/promptfoo/fixtures-fs/project-valid-plan/plans/test-plan.md
+++ b/tests/promptfoo/fixtures-fs/project-valid-plan/plans/test-plan.md
@@ -1,0 +1,73 @@
+# Test Feature Implementation Plan
+
+**Goal:** Add a test feature to validate plan format checking.
+**Architecture:** Simple module with two files and standard test coverage.
+**Source:** conversation context
+**Verification:** npm test
+
+---
+
+## Key Decisions
+
+- **Standalone module over extending existing:** Keeps the scope small and testable.
+
+---
+
+### Task 1: Create utility module
+
+**Complexity:** Standard
+**Risk:** Low
+**Depends on:** none
+**Verify:** tests
+
+**Files:**
+- Create: `src/utils/helper.js`
+- Test: `tests/utils/helper.test.js`
+
+**Description:**
+Create a utility module that exports a `formatDate(date)` function. It should accept a Date object and return an ISO 8601 formatted string. Handle null/undefined input by returning null.
+
+**Acceptance criteria:**
+- [ ] `formatDate` returns ISO string for valid Date
+- [ ] `formatDate` returns null for null/undefined input
+- [ ] Tests cover both cases
+
+---
+
+### Task 2: Create API endpoint
+
+**Complexity:** Standard
+**Risk:** Medium
+**Depends on:** Task 1
+**Verify:** tests, build
+
+**Files:**
+- Create: `src/routes/dates.js`
+- Modify: `src/routes/index.js` — add dates route import
+
+**Description:**
+Create a GET `/api/dates/now` endpoint that returns the current date using the `formatDate` utility from Task 1. Response format: `{ date: "<iso-string>" }`.
+
+**Acceptance criteria:**
+- [ ] GET /api/dates/now returns 200 with JSON body
+- [ ] Response contains `date` field with ISO string
+- [ ] Uses formatDate from Task 1
+
+---
+
+### Task 3: Add documentation
+
+**Complexity:** Trivial
+**Risk:** Low
+**Depends on:** Task 2
+**Verify:** manual
+
+**Files:**
+- Modify: `README.md` — add API endpoint documentation
+
+**Description:**
+Add a section to the README documenting the new `/api/dates/now` endpoint, including example request and response.
+
+**Acceptance criteria:**
+- [ ] README contains endpoint documentation
+- [ ] Example request and response included

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -7,6 +7,7 @@ evaluateOptions:
 # The prompt is unused for script tests but required by the promptfoo config schema.
 providers:
   - id: file://providers/script-runner.js
+  - id: file://providers/hook-runner.js
 
 prompts:
   - "run"
@@ -25,3 +26,6 @@ tests:
   - file://datasets/ship-prepare-exec.yaml
   - file://datasets/guardrails-prepare-exec.yaml
   - file://datasets/setup-init-exec.yaml
+  - file://datasets/plan-format-exec.yaml
+  - file://datasets/hook-git-guard-exec.yaml
+  - file://datasets/hook-error-report-exec.yaml

--- a/tests/promptfoo/providers/hook-runner.js
+++ b/tests/promptfoo/providers/hook-runner.js
@@ -1,0 +1,49 @@
+/**
+ * Hook runner provider — executes a node hook script with stdin piped
+ * and returns {stdout, stderr, exitCode} as JSON.
+ *
+ * Used for testing stdin-based hook scripts that communicate via exit codes
+ * and stderr (unlike script-runner.js which returns stdout only).
+ *
+ * Expects vars:
+ *   script_path  — absolute path to the hook script
+ *   script_args  — (optional) space-separated args
+ *   script_stdin — JSON string piped to the script's stdin
+ *   script_cwd   — (optional) working directory for script execution
+ */
+const { spawnSync } = require('child_process');
+
+class HookRunnerProvider {
+  id() {
+    return 'hook-runner';
+  }
+
+  async callApi(prompt, context) {
+    const vars = context?.vars ?? {};
+    const scriptPath = vars.script_path;
+    const scriptArgs = (vars.script_args ?? '').split(/\s+/).filter(Boolean);
+    const stdinData  = vars.script_stdin || '';
+    const cwd        = vars.script_cwd || undefined;
+
+    if (!scriptPath) {
+      return { error: 'hook-runner: script_path var is required' };
+    }
+
+    const result = spawnSync('node', [scriptPath, ...scriptArgs], {
+      input: stdinData,
+      timeout: 30_000,
+      encoding: 'utf8',
+      cwd,
+    });
+
+    const output = JSON.stringify({
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+      exitCode: result.status ?? -1,
+    });
+
+    return { output };
+  }
+}
+
+module.exports = HookRunnerProvider;


### PR DESCRIPTION
## Summary
Add four new Claude Code hook scripts for pipeline safety and validation (stop-state-save, post-failure-error-report, pre-tool-git-guard, validate-plan-format), extend the existing post-tool-validate hook with plan format detection, and include comprehensive promptfoo test coverage with a new hook-runner test provider.

## Business Context
Claude Code pipelines (ship-sdlc, execute-plan-sdlc) can fail silently when dangerous git commands execute, plan files have structural errors, or sessions crash mid-pipeline without preserving state. Users lose work and debugging context. This PR adds automated safety rails at the hook layer to catch these problems before they cause damage.

## Business Benefits
- Prevents accidental data loss from destructive git commands (force push, hard reset, checkout .) by blocking them before execution
- Preserves pipeline execution state on session stop, enabling recovery after crashes
- Surfaces actionable error reports when prepare scripts crash, reducing time-to-fix
- Validates plan file structure on save, catching formatting errors before they cause execution failures

## Github Issue
Closes #148

## Technical Design
Four independent hook scripts, each targeting a specific Claude Code hook event type:
- **Stop hook** (`stop-state-save.js`): Reads ship/execute pipeline state via the existing `scripts/lib/state` module and writes a compact recovery JSON to `.sdlc/execution/.compact-recovery.json`. Graceful degradation — always exits 0.
- **PostToolUseFailure hook** (`post-failure-error-report.js`): Pattern-matches Bash tool failures against `scripts/skill/*.js` and triggers on exit code 2 (crash convention). Surfaces a structured reminder to invoke error-report-sdlc.
- **PreToolUse hook** (`pre-tool-git-guard.js`): Fast-bails if the command doesn't contain `git `. Blocks destructive patterns (push --force, reset --hard, checkout ., clean -f) with exit 2. Warns on direct pushes to main/master without blocking.
- **CI script** (`validate-plan-format.js`): Validates plan markdown against 5 structural checks (PF1-PF5): header fields, task numbering, required metadata, dependency validity with cycle detection, and task body completeness.

The existing `post-tool-validate.js` dispatcher was extended with a `plans/*.md` pattern to route plan file writes through the new validator.

## Technical Impact
- New hook event types registered in `hooks.json`: Stop, PostToolUseFailure, PreToolUse (previously only PostToolUse was used)
- `post-tool-validate.js` script resolution paths updated from `scripts/validate-*.js` to `scripts/ci/validate-*.js` (aligns with the scripts reorganization in #142)
- Plugin version bumped to 0.17.14
- No breaking changes to existing skill interfaces or hook payloads

## Changes Overview
- Pipeline state recovery on session stop — saves compact JSON snapshot of active ship/execute pipeline state for crash recovery
- Prepare script crash detection — monitors Bash tool failures for skill script crashes and surfaces structured error-report-sdlc invocation reminders
- Destructive git command interception — blocks force push, hard reset, checkout ., and clean -f before execution; warns on direct pushes to main/master
- Plan file structural validation — enforces canonical plan format with 5 checks covering header fields, task numbering, metadata, dependency graph integrity, and task body completeness
- Post-tool validation dispatcher extended to route plan file writes to the new plan format validator
- Hook-runner test provider for promptfoo — enables CI-level testing of hook scripts with fixture-based validation
- Three new promptfoo test datasets covering error reporting, git guard, and plan format validation scenarios

## Testing
- Three new promptfoo exec test datasets: `hook-error-report-exec.yaml`, `hook-git-guard-exec.yaml`, `plan-format-exec.yaml`
- New `hook-runner.js` test provider that simulates hook stdin/stdout/stderr contract for isolated script testing
- Filesystem fixtures for valid and invalid plan files (`project-valid-plan/`, `project-invalid-plan/`)
- `promptfooconfig-exec.yaml` updated with new test entries