### PR TITLE
fix(#156): ci - rename scripts from .js to .cjs for ESM compatibility

### DIFF
--- a/.github/scripts/check-changelog.cjs
+++ b/.github/scripts/check-changelog.cjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * check-changelog.js
+ * check-changelog.cjs
  * CI script: validates that CHANGELOG.md contains an entry for the current version.
  *
  * Only runs when `changelog: true` is set in `.claude/version.json`.
  * Designed to be copied into user projects under `.github/scripts/`.
  *
  * Usage (GitHub Actions — runs on push to main or in a PR check):
- *   node .github/scripts/check-changelog.js
+ *   node .github/scripts/check-changelog.cjs
  *
  * Reads: .claude/version.json  (sdlc versioning config)
  * Modes:
@@ -21,8 +21,8 @@
 
 'use strict';
 
-/** @version 2 — check-changelog script version. Bump when behavior changes. */
-const CHECK_CHANGELOG_SCRIPT_VERSION = 2;
+/** @version 3 — check-changelog script version. Bump when behavior changes (e.g. .cjs rename for ESM compat). */
+const CHECK_CHANGELOG_SCRIPT_VERSION = 3;
 
 const fs   = require('node:fs');
 const path = require('node:path');
@@ -184,7 +184,7 @@ function main() {
 try {
   main();
 } catch (err) {
-  process.stderr.write(`Unexpected error in check-changelog.js: ${err.message}\n${err.stack}\n`);
+  process.stderr.write(`Unexpected error in check-changelog.cjs: ${err.message}\n${err.stack}\n`);
   process.exit(2);
 }
 

--- a/.github/scripts/check-version-bump.cjs
+++ b/.github/scripts/check-version-bump.cjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 /**
- * check-version-bump.js
+ * check-version-bump.cjs
  * CI script: verifies that modified plugins have their version bumped.
  *
  * Usage:
- *   node check-version-bump.js [--base <ref>]
+ *   node check-version-bump.cjs [--base <ref>]
  *
  * Environment variables (set by GitHub Actions):
  *   BASE_REF  — base commit SHA (from PR base)
@@ -112,7 +112,7 @@ function main() {
 
   if (!baseRef) {
     process.stderr.write('Error: BASE_REF environment variable or --base argument required\n');
-    process.stderr.write('Usage: node check-version-bump.js --base <ref>\n');
+    process.stderr.write('Usage: node check-version-bump.cjs --base <ref>\n');
     process.exit(2);
   }
 

--- a/.github/scripts/retag-release.cjs
+++ b/.github/scripts/retag-release.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * retag-release.js
+ * retag-release.cjs
  * CI script: ensures the current version's git tag points to HEAD on the main branch.
  *
  * Fixes orphaned tags that result from squash-merging a release branch:
@@ -8,7 +8,7 @@
  * unreachable from main after squash. This script moves it to HEAD.
  *
  * Usage (GitHub Actions — runs on push to main):
- *   node .github/scripts/retag-release.js
+ *   node .github/scripts/retag-release.cjs
  *
  * Reads: .claude/version.json  (sdlc versioning config)
  * Modes:
@@ -22,8 +22,8 @@
 
 'use strict';
 
-/** @version 4 — retag script version. Bump when behavior changes (e.g. message preservation). */
-const RETAG_SCRIPT_VERSION = 4;
+/** @version 5 — retag script version. Bump when behavior changes (e.g. .cjs rename for ESM compat). */
+const RETAG_SCRIPT_VERSION = 5;
 
 const fs   = require('node:fs');
 const path = require('node:path');

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,4 +1,4 @@
-# check-changelog-version: 1
+# check-changelog-version: 2
 name: Validate Changelog Entry
 
 on:
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
 
       - name: Check changelog entry for current version
-        run: node .github/scripts/check-changelog.js
+        run: node .github/scripts/check-changelog.cjs

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Check version bumps
         if: steps.skip-check.outputs.skip != 'true'
-        run: node .github/scripts/check-version-bump.js
+        run: node .github/scripts/check-version-bump.cjs
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/retag-release.yml
+++ b/.github/workflows/retag-release.yml
@@ -1,4 +1,4 @@
-# retag-release-version: 3
+# retag-release-version: 4
 name: Re-tag Release on Main
 
 on:
@@ -22,4 +22,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Re-tag release commit
-        run: node .github/scripts/retag-release.js
+        run: node .github/scripts/retag-release.cjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.17] - 2026-04-12
+
+### Fixed
+- CI scripts renamed from `.js` to `.cjs` to prevent ESM/CommonJS namespace collision when consumer repos use `"type": "module"` (#156)
+
 ## [0.17.16] - 2026-04-12
 
 ### Added

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -257,7 +257,7 @@ uses a literal `[ -f "..." ]` check with no globbing — impossible to corrupt.
 
 ## Version Bump Enforcement
 
-The CI workflow (`.github/scripts/check-version-bump.js`) automatically enforces
+The CI workflow (`.github/scripts/check-version-bump.cjs`) automatically enforces
 version bumps on pull requests:
 
 1. Reads `.claude-plugin/marketplace.json` to discover all plugins

--- a/docs/skills/version-sdlc.md
+++ b/docs/skills/version-sdlc.md
@@ -311,7 +311,7 @@ The automated changelog is a **draft**, not a source of truth. Squash merges, pa
 1. Merge to main
 2. `git checkout main && git pull`
 3. Run `/version-sdlc --changelog` to reconcile the changelog with the actual tag-to-tag commits
-4. The CI `check-changelog.js` (scaffolded during `--init` when changelog is enabled) validates that an entry exists on every push to main
+4. The CI `check-changelog.cjs` (scaffolded during `--init` when changelog is enabled) validates that an entry exists on every push to main
 
 ## Related Skills
 

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -40,6 +40,7 @@
 - R17: Deferred review findings (medium/low) collected and displayed in final summary
 - R18: Ship config is optional and developer-local (`.sdlc/local.json`); pipeline runs with built-in defaults
 - R19: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R20: `--auto` suppresses pipeline pauses: when `--auto` is active, `pause` must be `false` for every step that accepts `--auto` (per R7 forwarding audit: commit-sdlc, received-review-sdlc, version-sdlc, pr-sdlc). The sub-skill's consent gate is skipped via the forwarded flag, so the pipeline has no reason to pause at that step.
 
 ## Workflow Phases
 

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -114,4 +114,4 @@
 - I3: `commit-sdlc` — can be invoked when uncommitted changes need committing first
 - I4: `jira-sdlc` — common follow-up to update ticket status after release
 - I5: `retag-release.yml` — CI workflow scaffolded during init to handle squash-merge tag relocation
-- I6: `ci/check-changelog.js` — CI script scaffolded during init to validate changelog presence
+- I6: `ci/check-changelog.cjs` — CI script scaffolded during init to validate changelog presence

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.16",
+  "version": "0.17.17",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/ci/check-changelog.cjs
+++ b/plugins/sdlc-utilities/scripts/ci/check-changelog.cjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * check-changelog.js
+ * check-changelog.cjs
  * CI script: validates that CHANGELOG.md contains an entry for the current version.
  *
  * Only runs when `changelog: true` is set in `.claude/version.json`.
  * Designed to be copied into user projects under `.github/scripts/`.
  *
  * Usage (GitHub Actions — runs on push to main or in a PR check):
- *   node .github/scripts/check-changelog.js
+ *   node .github/scripts/check-changelog.cjs
  *
  * Reads: .claude/version.json  (sdlc versioning config)
  * Modes:
@@ -21,8 +21,8 @@
 
 'use strict';
 
-/** @version 2 — check-changelog script version. Bump when behavior changes. */
-const CHECK_CHANGELOG_SCRIPT_VERSION = 2;
+/** @version 3 — check-changelog script version. Bump when behavior changes (e.g. .cjs rename for ESM compat). */
+const CHECK_CHANGELOG_SCRIPT_VERSION = 3;
 
 const fs   = require('node:fs');
 const path = require('node:path');
@@ -184,7 +184,7 @@ function main() {
 try {
   main();
 } catch (err) {
-  process.stderr.write(`Unexpected error in check-changelog.js: ${err.message}\n${err.stack}\n`);
+  process.stderr.write(`Unexpected error in check-changelog.cjs: ${err.message}\n${err.stack}\n`);
   process.exit(2);
 }
 

--- a/plugins/sdlc-utilities/scripts/ci/retag-release.cjs
+++ b/plugins/sdlc-utilities/scripts/ci/retag-release.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * retag-release.js
+ * retag-release.cjs
  * CI script: ensures the current version's git tag points to HEAD on the main branch.
  *
  * Fixes orphaned tags that result from squash-merging a release branch:
@@ -8,7 +8,7 @@
  * unreachable from main after squash. This script moves it to HEAD.
  *
  * Usage (GitHub Actions — runs on push to main):
- *   node .github/scripts/retag-release.js
+ *   node .github/scripts/retag-release.cjs
  *
  * Reads: .claude/version.json  (sdlc versioning config)
  * Modes:
@@ -22,8 +22,8 @@
 
 'use strict';
 
-/** @version 4 — retag script version. Bump when behavior changes (e.g. message preservation). */
-const RETAG_SCRIPT_VERSION = 4;
+/** @version 5 — retag script version. Bump when behavior changes (e.g. .cjs rename for ESM compat). */
+const RETAG_SCRIPT_VERSION = 5;
 
 const fs   = require('node:fs');
 const path = require('node:path');

--- a/plugins/sdlc-utilities/scripts/util/scaffold-ci.js
+++ b/plugins/sdlc-utilities/scripts/util/scaffold-ci.js
@@ -41,8 +41,9 @@ const PLUGIN_ROOT = path.resolve(__dirname, '..', '..');
  */
 const MANIFEST = [
   {
-    src:  path.join('scripts', 'ci', 'retag-release.js'),
-    dest: path.join('.github', 'scripts', 'retag-release.js'),
+    src:  path.join('scripts', 'ci', 'retag-release.cjs'),
+    dest: path.join('.github', 'scripts', 'retag-release.cjs'),
+    legacyDest: path.join('.github', 'scripts', 'retag-release.js'),
     versionRegex: /const\s+RETAG_SCRIPT_VERSION\s*=\s*(\d+)/,
     versionConst: 'RETAG_SCRIPT_VERSION',
     group: 'retag',
@@ -55,8 +56,9 @@ const MANIFEST = [
     group: 'retag',
   },
   {
-    src:  path.join('scripts', 'ci', 'check-changelog.js'),
-    dest: path.join('.github', 'scripts', 'check-changelog.js'),
+    src:  path.join('scripts', 'ci', 'check-changelog.cjs'),
+    dest: path.join('.github', 'scripts', 'check-changelog.cjs'),
+    legacyDest: path.join('.github', 'scripts', 'check-changelog.js'),
     versionRegex: /const\s+CHECK_CHANGELOG_SCRIPT_VERSION\s*=\s*(\d+)/,
     versionConst: 'CHECK_CHANGELOG_SCRIPT_VERSION',
     group: 'changelog',
@@ -122,19 +124,28 @@ function main() {
     const srcContent = fs.readFileSync(srcPath, 'utf8');
     const currentVersion = extractVersion(srcContent, entry.versionRegex);
 
-    // Check destination
+    // Check destination (and legacy path for .js → .cjs migration)
     const destExists = fs.existsSync(destPath);
+    const legacyPath = entry.legacyDest ? path.join(projectRoot, entry.legacyDest) : null;
+    const legacyExists = legacyPath ? fs.existsSync(legacyPath) : false;
     let installedVersion = null;
     let action = 'none';
 
     if (destExists) {
       const destContent = fs.readFileSync(destPath, 'utf8');
       installedVersion = extractVersion(destContent, entry.versionRegex);
+    } else if (legacyExists) {
+      // Legacy .js file present but new .cjs file missing — read version from legacy
+      const legacyContent = fs.readFileSync(legacyPath, 'utf8');
+      installedVersion = extractVersion(legacyContent, entry.versionRegex);
     }
 
     if (cli.checkOnly) {
       // Report-only mode
-      if (!destExists) {
+      if (!destExists && legacyExists) {
+        action = 'outdated';
+        warnings.push(`Legacy file found: ${entry.legacyDest} → will be replaced by ${entry.dest}`);
+      } else if (!destExists) {
         action = 'missing';
       } else if (installedVersion < currentVersion) {
         action = 'outdated';
@@ -143,7 +154,14 @@ function main() {
       }
     } else {
       // Write mode
-      if (!destExists) {
+      if (!destExists && legacyExists && cli.force) {
+        // Migration: delete legacy .js, install new .cjs
+        fs.unlinkSync(legacyPath);
+        action = 'migrated';
+      } else if (!destExists && legacyExists) {
+        action = 'outdated';
+        warnings.push(`Legacy file found: ${entry.legacyDest} → use --force to migrate to ${entry.dest}`);
+      } else if (!destExists) {
         action = 'created';
       } else if (cli.force) {
         action = 'overwritten';
@@ -154,7 +172,7 @@ function main() {
         action = 'skipped';
       }
 
-      if (action === 'created' || action === 'overwritten') {
+      if (action === 'created' || action === 'overwritten' || action === 'migrated') {
         const destDir = path.dirname(destPath);
         if (!fs.existsSync(destDir)) {
           fs.mkdirSync(destDir, { recursive: true });

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -350,9 +350,9 @@ The automated changelog is a **draft, not a source of truth**. Correctness is th
 
 ### Mitigation: 4-Layer Defense
 
-1. **CI validates presence** — `check-changelog.js` (scaffolded during init when changelog is enabled) fails on push to main if no `## [version]` heading exists. Ensures at least a placeholder entry.
+1. **CI validates presence** — `check-changelog.cjs` (scaffolded during init when changelog is enabled) fails on push to main if no `## [version]` heading exists. Ensures at least a placeholder entry.
 2. **`/version-sdlc --changelog` on main** — After merge, switch to main and run this command. It re-derives the changelog from the actual `previousTag..currentTag` range (not the feature branch), shows a diff against the existing entry, and lets you approve or edit the update without creating a new tag.
-3. **Retag script advisory** — After retagging, `retag-release.js` prints a warning if `changelog: true` and no entry exists for the tag. Reminds developers to verify.
+3. **Retag script advisory** — After retagging, `retag-release.cjs` prints a warning if `changelog: true` and no entry exists for the tag. Reminds developers to verify.
 4. **Manual review** — Before release communications, treat the CHANGELOG as a draft to review, not a finished document.
 
 ## Learning Capture

--- a/plugins/sdlc-utilities/skills/version-sdlc/init-workflow.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/init-workflow.md
@@ -68,9 +68,9 @@ Display:
 ```
 ✓ .claude/sdlc.json → version section written.
 ✓ .github/workflows/retag-release.yml added (auto-fixes tags after squash merge to main).
-✓ .github/scripts/retag-release.js added.
+✓ .github/scripts/retag-release.cjs added.
 ✓ .github/workflows/check-changelog.yml added (validates changelog entry exists after each push to main).
-✓ .github/scripts/check-changelog.js added.
+✓ .github/scripts/check-changelog.cjs added.
 Run /version-sdlc patch to create your first release.
 ```
 
@@ -88,7 +88,7 @@ Read the JSON output. If any files have `action: "outdated"`:
 
 ```
 ⚠  Outdated CI files detected:
-   .github/scripts/retag-release.js   (installed: v<N>, current: v<M>)
+   .github/scripts/retag-release.cjs   (installed: v<N>, current: v<M>)
 
 Update these files? (yes / no)
 ```

--- a/plugins/sdlc-utilities/templates/check-changelog.yml
+++ b/plugins/sdlc-utilities/templates/check-changelog.yml
@@ -1,4 +1,4 @@
-# check-changelog-version: 1
+# check-changelog-version: 2
 name: Validate Changelog Entry
 
 on:
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
 
       - name: Check changelog entry for current version
-        run: node .github/scripts/check-changelog.js
+        run: node .github/scripts/check-changelog.cjs

--- a/plugins/sdlc-utilities/templates/retag-release.yml
+++ b/plugins/sdlc-utilities/templates/retag-release.yml
@@ -1,4 +1,4 @@
-# retag-release-version: 3
+# retag-release-version: 4
 name: Re-tag Release on Main
 
 on:
@@ -22,4 +22,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Re-tag release commit
-        run: node .github/scripts/retag-release.js
+        run: node .github/scripts/retag-release.cjs

--- a/site/src/content-source/plugin-installation.md
+++ b/site/src/content-source/plugin-installation.md
@@ -257,7 +257,7 @@ uses a literal `[ -f "..." ]` check with no globbing — impossible to corrupt.
 
 ## Version Bump Enforcement
 
-The CI workflow (`.github/scripts/check-version-bump.js`) automatically enforces
+The CI workflow (`.github/scripts/check-version-bump.cjs`) automatically enforces
 version bumps on pull requests:
 
 1. Reads `.claude-plugin/marketplace.json` to discover all plugins

--- a/site/src/content-source/skills/version-sdlc.md
+++ b/site/src/content-source/skills/version-sdlc.md
@@ -311,7 +311,7 @@ The automated changelog is a **draft**, not a source of truth. Squash merges, pa
 1. Merge to main
 2. `git checkout main && git pull`
 3. Run `/version-sdlc --changelog` to reconcile the changelog with the actual tag-to-tag commits
-4. The CI `check-changelog.js` (scaffolded during `--init` when changelog is enabled) validates that an entry exists on every push to main
+4. The CI `check-changelog.cjs` (scaffolded during `--init` when changelog is enabled) validates that an entry exists on every push to main
 
 ## Related Skills
 

--- a/tests/promptfoo/fixtures/project-changelog-update.md
+++ b/tests/promptfoo/fixtures/project-changelog-update.md
@@ -30,7 +30,7 @@ src/
 - Current version: **1.3.0** (already tagged as v1.3.0)
 - Previous version: **1.2.0** (tagged as v1.2.0)
 - The release was tagged on the feature branch before a late fix was added
-- After squash-merge, v1.3.0 tag was moved to the squash commit by retag-release.js
+- After squash-merge, v1.3.0 tag was moved to the squash commit by retag-release.cjs
 
 ## Existing CHANGELOG.md (partial)
 


### PR DESCRIPTION
## Summary

Renames all CI scripts from `.js` to `.cjs` so the plugin works correctly in consumer repos that set `"type": "module"` in their `package.json`, preventing ESM/CommonJS namespace collisions. Also adds ship-sdlc spec requirement R20 for `--auto` pipeline pause suppression.

## Business Context

Consumer projects adopting ESM (`"type": "module"`) encounter runtime errors when Node.js attempts to parse the plugin's `require()`-based CI scripts as ES modules. This blocks adoption for any team using modern ESM-first tooling.

## Business Benefits

Plugin users with ESM-configured repos can now install and run CI workflows without manual file extension workarounds. The scaffold utility also gains migration support, automatically detecting and replacing legacy `.js` scripts during init.

## Github Issue

https://github.com/rnagrodzki/sdlc-marketplace/issues/156

## Technical Design

All CI scripts (`check-changelog`, `check-version-bump`, `retag-release`) are renamed from `.js` to `.cjs` to force CommonJS parsing regardless of the consumer's `package.json` type field. Script version constants are bumped to reflect the behavioral change. The `scaffold-ci.js` utility gains a `legacyDest` field per manifest entry and migration logic: in `--check-only` mode it warns about legacy files; in write mode with `--force` it deletes the old `.js` file and installs the new `.cjs` replacement. GitHub Actions workflow files are updated to reference the new `.cjs` filenames, with workflow version comments bumped accordingly.

## Technical Impact

CI workflow YAML files reference new script filenames — repos that have already scaffolded these workflows will need to run `scaffold-ci --force` to migrate. The scaffold utility handles this automatically when invoked. No breaking changes to skill interfaces, hook payloads, or plugin APIs.

## Changes Overview

- CI scripts renamed from `.js` to `.cjs` extension with internal version constant bumps to signal the behavioral change
- GitHub Actions workflows updated to invoke `.cjs` scripts, with workflow version comments incremented
- Scaffold utility extended with legacy file detection and `--force` migration path that removes old `.js` files and installs `.cjs` replacements
- Documentation across skill docs, specs, site content, and installation guide updated to reference `.cjs` filenames
- Ship-sdlc spec updated with requirement R20 defining `--auto` pause suppression behavior
- Test fixture updated to reflect the `.cjs` rename in changelog verification context

## Testing

Changes are structural renames with version bumps — verified through CI workflow execution on the branch. The scaffold migration logic follows existing patterns with the added `legacyDest` field and conditional branching. Promptfoo test fixture updated to maintain consistency.