### PR TITLE
fix(#154): jira-sdlc - convert markdown to ADF for Jira comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.16] - 2026-04-12
+
+### Added
+- Jira comment posting now converts markdown to Atlassian Document Format (ADF), supporting headings, bold, italic, code blocks, lists, tables, blockquotes, links, and horizontal rules (#154)
+
+### Fixed
+- jira-sdlc documentation updated and script resolution guards added for markdown-to-ADF conversion (#154)
+
 ## [0.17.15] - 2026-04-06
 
 ### Added

--- a/docs/skills/jira-sdlc.md
+++ b/docs/skills/jira-sdlc.md
@@ -60,7 +60,7 @@ Returns a table of matching issues.
 Add a comment to PROJ-147 with the root cause analysis
 ```
 
-Posts a properly formatted markdown comment.
+Converts the markdown to Atlassian Document Format (ADF) via `markdown-to-adf.js` and posts the comment.
 
 ### Edit issue fields
 

--- a/docs/specs/jira-sdlc.md
+++ b/docs/specs/jira-sdlc.md
@@ -25,6 +25,7 @@
 - R9: On stale cache errors (invalid transition IDs, changed field schemas), auto-refresh cache and retry once
 - R10: When `--init-templates` is passed, initialize templates and stop — do not execute any Jira operation
 - R11: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R12: Comments must be converted from markdown to ADF via `scripts/lib/markdown-to-adf.js` before posting to Jira — compose in markdown using REFERENCE.md Section 4 safe syntax, pipe through the conversion script, then call `addCommentToJiraIssue` with `contentFormat: "adf"` and the ADF JSON body
 
 ## Workflow Phases
 
@@ -46,7 +47,7 @@
 ## Quality Gates
 
 - G1: Cache loaded — `cloudId`, `project`, `issueTypes`, `fieldSchemas` all present before any operation
-- G2: Content format — every description/comment call uses `contentFormat: "markdown"`
+- G2: Content format — comment calls use `contentFormat: "adf"` with ADF body from `scripts/lib/markdown-to-adf.js`; description/create calls use `contentFormat: "markdown"`
 - G3: Response format — every content-returning call uses `responseContentFormat: "markdown"`
 - G4: No raw placeholders — all `{placeholder}` markers in templates filled or section removed
 - G5: Required fields — all required fields per `fieldSchemas` have values before create
@@ -76,7 +77,7 @@
 
 ## Constraints
 
-- C1: Must not use ADF format — always `contentFormat: "markdown"` and `responseContentFormat: "markdown"`
+- C1: Must convert markdown to ADF via `scripts/lib/markdown-to-adf.js` for comment posting; must keep `responseContentFormat: "markdown"` for reading
 - C2: Must not call discovery endpoints after cache initialization (getAccessibleAtlassianResources, getJiraIssueTypeMetaWithFields, getIssueLinkTypes)
 - C3: Must not pass transition name to `transitionJiraIssue` — requires `{ id: "..." }` object
 - C4: Must not pass display name as assignee — requires `{ accountId: "..." }`

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.15",
+  "version": "0.17.16",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js
+++ b/plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * markdown-to-adf.js — Convert markdown to Atlassian Document Format (ADF) v1.
+ *
+ * Reads markdown from stdin, writes ADF JSON to stdout.
+ * No npm dependencies — Node.js built-ins only.
+ *
+ * Supported elements:
+ *   Headings (h1-h3), bold, italic, inline code, fenced code blocks,
+ *   unordered/ordered lists, links, tables, blockquotes, horizontal rules.
+ *
+ * Usage (CLI):   echo "# Hello" | node markdown-to-adf.js
+ * Usage (API):   const { convert } = require('./markdown-to-adf.js');
+ *                const adf = convert('# Hello');
+ */
+
+// ---------------------------------------------------------------------------
+// Inline tokenizer — parses bold, italic, code, links within text
+// ---------------------------------------------------------------------------
+
+function tokenizeInline(text) {
+  const nodes = [];
+  // Regex matches: links, bold, italic, inline code, or plain text
+  // Order matters: bold before italic to handle ** vs *
+  const re = /(\[([^\]]+)\]\(([^)]+)\))|(`([^`]+)`)|(\*\*(.+?)\*\*)|(\*(.+?)\*)|([^[`*]+)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1]) {
+      // Link: [text](url)
+      const linkText = m[2];
+      const href = m[3];
+      nodes.push({
+        type: 'text',
+        text: linkText,
+        marks: [{ type: 'link', attrs: { href } }],
+      });
+    } else if (m[4]) {
+      // Inline code: `code`
+      nodes.push({
+        type: 'text',
+        text: m[5],
+        marks: [{ type: 'code' }],
+      });
+    } else if (m[6]) {
+      // Bold: **text**
+      nodes.push({
+        type: 'text',
+        text: m[7],
+        marks: [{ type: 'strong' }],
+      });
+    } else if (m[8]) {
+      // Italic: *text*
+      nodes.push({
+        type: 'text',
+        text: m[9],
+        marks: [{ type: 'em' }],
+      });
+    } else if (m[10]) {
+      // Plain text
+      const t = m[10];
+      if (t) {
+        nodes.push({ type: 'text', text: t });
+      }
+    }
+  }
+  return nodes.length > 0 ? nodes : [{ type: 'text', text: text || '' }];
+}
+
+function inlineToContent(text) {
+  return tokenizeInline(text);
+}
+
+// ---------------------------------------------------------------------------
+// Table parser — parses a run of pipe-delimited lines into an ADF table
+// ---------------------------------------------------------------------------
+
+function parseTableRow(line) {
+  // Split on pipe, trim, drop leading/trailing empty cells
+  const cells = line.split('|').map((c) => c.trim());
+  // Remove first and last if empty (from leading/trailing pipes)
+  if (cells.length > 0 && cells[0] === '') cells.shift();
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+  return cells;
+}
+
+function isSeparatorRow(line) {
+  // Matches rows like | --- | --- | or |:---:|---:|
+  return /^\|?[\s:]*-{2,}[\s:]*(\|[\s:]*-{2,}[\s:]*)*\|?\s*$/.test(line);
+}
+
+function buildTable(tableLines) {
+  if (tableLines.length < 2) return null;
+  const headerCells = parseTableRow(tableLines[0]);
+  // Skip separator row (index 1)
+  const bodyStartIndex = isSeparatorRow(tableLines[1]) ? 2 : 1;
+  const rows = [];
+
+  // Header row
+  rows.push({
+    type: 'tableRow',
+    content: headerCells.map((cell) => ({
+      type: 'tableHeader',
+      attrs: {},
+      content: [{ type: 'paragraph', content: inlineToContent(cell) }],
+    })),
+  });
+
+  // Body rows
+  for (let i = bodyStartIndex; i < tableLines.length; i++) {
+    const cells = parseTableRow(tableLines[i]);
+    rows.push({
+      type: 'tableRow',
+      content: cells.map((cell) => ({
+        type: 'tableCell',
+        attrs: {},
+        content: [{ type: 'paragraph', content: inlineToContent(cell) }],
+      })),
+    });
+  }
+
+  return { type: 'table', attrs: { isNumberColumnEnabled: false, layout: 'default' }, content: rows };
+}
+
+// ---------------------------------------------------------------------------
+// List helpers
+// ---------------------------------------------------------------------------
+
+function buildListItem(text) {
+  return {
+    type: 'listItem',
+    content: [{ type: 'paragraph', content: inlineToContent(text) }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Block parser — state machine for multi-line constructs
+// ---------------------------------------------------------------------------
+
+function convert(markdown) {
+  const lines = markdown.split('\n');
+  const content = [];
+
+  let i = 0;
+
+  function flushParagraph(text) {
+    const trimmed = text.trim();
+    if (trimmed) {
+      content.push({ type: 'paragraph', content: inlineToContent(trimmed) });
+    }
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // --- Fenced code block ---
+    const fenceMatch = line.match(/^```(\w*)\s*$/);
+    if (fenceMatch) {
+      const lang = fenceMatch[1] || null;
+      const codeLines = [];
+      i++;
+      while (i < lines.length && !lines[i].match(/^```\s*$/)) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      const node = { type: 'codeBlock', content: [{ type: 'text', text: codeLines.join('\n') }] };
+      if (lang) node.attrs = { language: lang };
+      content.push(node);
+      i++; // skip closing ```
+      continue;
+    }
+
+    // --- Horizontal rule ---
+    if (/^(---|\*\*\*|___)\s*$/.test(line)) {
+      content.push({ type: 'rule' });
+      i++;
+      continue;
+    }
+
+    // --- Heading ---
+    const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+      content.push({
+        type: 'heading',
+        attrs: { level },
+        content: inlineToContent(text),
+      });
+      i++;
+      continue;
+    }
+
+    // --- Blockquote ---
+    if (line.match(/^>\s?/)) {
+      const quoteLines = [];
+      while (i < lines.length && lines[i].match(/^>\s?/)) {
+        quoteLines.push(lines[i].replace(/^>\s?/, ''));
+        i++;
+      }
+      content.push({
+        type: 'blockquote',
+        content: [{ type: 'paragraph', content: inlineToContent(quoteLines.join(' ').trim()) }],
+      });
+      continue;
+    }
+
+    // --- Unordered list ---
+    if (line.match(/^[\-\*]\s+/)) {
+      const items = [];
+      while (i < lines.length && lines[i].match(/^[\-\*]\s+/)) {
+        items.push(buildListItem(lines[i].replace(/^[\-\*]\s+/, '')));
+        i++;
+      }
+      content.push({ type: 'bulletList', content: items });
+      continue;
+    }
+
+    // --- Ordered list ---
+    if (line.match(/^\d+\.\s+/)) {
+      const items = [];
+      while (i < lines.length && lines[i].match(/^\d+\.\s+/)) {
+        items.push(buildListItem(lines[i].replace(/^\d+\.\s+/, '')));
+        i++;
+      }
+      content.push({ type: 'orderedList', content: items });
+      continue;
+    }
+
+    // --- Table ---
+    if (line.match(/^\|/)) {
+      const tableLines = [];
+      while (i < lines.length && lines[i].match(/^\|/)) {
+        tableLines.push(lines[i]);
+        i++;
+      }
+      const table = buildTable(tableLines);
+      if (table) content.push(table);
+      continue;
+    }
+
+    // --- Empty line (skip) ---
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // --- Paragraph (default) ---
+    flushParagraph(line);
+    i++;
+  }
+
+  // If the input was empty, produce a minimal doc with one empty paragraph
+  if (content.length === 0) {
+    content.push({ type: 'paragraph', content: [{ type: 'text', text: '' }] });
+  }
+
+  return { version: 1, type: 'doc', content };
+}
+
+// ---------------------------------------------------------------------------
+// CLI mode — read from stdin, write to stdout
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const { readFileSync } = require('fs');
+
+  // --file <path> for file-based invocation (used by test runner)
+  const fileIdx = process.argv.indexOf('--file');
+  if (fileIdx !== -1 && process.argv[fileIdx + 1] !== undefined) {
+    try {
+      const md = readFileSync(process.argv[fileIdx + 1], 'utf8');
+      const result = convert(md);
+      process.stdout.write(JSON.stringify(result));
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(`markdown-to-adf error: ${err.message}\n`);
+      process.exit(1);
+    }
+  } else {
+    // stdin mode
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      input += chunk;
+    });
+    process.stdin.on('end', () => {
+      try {
+        const result = convert(input);
+        process.stdout.write(JSON.stringify(result));
+        process.exit(0);
+      } catch (err) {
+        process.stderr.write(`markdown-to-adf error: ${err.message}\n`);
+        process.exit(1);
+      }
+    });
+    process.stdin.resume();
+  }
+} else {
+  module.exports = { convert };
+}

--- a/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
@@ -4,8 +4,9 @@ Copy-paste MCP call examples for every operation. Values marked with `← cache.
 come from the project cache at `.claude/jira-cache/<PROJECT_KEY>.json`. Replace
 `PROJ` with the actual project key and adjust IDs to match the cache.
 
-All examples use `contentFormat: "markdown"` and `responseContentFormat: "markdown"`.
-Never use ADF format.
+Comment examples use `contentFormat: "adf"` with the body converted via `markdown-to-adf.js`.
+All other write operations use `contentFormat: "markdown"`.
+All read operations use `responseContentFormat: "markdown"`.
 
 ---
 
@@ -418,11 +419,19 @@ mcp__atlassian__transitionJiraIssue({
 ### 6a. Plain Comment
 
 ```
+# Step 1: Compose comment in markdown
+COMMENT_MD="Reviewed the implementation. Token refresh is working in staging. Ready for QA sign-off."
+
+# Step 2: Convert to ADF
+SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
+ADF_JSON=$(echo "$COMMENT_MD" | node "$SCRIPT")
+
+# Step 3: Post with ADF format
 mcp__atlassian__addCommentToJiraIssue({
-  cloudId:   "a1b2c3d4-e5f6-7890-abcd-ef1234567890",  ← cache.cloudId
-  issueKey:  "PROJ-147",
-  comment:   "Reviewed the implementation. Token refresh is working in staging. Ready for QA sign-off.",
-  contentFormat:         "markdown",
+  cloudId:        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",  ← cache.cloudId
+  issueIdOrKey:   "PROJ-147",
+  commentBody:    <ADF_JSON>,
+  contentFormat:         "adf",
   responseContentFormat: "markdown"
 })
 ```
@@ -430,11 +439,19 @@ mcp__atlassian__addCommentToJiraIssue({
 ### 6b. Comment with Code Block and Table
 
 ```
+# Step 1: Compose comment in markdown (use REFERENCE.md Section 4 safe syntax)
+COMMENT_MD="## Root Cause Analysis\n\nThe blank page is caused by the SAML callback handler returning early when \`RelayState\` is empty.\n\n\`\`\`js\n// Before fix:\nif (!relayState) return; // silently drops the response\n\n// After fix:\nif (!relayState) relayState = '/dashboard';\n\`\`\`\n\n## Test Results\n\n| Browser | Status |\n|---------|--------|\n| Chrome  | Pass   |\n| Firefox | Pass   |\n| Safari  | Pass   |"
+
+# Step 2: Convert to ADF
+SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
+ADF_JSON=$(echo -e "$COMMENT_MD" | node "$SCRIPT")
+
+# Step 3: Post with ADF format
 mcp__atlassian__addCommentToJiraIssue({
-  cloudId:  "a1b2c3d4-e5f6-7890-abcd-ef1234567890",  ← cache.cloudId
-  issueKey: "PROJ-148",
-  comment: "## Root Cause Analysis\n\nThe blank page is caused by the SAML callback handler returning early when `RelayState` is empty.\n\n```js\n// Before fix:\nif (!relayState) return; // silently drops the response\n\n// After fix:\nif (!relayState) relayState = '/dashboard';\n```\n\n## Test Results\n\n| Browser | Status |\n|---------|--------|\n| Chrome  | Pass   |\n| Firefox | Pass   |\n| Safari  | Pass   |",
-  contentFormat:         "markdown",
+  cloudId:        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",  ← cache.cloudId
+  issueIdOrKey:   "PROJ-148",
+  commentBody:    <ADF_JSON>,
+  contentFormat:         "adf",
   responseContentFormat: "markdown"
 })
 ```

--- a/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
@@ -424,6 +424,8 @@ COMMENT_MD="Reviewed the implementation. Token refresh is working in staging. Re
 
 # Step 2: Convert to ADF
 SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+[ -z "$SCRIPT" ] && { echo "ERROR: markdown-to-adf.js not found"; exit 2; }
 ADF_JSON=$(echo "$COMMENT_MD" | node "$SCRIPT")
 
 # Step 3: Post with ADF format
@@ -444,6 +446,8 @@ COMMENT_MD="## Root Cause Analysis\n\nThe blank page is caused by the SAML callb
 
 # Step 2: Convert to ADF
 SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+[ -z "$SCRIPT" ] && { echo "ERROR: markdown-to-adf.js not found"; exit 2; }
 ADF_JSON=$(echo -e "$COMMENT_MD" | node "$SCRIPT")
 
 # Step 3: Post with ADF format

--- a/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
@@ -158,11 +158,13 @@ full initialization sequence.
 
 ```
 ALWAYS:
-  contentFormat: "markdown"           — on every call that accepts description/comment input
-  responseContentFormat: "markdown"   — on every call that returns content
+  Comments:     convert markdown to ADF via scripts/lib/markdown-to-adf.js,
+                then pass contentFormat: "adf" with the ADF JSON body
+  Descriptions: contentFormat: "markdown"  — on create/edit calls (no conversion needed)
+  Reading:      responseContentFormat: "markdown"   — on every call that returns content
 
 NEVER:
-  Use ADF (Atlassian Document Format) — it produces garbled output
+  Post raw markdown comments without ADF conversion — always pipe through markdown-to-adf.js
   Call getAccessibleAtlassianResources after cache init
   Call getJiraIssueTypeMetaWithFields after cache init
   Call getIssueLinkTypes after cache init
@@ -361,9 +363,9 @@ open-ended discovery.
 | Parameter | Type | Required | Notes |
 |-----------|------|----------|-------|
 | `cloudId` | string | Yes | From `cache.cloudId` |
-| `issueKey` | string | Yes | E.g., `"PROJ-123"` |
-| `comment` | string | Yes | Markdown string |
-| `contentFormat` | string | No | Always pass `"markdown"` |
+| `issueIdOrKey` | string | Yes | E.g., `"PROJ-123"` |
+| `commentBody` | string | Yes | ADF JSON string from `markdown-to-adf.js` |
+| `contentFormat` | string | No | Pass `"adf"` for comments (compose in markdown, convert via script) |
 | `responseContentFormat` | string | No | Always pass `"markdown"` |
 
 #### `mcp__atlassian__addWorklogToJiraIssue`
@@ -479,8 +481,12 @@ Required fields on create produce 400 if omitted.
 
 ## Section 4: Markdown Content Rules
 
-All descriptions and comments must be submitted with `contentFormat: "markdown"`. The
-Jira markdown renderer is a subset of CommonMark. The following tables define what is
+Compose all content (descriptions and comments) in markdown following the rules below.
+For **comments**, the markdown is then converted to ADF via `scripts/lib/markdown-to-adf.js`
+before posting — the conversion is automatic, but the source must use only the safe syntax
+defined here. For **descriptions**, markdown is submitted directly with `contentFormat: "markdown"`.
+
+The Jira markdown renderer is a subset of CommonMark. The following tables define what is
 safe to use and what to avoid.
 
 ### Supported Syntax

--- a/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
@@ -361,7 +361,7 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 | Gate | Check |
 |------|-------|
 | Cache loaded | `cloudId`, `project`, `issueTypes`, `fieldSchemas` all present before any operation |
-| Content format | Every description/comment call uses `contentFormat: "markdown"` |
+| Content format | Comment calls use `contentFormat: "adf"` with ADF body from conversion script; description/create calls use `contentFormat: "markdown"` |
 | Response format | Every content-returning call uses `responseContentFormat: "markdown"` |
 | No raw placeholders | All `{placeholder}` markers in templates filled or section removed |
 | Required fields | All required fields per `fieldSchemas` have values before create |
@@ -373,7 +373,7 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 
 ## DO NOT
 
-- Use ADF format — always `contentFormat: "markdown"` and `responseContentFormat: "markdown"`
+- Post comments with `contentFormat: "markdown"` — always convert to ADF via `markdown-to-adf.js` first and use `contentFormat: "adf"`
 - Call `getAccessibleAtlassianResources` after cache init — use cached `cloudId`
 - Call `getJiraIssueTypeMetaWithFields` after cache init — use cached `fieldSchemas`
 - Call `getIssueLinkTypes` after cache init — use cached `linkTypes`

--- a/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
@@ -117,6 +117,7 @@ conditionally after Step 2 classifies the operation type.
 2. Convert to ADF — resolve the lib directory and run the conversion script:
    SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
    [ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+   [ -z "$SCRIPT" ] && { echo "ERROR: markdown-to-adf.js not found"; exit 2; }
    cat <<'COMMENT_MD' | node "$SCRIPT"
    <markdown text>
    COMMENT_MD

--- a/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
@@ -4,7 +4,8 @@ Per-operation execution procedures for the `jira-sdlc` skill. This file is loade
 conditionally after Step 2 classifies the operation type.
 
 > **Universal rules — apply to EVERY MCP call:**
-> - Always pass `contentFormat: "markdown"` on calls that accept description/comment
+> - **Comments:** convert markdown to ADF via `scripts/lib/markdown-to-adf.js`, then pass `contentFormat: "adf"` with the ADF JSON body
+> - **Descriptions/create:** pass `contentFormat: "markdown"` (no conversion needed)
 > - Always pass `responseContentFormat: "markdown"` on calls that return content
 > - Always use `cloudId` from cache — never call `getAccessibleAtlassianResources` again
 > - Never guess field IDs, transition IDs, or user accountIds
@@ -113,13 +114,19 @@ conditionally after Step 2 classifies the operation type.
 
 ```
 1. Compose comment in markdown (use REFERENCE.md Section 4 safe syntax only)
-2. Call mcp__atlassian__addCommentToJiraIssue({
-     cloudId, issueKey,
-     comment: "<markdown text>",
-     contentFormat: "markdown",
+2. Convert to ADF — resolve the lib directory and run the conversion script:
+   SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
+   [ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+   cat <<'COMMENT_MD' | node "$SCRIPT"
+   <markdown text>
+   COMMENT_MD
+3. Call mcp__atlassian__addCommentToJiraIssue({
+     cloudId, issueIdOrKey,
+     commentBody: <ADF JSON from step 2>,
+     contentFormat: "adf",
      responseContentFormat: "markdown"
    })
-3. Never use HTML tags, task lists (- [ ]), or footnotes in comments
+4. Never use HTML tags, task lists (- [ ]), or footnotes in source markdown
 ```
 
 ## Link Operation

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -78,9 +78,6 @@
       value: 'contentFormat'
     - type: icontains
       value: "adf"
-    # Must NOT use contentFormat "markdown" for posting the comment
-    - type: not-icontains
-      value: 'contentFormat: "markdown"'
     # Must preserve responseContentFormat "markdown" for reading
     - type: icontains
       value: 'responseContentFormat'

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -1,6 +1,7 @@
 # Fixture appropriateness:
 #   jira-ticket-created            -- CORRECT: simulates a created Jira ticket, triggers workflow continuation
 #   jira-create-task               -- CORRECT: simulates Jira cache with project metadata for create operation
+#   jira-comment-adf               -- CORRECT: simulates Jira cache for comment operation with ADF conversion
 
 - description: "jira-sdlc: shows workflow continuation menu after Jira ticket created"
   vars:
@@ -60,3 +61,42 @@
         contentFormat: "markdown" and the cloudId from cache. It does NOT fabricate
         fields not present in the cache (no components, no custom fields unless the
         user asked). The summary matches what the user requested exactly.
+
+- description: "jira-sdlc: converts comment to ADF before posting via addCommentToJiraIssue"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-comment-adf.md"
+    user_request: >
+      Run /jira-sdlc. Add a comment to PROJ-150 with a heading, bullet list, and
+      code block summarizing test results. The Jira cache is loaded in the project context.
+  assert:
+    # Must reference the conversion script
+    - type: icontains
+      value: "markdown-to-adf"
+    # Must use contentFormat "adf" for the comment
+    - type: icontains
+      value: 'contentFormat'
+    - type: icontains
+      value: "adf"
+    # Must NOT use contentFormat "markdown" for posting the comment
+    - type: not-icontains
+      value: 'contentFormat: "markdown"'
+    # Must preserve responseContentFormat "markdown" for reading
+    - type: icontains
+      value: 'responseContentFormat'
+    # Must use correct parameter names
+    - type: icontains
+      value: "commentBody"
+    - type: icontains
+      value: "issueIdOrKey"
+    # Behavioral: follows ADF comment flow from operations-reference.md
+    - type: llm-rubric
+      value: >
+        The response follows the Comment Operation procedure for ADF conversion:
+        (1) It composes the comment in markdown using safe syntax (heading, bullet list,
+        code block). (2) It describes running the markdown-to-adf.js conversion script
+        to convert markdown to ADF JSON. (3) It calls addCommentToJiraIssue with
+        contentFormat: "adf" and the ADF JSON as commentBody (not "comment"), using
+        issueIdOrKey (not "issueKey"). (4) It uses responseContentFormat: "markdown"
+        for reading. It does NOT post raw markdown with contentFormat: "markdown" for
+        the comment. The cloudId comes from the cache.

--- a/tests/promptfoo/datasets/markdown-to-adf-exec.yaml
+++ b/tests/promptfoo/datasets/markdown-to-adf-exec.yaml
@@ -198,3 +198,17 @@
       value: '"type":"bulletList"'
     - type: icontains
       value: "# Not a heading"
+
+- description: "markdown-to-adf: --file with non-existent path exits with error"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file /tmp/does-not-exist-markdown-to-adf-test.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: "markdown-to-adf error"
+    - type: icontains
+      value: "ENOENT"
+    # Must NOT contain valid ADF output
+    - type: not-icontains
+      value: '"type":"doc"'

--- a/tests/promptfoo/datasets/markdown-to-adf-exec.yaml
+++ b/tests/promptfoo/datasets/markdown-to-adf-exec.yaml
@@ -1,0 +1,200 @@
+# Script execution tests for markdown-to-adf.js.
+# Verifies ADF output structure for each supported markdown element.
+# Runs the script with --file against fixture markdown files (no LLM).
+
+- description: "markdown-to-adf: simple paragraph"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/simple-paragraph.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"version":1'
+    - type: icontains
+      value: '"type":"doc"'
+    - type: icontains
+      value: '"type":"paragraph"'
+    - type: icontains
+      value: "simple paragraph with plain text"
+
+- description: "markdown-to-adf: headings h1-h3"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/headings.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"heading"'
+    - type: icontains
+      value: '"level":1'
+    - type: icontains
+      value: '"level":2'
+    - type: icontains
+      value: '"level":3'
+
+- description: "markdown-to-adf: bold and italic inline marks"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/bold-italic.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"strong"'
+    - type: icontains
+      value: '"type":"em"'
+    - type: icontains
+      value: "bold text"
+    - type: icontains
+      value: "italic text"
+
+- description: "markdown-to-adf: unordered list"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/unordered-list.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"bulletList"'
+    - type: icontains
+      value: '"type":"listItem"'
+    - type: icontains
+      value: "First item"
+    - type: icontains
+      value: "Third item"
+
+- description: "markdown-to-adf: ordered list"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/ordered-list.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"orderedList"'
+    - type: icontains
+      value: '"type":"listItem"'
+    - type: icontains
+      value: "First item"
+
+- description: "markdown-to-adf: fenced code block with language"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/fenced-code.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"codeBlock"'
+    - type: icontains
+      value: '"language":"javascript"'
+    - type: icontains
+      value: "const x = 1"
+
+- description: "markdown-to-adf: inline code"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/inline-code.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"code"'
+    - type: icontains
+      value: "convert()"
+
+- description: "markdown-to-adf: link"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/link.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"link"'
+    - type: icontains
+      value: '"href":"https://atlassian.com"'
+    - type: icontains
+      value: "Atlassian"
+
+- description: "markdown-to-adf: table with header row"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/table.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"table"'
+    - type: icontains
+      value: '"type":"tableHeader"'
+    - type: icontains
+      value: '"type":"tableCell"'
+    - type: icontains
+      value: "Bug fix"
+
+- description: "markdown-to-adf: blockquote"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/blockquote.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"blockquote"'
+    - type: icontains
+      value: "important information"
+
+- description: "markdown-to-adf: horizontal rule"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/horizontal-rule.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"rule"'
+    - type: icontains
+      value: "Above the rule"
+    - type: icontains
+      value: "Below the rule"
+
+- description: "markdown-to-adf: mixed realistic comment"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/mixed-realistic.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"heading"'
+    - type: icontains
+      value: '"type":"codeBlock"'
+    - type: icontains
+      value: '"type":"table"'
+    - type: icontains
+      value: '"type":"bulletList"'
+    - type: icontains
+      value: "Test Results Summary"
+
+- description: "markdown-to-adf: empty input produces minimal doc"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/empty.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"version":1'
+    - type: icontains
+      value: '"type":"doc"'
+    - type: icontains
+      value: '"type":"paragraph"'
+
+- description: "markdown-to-adf: code block preserves markdown syntax"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
+    script_args: "--file {{project_root}}/code-with-markdown.md"
+    project_root: "file://fixtures-fs/markdown-to-adf"
+  assert:
+    - type: icontains
+      value: '"type":"codeBlock"'
+    # Must NOT contain heading, strong, bulletList — code block content is literal
+    - type: not-icontains
+      value: '"type":"heading"'
+    - type: not-icontains
+      value: '"type":"strong"'
+    - type: not-icontains
+      value: '"type":"bulletList"'
+    - type: icontains
+      value: "# Not a heading"

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/blockquote.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/blockquote.md
@@ -1,0 +1,1 @@
+> This is a blockquote with important information.

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/bold-italic.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/bold-italic.md
@@ -1,0 +1,1 @@
+This has **bold text** and *italic text* together.

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/code-with-markdown.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/code-with-markdown.md
@@ -1,0 +1,6 @@
+```
+# Not a heading
+**Not bold**
+- Not a list
+> Not a blockquote
+```

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/fenced-code.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/fenced-code.md
@@ -1,0 +1,4 @@
+```javascript
+const x = 1;
+console.log(x);
+```

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/headings.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/headings.md
@@ -1,0 +1,5 @@
+# Heading 1
+
+## Heading 2
+
+### Heading 3

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/horizontal-rule.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/horizontal-rule.md
@@ -1,0 +1,5 @@
+Above the rule
+
+---
+
+Below the rule

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/inline-code.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/inline-code.md
@@ -1,0 +1,1 @@
+Use the `convert()` function to transform markdown.

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/link.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/link.md
@@ -1,0 +1,1 @@
+Visit [Atlassian](https://atlassian.com) for more info.

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/mixed-realistic.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/mixed-realistic.md
@@ -1,0 +1,15 @@
+## Test Results Summary
+
+All tests passed successfully. Key findings:
+
+- Unit tests: **42 passed**, 0 failed
+- Integration tests: **12 passed**, 0 failed
+
+```bash
+npm test -- --coverage
+```
+
+| Suite | Pass | Fail |
+| --- | --- | --- |
+| Unit | 42 | 0 |
+| Integration | 12 | 0 |

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/ordered-list.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/ordered-list.md
@@ -1,0 +1,3 @@
+1. First item
+2. Second item
+3. Third item

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/simple-paragraph.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/simple-paragraph.md
@@ -1,0 +1,1 @@
+This is a simple paragraph with plain text.

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/table.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/table.md
@@ -1,0 +1,4 @@
+| Name | Status | Priority |
+| --- | --- | --- |
+| Bug fix | Done | High |
+| Feature | In Progress | Medium |

--- a/tests/promptfoo/fixtures-fs/markdown-to-adf/unordered-list.md
+++ b/tests/promptfoo/fixtures-fs/markdown-to-adf/unordered-list.md
@@ -1,0 +1,3 @@
+- First item
+- Second item
+- Third item

--- a/tests/promptfoo/fixtures/jira-comment-adf.md
+++ b/tests/promptfoo/fixtures/jira-comment-adf.md
@@ -1,0 +1,34 @@
+# Jira Project Context
+
+## Cache (from jira-prepare.js)
+```json
+{
+  "project": "PROJ",
+  "cloudId": "abc-123-def-456",
+  "issueTypes": ["Bug", "Story", "Task", "Sub-task", "Epic"],
+  "fieldSchemas": {
+    "Task": {
+      "summary": { "required": true, "type": "string" },
+      "description": { "required": false, "type": "string" },
+      "priority": {
+        "required": false,
+        "type": "priority",
+        "allowedValues": [
+          { "name": "Highest" },
+          { "name": "High" },
+          { "name": "Medium" },
+          { "name": "Low" },
+          { "name": "Lowest" }
+        ]
+      }
+    }
+  },
+  "workflows": {},
+  "linkTypes": [],
+  "userMappings": {}
+}
+```
+
+## Issue Context
+Issue PROJ-150 exists and is a Task currently in "In Progress" status.
+The user wants to add a comment to this issue.

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -29,3 +29,4 @@ tests:
   - file://datasets/plan-format-exec.yaml
   - file://datasets/hook-git-guard-exec.yaml
   - file://datasets/hook-error-report-exec.yaml
+  - file://datasets/markdown-to-adf-exec.yaml

--- a/tests/promptfoo/providers/script-runner.js
+++ b/tests/promptfoo/providers/script-runner.js
@@ -32,10 +32,11 @@ class ScriptRunnerProvider {
       });
       return { output: stdout };
     } catch (err) {
-      // Include stdout even on non-zero exit (scripts may print to stdout before erroring)
+      // Include stdout + stderr on non-zero exit so assertions can check error messages
+      const stdout = err.stdout ?? '';
+      const stderr = err.stderr ?? err.message;
       return {
-        output: err.stdout ?? '',
-        error: err.stderr ?? err.message,
+        output: [stdout, stderr].filter(Boolean).join('\n'),
       };
     }
   }


### PR DESCRIPTION
## Summary
Adds markdown-to-ADF conversion so that comments posted to Jira through jira-sdlc use Atlassian Document Format instead of raw markdown, fixing rendering issues with bold, italic, code blocks, tables, and other markup in Jira comment bodies.

## Business Context
Jira's comment API renders raw markdown inconsistently — formatting like bold, tables, and code blocks often appears broken. This forces users to manually reformat comments after posting, negating the automation benefits of jira-sdlc.

## Business Benefits
Comments posted by jira-sdlc now render correctly in Jira with proper formatting for headings, lists, tables, code blocks, links, and inline styles. Users no longer need to manually fix comment formatting after automated posting.

## Github Issue
Fixes #154

## Technical Design
Introduces a zero-dependency Node.js script (`markdown-to-adf.js`) that converts markdown to ADF v1 JSON using a line-by-line state machine parser with inline tokenization. The script supports CLI mode (stdin/stdout and `--file` flag) and programmatic API (`require` + `convert()`). The jira-sdlc skill now pipes comment markdown through this converter before calling `addCommentToJiraIssue` with `contentFormat: "adf"`. Issue creation and description updates continue using `contentFormat: "markdown"` since Jira handles those differently.

## Technical Impact
The `addCommentToJiraIssue` call signature changes from `contentFormat: "markdown"` to `contentFormat: "adf"` with a pre-converted ADF body. No breaking changes to the skill's user-facing interface — the conversion is transparent. Read operations remain unchanged (`responseContentFormat: "markdown"`).

## Changes Overview
- Markdown-to-ADF converter supporting headings, bold, italic, inline code, fenced code blocks, lists, tables, blockquotes, links, and horizontal rules
- jira-sdlc skill updated to convert comments to ADF before posting, with script resolution guards for the converter
- Spec requirement R12 added defining the ADF conversion contract for comments
- Quality gate G2 and constraint C1 updated to reflect the split: ADF for comments, markdown for descriptions
- Comprehensive promptfoo execution test suite with 14 markdown fixture files covering edge cases (empty input, code blocks with embedded markdown, mixed realistic content)
- Behavioral test case added for ADF comment posting flow
- Script runner updated with improved stderr handling for error test cases

## Testing
Tested via promptfoo execution tests (`markdown-to-adf-exec.yaml`) covering 14 fixture scenarios: simple paragraphs, headings, bold/italic, inline code, fenced code blocks, ordered and unordered lists, tables, blockquotes, links, horizontal rules, mixed realistic content, code with embedded markdown, and empty input. Error handling tested with a non-existent file input case. Behavioral test case added for the Jira comment ADF conversion flow.