### PR TITLE
feat(#150): ci - make scripts self-contained, add scaffold utility

### DIFF
--- a/.github/scripts/check-changelog.js
+++ b/.github/scripts/check-changelog.js
@@ -21,15 +21,12 @@
 
 'use strict';
 
-/** @version 1 — check-changelog script version. Bump when behavior changes. */
-const CHECK_CHANGELOG_SCRIPT_VERSION = 1;
+/** @version 2 — check-changelog script version. Bump when behavior changes. */
+const CHECK_CHANGELOG_SCRIPT_VERSION = 2;
 
 const fs   = require('node:fs');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
-const LIB = path.join(__dirname, '..', 'lib');
-
-const { readSection } = require(path.join(LIB, 'config'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -44,15 +41,36 @@ function exec(cmd, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Config
+// Config (self-contained — no external lib dependency)
 // ---------------------------------------------------------------------------
 
-function readConfig(repoRoot) {
-  try {
-    return readSection(repoRoot, 'version');
-  } catch (_) {
-    return null;
+/**
+ * Read the version section from .claude/sdlc.json, with legacy .claude/version.json fallback.
+ * Returns the version config object or null if neither file exists.
+ */
+function readVersionConfig(repoRoot) {
+  // Primary: .claude/sdlc.json → .version
+  const sdlcPath = path.join(repoRoot, '.claude', 'sdlc.json');
+  if (fs.existsSync(sdlcPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(sdlcPath, 'utf8'));
+      return config.version || null;
+    } catch (_) {
+      return null;
+    }
   }
+
+  // Legacy fallback: .claude/version.json
+  const legacyPath = path.join(repoRoot, '.claude', 'version.json');
+  if (fs.existsSync(legacyPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +126,7 @@ function main() {
   const repoRoot = process.cwd();
 
   // Step 1: Read config — exit 0 silently if not present or unparseable
-  const config = readConfig(repoRoot);
+  const config = readVersionConfig(repoRoot);
   if (!config) {
     process.exit(0);
   }

--- a/.github/scripts/retag-release.js
+++ b/.github/scripts/retag-release.js
@@ -22,16 +22,13 @@
 
 'use strict';
 
-/** @version 3 — retag script version. Bump when behavior changes (e.g. message preservation). */
-const RETAG_SCRIPT_VERSION = 3;
+/** @version 4 — retag script version. Bump when behavior changes (e.g. message preservation). */
+const RETAG_SCRIPT_VERSION = 4;
 
 const fs   = require('node:fs');
 const path = require('node:path');
 const os   = require('node:os');
 const { execSync } = require('node:child_process');
-const LIB = path.join(__dirname, '..', 'lib');
-
-const { readSection } = require(path.join(LIB, 'config'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,16 +47,38 @@ function execOrThrow(cmd, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Config
+// Config (self-contained — no external lib dependency)
 // ---------------------------------------------------------------------------
 
-function readConfig(repoRoot) {
-  try {
-    return readSection(repoRoot, 'version');
-  } catch (err) {
-    process.stderr.write(`Error parsing version config: ${err.message}\n`);
-    process.exit(1);
+/**
+ * Read the version section from .claude/sdlc.json, with legacy .claude/version.json fallback.
+ * Returns the version config object or null if neither file exists.
+ */
+function readVersionConfig(repoRoot) {
+  // Primary: .claude/sdlc.json → .version
+  const sdlcPath = path.join(repoRoot, '.claude', 'sdlc.json');
+  if (fs.existsSync(sdlcPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(sdlcPath, 'utf8'));
+      return config.version || null;
+    } catch (err) {
+      process.stderr.write(`Error parsing .claude/sdlc.json: ${err.message}\n`);
+      process.exit(1);
+    }
   }
+
+  // Legacy fallback: .claude/version.json
+  const legacyPath = path.join(repoRoot, '.claude', 'version.json');
+  if (fs.existsSync(legacyPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+    } catch (err) {
+      process.stderr.write(`Error parsing .claude/version.json: ${err.message}\n`);
+      process.exit(1);
+    }
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,7 +209,7 @@ function retagOnHead(tag, repoRoot) {
 function main() {
   const repoRoot = process.cwd();
 
-  const config = readConfig(repoRoot);
+  const config = readVersionConfig(repoRoot);
   if (!config) {
     console.log('No .claude/version.json found. Skipping retag.');
     process.exit(0);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.15] - 2026-04-06
+
+### Added
+- Self-contained CI scripts with inlined config reading, and new `scaffold-ci.js` utility for deterministic CI file scaffolding with version tracking (#150)
+
 ## [0.17.14] - 2026-04-06
 
 ### Added

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/ci/check-changelog.js
+++ b/plugins/sdlc-utilities/scripts/ci/check-changelog.js
@@ -21,15 +21,12 @@
 
 'use strict';
 
-/** @version 1 — check-changelog script version. Bump when behavior changes. */
-const CHECK_CHANGELOG_SCRIPT_VERSION = 1;
+/** @version 2 — check-changelog script version. Bump when behavior changes. */
+const CHECK_CHANGELOG_SCRIPT_VERSION = 2;
 
 const fs   = require('node:fs');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
-const LIB = path.join(__dirname, '..', 'lib');
-
-const { readSection } = require(path.join(LIB, 'config'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -44,15 +41,36 @@ function exec(cmd, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Config
+// Config (self-contained — no external lib dependency)
 // ---------------------------------------------------------------------------
 
-function readConfig(repoRoot) {
-  try {
-    return readSection(repoRoot, 'version');
-  } catch (_) {
-    return null;
+/**
+ * Read the version section from .claude/sdlc.json, with legacy .claude/version.json fallback.
+ * Returns the version config object or null if neither file exists.
+ */
+function readVersionConfig(repoRoot) {
+  // Primary: .claude/sdlc.json → .version
+  const sdlcPath = path.join(repoRoot, '.claude', 'sdlc.json');
+  if (fs.existsSync(sdlcPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(sdlcPath, 'utf8'));
+      return config.version || null;
+    } catch (_) {
+      return null;
+    }
   }
+
+  // Legacy fallback: .claude/version.json
+  const legacyPath = path.join(repoRoot, '.claude', 'version.json');
+  if (fs.existsSync(legacyPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +126,7 @@ function main() {
   const repoRoot = process.cwd();
 
   // Step 1: Read config — exit 0 silently if not present or unparseable
-  const config = readConfig(repoRoot);
+  const config = readVersionConfig(repoRoot);
   if (!config) {
     process.exit(0);
   }

--- a/plugins/sdlc-utilities/scripts/ci/retag-release.js
+++ b/plugins/sdlc-utilities/scripts/ci/retag-release.js
@@ -22,16 +22,13 @@
 
 'use strict';
 
-/** @version 3 — retag script version. Bump when behavior changes (e.g. message preservation). */
-const RETAG_SCRIPT_VERSION = 3;
+/** @version 4 — retag script version. Bump when behavior changes (e.g. message preservation). */
+const RETAG_SCRIPT_VERSION = 4;
 
 const fs   = require('node:fs');
 const path = require('node:path');
 const os   = require('node:os');
 const { execSync } = require('node:child_process');
-const LIB = path.join(__dirname, '..', 'lib');
-
-const { readSection } = require(path.join(LIB, 'config'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,16 +47,38 @@ function execOrThrow(cmd, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Config
+// Config (self-contained — no external lib dependency)
 // ---------------------------------------------------------------------------
 
-function readConfig(repoRoot) {
-  try {
-    return readSection(repoRoot, 'version');
-  } catch (err) {
-    process.stderr.write(`Error parsing version config: ${err.message}\n`);
-    process.exit(1);
+/**
+ * Read the version section from .claude/sdlc.json, with legacy .claude/version.json fallback.
+ * Returns the version config object or null if neither file exists.
+ */
+function readVersionConfig(repoRoot) {
+  // Primary: .claude/sdlc.json → .version
+  const sdlcPath = path.join(repoRoot, '.claude', 'sdlc.json');
+  if (fs.existsSync(sdlcPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(sdlcPath, 'utf8'));
+      return config.version || null;
+    } catch (err) {
+      process.stderr.write(`Error parsing .claude/sdlc.json: ${err.message}\n`);
+      process.exit(1);
+    }
   }
+
+  // Legacy fallback: .claude/version.json
+  const legacyPath = path.join(repoRoot, '.claude', 'version.json');
+  if (fs.existsSync(legacyPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+    } catch (err) {
+      process.stderr.write(`Error parsing .claude/version.json: ${err.message}\n`);
+      process.exit(1);
+    }
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,7 +209,7 @@ function retagOnHead(tag, repoRoot) {
 function main() {
   const repoRoot = process.cwd();
 
-  const config = readConfig(repoRoot);
+  const config = readVersionConfig(repoRoot);
   if (!config) {
     console.log('No .claude/version.json found. Skipping retag.');
     process.exit(0);

--- a/plugins/sdlc-utilities/scripts/util/scaffold-ci.js
+++ b/plugins/sdlc-utilities/scripts/util/scaffold-ci.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * scaffold-ci.js
+ * Deterministically copies CI scripts and workflow files into a user project.
+ *
+ * Usage:
+ *   node scaffold-ci.js [options]
+ *
+ * Options:
+ *   --changelog       Include changelog CI scripts/workflows
+ *   --force           Overwrite existing files
+ *   --check-only      Report version status without writing files
+ *   --output-file     Write JSON to temp file (path on stdout)
+ *
+ * Exit codes:
+ *   0 = success, JSON on stdout (or temp file path with --output-file)
+ *   1 = validation error (JSON with non-empty errors[])
+ *   2 = unexpected script crash (message on stderr)
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const LIB  = path.join(__dirname, '..', 'lib');
+
+const { writeOutput } = require(path.join(LIB, 'output'));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Plugin root relative to this script: scripts/util/ → plugin root */
+const PLUGIN_ROOT = path.resolve(__dirname, '..', '..');
+
+/**
+ * File manifest. Each entry maps a plugin source to a project destination.
+ * versionRegex extracts the version constant from the installed file.
+ */
+const MANIFEST = [
+  {
+    src:  path.join('scripts', 'ci', 'retag-release.js'),
+    dest: path.join('.github', 'scripts', 'retag-release.js'),
+    versionRegex: /const\s+RETAG_SCRIPT_VERSION\s*=\s*(\d+)/,
+    versionConst: 'RETAG_SCRIPT_VERSION',
+    group: 'retag',
+  },
+  {
+    src:  path.join('templates', 'retag-release.yml'),
+    dest: path.join('.github', 'workflows', 'retag-release.yml'),
+    versionRegex: /^#\s*retag-release-version:\s*(\d+)/m,
+    versionConst: 'retag-release-version',
+    group: 'retag',
+  },
+  {
+    src:  path.join('scripts', 'ci', 'check-changelog.js'),
+    dest: path.join('.github', 'scripts', 'check-changelog.js'),
+    versionRegex: /const\s+CHECK_CHANGELOG_SCRIPT_VERSION\s*=\s*(\d+)/,
+    versionConst: 'CHECK_CHANGELOG_SCRIPT_VERSION',
+    group: 'changelog',
+  },
+  {
+    src:  path.join('templates', 'check-changelog.yml'),
+    dest: path.join('.github', 'workflows', 'check-changelog.yml'),
+    versionRegex: /^#\s*check-changelog-version:\s*(\d+)/m,
+    versionConst: 'check-changelog-version',
+    group: 'changelog',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractVersion(content, regex) {
+  const match = content.match(regex);
+  return match ? parseInt(match[1], 10) : 1;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  return {
+    changelog: args.includes('--changelog'),
+    force:     args.includes('--force'),
+    checkOnly: args.includes('--check-only'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const projectRoot = process.cwd();
+  const cli = parseArgs(process.argv);
+
+  const errors   = [];
+  const warnings = [];
+  const files    = [];
+
+  // Filter manifest by flags
+  const entries = MANIFEST.filter(e => {
+    if (e.group === 'changelog' && !cli.changelog) return false;
+    return true;
+  });
+
+  for (const entry of entries) {
+    const srcPath  = path.join(PLUGIN_ROOT, entry.src);
+    const destPath = path.join(projectRoot, entry.dest);
+
+    // Read source file
+    if (!fs.existsSync(srcPath)) {
+      errors.push(`Source file not found: ${entry.src}`);
+      continue;
+    }
+    const srcContent = fs.readFileSync(srcPath, 'utf8');
+    const currentVersion = extractVersion(srcContent, entry.versionRegex);
+
+    // Check destination
+    const destExists = fs.existsSync(destPath);
+    let installedVersion = null;
+    let action = 'none';
+
+    if (destExists) {
+      const destContent = fs.readFileSync(destPath, 'utf8');
+      installedVersion = extractVersion(destContent, entry.versionRegex);
+    }
+
+    if (cli.checkOnly) {
+      // Report-only mode
+      if (!destExists) {
+        action = 'missing';
+      } else if (installedVersion < currentVersion) {
+        action = 'outdated';
+      } else {
+        action = 'current';
+      }
+    } else {
+      // Write mode
+      if (!destExists) {
+        action = 'created';
+      } else if (cli.force) {
+        action = 'overwritten';
+      } else if (installedVersion < currentVersion) {
+        action = 'outdated';
+        warnings.push(`${entry.dest} is outdated (installed: v${installedVersion}, current: v${currentVersion}). Use --force to update.`);
+      } else {
+        action = 'skipped';
+      }
+
+      if (action === 'created' || action === 'overwritten') {
+        const destDir = path.dirname(destPath);
+        if (!fs.existsSync(destDir)) {
+          fs.mkdirSync(destDir, { recursive: true });
+        }
+        fs.writeFileSync(destPath, srcContent, 'utf8');
+      }
+    }
+
+    files.push({
+      path: entry.dest,
+      action,
+      installedVersion,
+      currentVersion,
+      group: entry.group,
+    });
+  }
+
+  const result = { errors, warnings, files };
+  writeOutput(result, 'scaffold-ci', errors.length > 0 ? 1 : 0);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    process.stderr.write(`scaffold-ci.js error: ${err.message}\n${err.stack}\n`);
+    process.exit(2);
+  }
+}
+
+module.exports = { MANIFEST, extractVersion };

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -201,13 +201,27 @@ Resolve any issues found in Step 6 before proceeding. If a blocking issue cannot
 Before executing, check whether the project's installed CI scripts need updating.
 This ensures projects that ran `--init` in a prior session get notified about improvements.
 
-1. Check retag scripts — same version check as described in Branch A Step 4 (retag script version check).
-2. If `config.changelog === true`: check check-changelog scripts — same version check as described in Branch A Step 4 (changelog script version check).
-3. If any scripts are outdated or missing (and `config.changelog === true` for the check-changelog check):
-   - Show what changed and which files would be updated
+Locate and run the scaffold script in check-only mode:
+
+```bash
+SCRIPT=$(find ~/.claude/plugins -name "scaffold-ci.js" -path "*/sdlc*/scripts/util/scaffold-ci.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/util/scaffold-ci.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/util/scaffold-ci.js"
+[ -z "$SCRIPT" ] && { echo "WARN: Could not locate util/scaffold-ci.js — skipping CI script check" >&2; exit 0; }
+```
+
+Run the check (include `--changelog` only when `config.changelog === true`):
+
+```bash
+SCAFFOLD_OUTPUT_FILE=$(node "$SCRIPT" --check-only --output-file)
+# Add --changelog if config.changelog === true:
+# SCAFFOLD_OUTPUT_FILE=$(node "$SCRIPT" --check-only --changelog --output-file)
+```
+
+Read the JSON output. If any files have `action: "outdated"` or `action: "missing"`:
+   - Show what changed and which files would be updated (use `installedVersion` / `currentVersion` from the output)
    - Use AskUserQuestion to ask: "Update CI scripts? (yes / no) — this does not block the release."
    - **Auto mode:** When `flags.auto` is true, skip the AskUserQuestion and treat the response as `yes` — update outdated CI scripts automatically.
-   - On `yes`: scaffold/overwrite the outdated files
+   - On `yes`: run `node "$SCRIPT" --force` (add `--changelog` if applicable) to overwrite the outdated files
    - On `no`: warn and continue with the release
 
 The release proceeds regardless of the user's answer. This is informational, not a gate.

--- a/plugins/sdlc-utilities/skills/version-sdlc/init-workflow.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/init-workflow.md
@@ -42,19 +42,26 @@ Options:
 On `yes` or `changelog`, write the version section to `.claude/sdlc.json` using `writeSection` from lib/config.js with
 the content from `suggestedConfig` (adjusted if `changelog` was chosen).
 
-Then scaffold the retag workflow into the project:
+Then scaffold CI scripts and workflows using `scaffold-ci.js`:
 
-1. Copy `plugins/sdlc-utilities/scripts/retag-release.js` → `.github/scripts/retag-release.js` (create `.github/scripts/` if it doesn't exist)
-2. Copy `plugins/sdlc-utilities/templates/retag-release.yml` → `.github/workflows/retag-release.yml` (create `.github/workflows/` if it doesn't exist)
+```bash
+SCRIPT=$(find ~/.claude/plugins -name "scaffold-ci.js" -path "*/sdlc*/scripts/util/scaffold-ci.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/util/scaffold-ci.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/util/scaffold-ci.js"
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate util/scaffold-ci.js" >&2; exit 2; }
+```
 
-If either target file already exists, skip copying it (do not overwrite).
+Run the scaffold (include `--changelog` when `config.changelog === true`):
 
-**When `config.changelog === true`** (i.e., user chose `changelog` option, or changelog was already enabled):
+```bash
+# Without changelog:
+SCAFFOLD_OUTPUT_FILE=$(node "$SCRIPT" --output-file)
+# With changelog:
+SCAFFOLD_OUTPUT_FILE=$(node "$SCRIPT" --changelog --output-file)
+```
 
-3. Copy `plugins/sdlc-utilities/scripts/check-changelog.js` → `.github/scripts/check-changelog.js` (reuse the same `.github/scripts/` directory)
-4. Copy `plugins/sdlc-utilities/templates/check-changelog.yml` → `.github/workflows/check-changelog.yml`
-
-If either target file already exists, skip copying it (do not overwrite).
+Read the JSON output. For each file in the `files` array:
+- `action: "created"` → show `✓ <path> added (<description>).`
+- `action: "skipped"` → show `✓ <path> (already exists — skipped).`
 
 Display:
 
@@ -67,38 +74,29 @@ Display:
 Run /version-sdlc patch to create your first release.
 ```
 
-If a file was skipped because it already existed, show `(already exists — skipped)` instead of `added`.
 The check-changelog lines are only shown when `config.changelog === true`.
 
-**Retag script version check** — after scaffolding (whether files were added or skipped), check if the installed files are up to date:
+**Version check** — after scaffolding, check if any installed files are outdated. Run the scaffold script again in check-only mode:
 
-1. Read the installed `.github/scripts/retag-release.js` (if it exists) and look for `const RETAG_SCRIPT_VERSION = (\d+);`. If absent, treat as version 1.
-2. Read the installed `.github/workflows/retag-release.yml` (if it exists) and look for `# retag-release-version: (\d+)`. If absent, treat as version 1.
-3. Read the plugin's current copies of those files (from the same paths used for scaffolding) and extract their version numbers the same way.
-4. If either installed file's version is less than the plugin's current version, show an update prompt:
+```bash
+CHECK_OUTPUT_FILE=$(node "$SCRIPT" --check-only --output-file)
+# With changelog:
+CHECK_OUTPUT_FILE=$(node "$SCRIPT" --check-only --changelog --output-file)
+```
+
+Read the JSON output. If any files have `action: "outdated"`:
 
 ```
-⚠  Outdated retag files detected:
-   .github/scripts/retag-release.js   (installed: v1, current: v2)
-   .github/workflows/retag-release.yml (installed: v1, current: v2)
-
-Changes in v2:
-- Retag now preserves original tag message metadata (required for --hotfix DORA annotations)
+⚠  Outdated CI files detected:
+   .github/scripts/retag-release.js   (installed: v<N>, current: v<M>)
 
 Update these files? (yes / no)
 ```
 
-On `yes`, overwrite the outdated files with the plugin's current copies. On `no`, warn:
+On `yes`, run `node "$SCRIPT" --force` (add `--changelog` if applicable) to overwrite the outdated files. On `no`, warn:
 ```
-⚠  Skipped update. Note: hotfix tag metadata (Type: hotfix) will not survive retagging until you update these files.
+⚠  Skipped update. Outdated CI scripts may miss bug fixes or new features.
 ```
-
-**Changelog script version check** — after checking retag files, if `config.changelog === true`:
-
-1. Read `.github/scripts/check-changelog.js` (if it exists) and look for `const CHECK_CHANGELOG_SCRIPT_VERSION = (\d+);`. If absent, treat as version 1.
-2. Read `.github/workflows/check-changelog.yml` (if it exists) and look for `# check-changelog-version: (\d+)`. If absent, treat as version 1.
-3. Read the plugin's current copies and extract their version numbers.
-4. If either installed file's version is less than the plugin's current version, include them in the update prompt alongside outdated retag files.
 
 On `tag-only`, update `suggestedConfig.mode` to `"tag"` before writing. Apply the same workflow scaffolding.
 


### PR DESCRIPTION
## Summary
CI scripts (check-changelog.js, retag-release.js) are now self-contained by inlining the config-reading logic that previously required a relative `../lib/config` import. A new scaffold-ci.js utility provides deterministic CI file scaffolding with version tracking, replacing the manual file-copy instructions in version-sdlc.

## Business Context
When CI scripts were scaffolded into a project's `.github/scripts/` directory, they broke at runtime because the `require('../lib/config')` path no longer resolved — the lib directory doesn't exist in the target project. This made the CI automation unreliable for any project consuming the plugin's CI workflows.

## Business Benefits
Projects using the sdlc plugin's CI scaffolding now get scripts that work out of the box without hidden dependencies. The scaffold utility also tracks installed script versions, enabling automatic detection and update of outdated CI files during releases.

## Github Issue
Closes #150

## Technical Design
Each CI script (check-changelog.js, retag-release.js) had its `readConfig()` function replaced with a self-contained `readVersionConfig()` that directly reads `.claude/sdlc.json` (with `.claude/version.json` legacy fallback) without importing from `../lib/config`. The new `scaffold-ci.js` utility uses a declarative manifest to map plugin source files to project destinations, extracts version numbers via regex from both source and installed files, and supports `--check-only`, `--force`, and `--changelog` flags for different scaffolding scenarios.

## Technical Impact
- CI script versions bumped (check-changelog v1→v2, retag-release v3→v4) — projects with older installed versions will be prompted to update on their next release
- The `../lib/config` import path is removed from scaffolded scripts — no breaking change since the old scripts failed at runtime anyway
- version-sdlc SKILL.md and init-workflow.md now delegate file operations to scaffold-ci.js instead of inline copy instructions

## Changes Overview
- Inlined config-reading logic in both CI scripts to eliminate the broken cross-directory require dependency
- Created a scaffold utility that declaratively manages CI file installation with version tracking, check-only mode, and forced overwrite support
- Updated version-sdlc skill documentation to use the scaffold utility for both initial setup and update-check workflows
- Bumped script version constants to trigger update detection for existing installations
- Version bump to v0.17.15 with changelog entry

## Testing
Manual verification that scripts execute without `MODULE_NOT_FOUND` errors when placed in `.github/scripts/`. The scaffold utility was tested with `--check-only` and default modes against existing project structures.