### PR TITLE
fix(#159): pipeline-contract - enforcement and per-step model routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.18] - 2026-04-13
+
+### Fixed
+- Pipeline step cleanup now validates all steps reach a terminal state (completed, skipped, or failed), with violations surfaced as JSON for debugging (#159)
+- Per-step model routing assigned across the ship pipeline — subagents now use the correct model for each step rather than defaulting to opus (#159)
+
 ## [0.17.17] - 2026-04-12
 
 ### Fixed

--- a/docs/specs/execute-plan-sdlc.md
+++ b/docs/specs/execute-plan-sdlc.md
@@ -108,6 +108,7 @@
 - C9: Must not write state files for small-plan direct execution (≤3 tasks)
 - C10: Must not auto-override error-severity guardrail violations in `--auto` mode
 - C11: Must not evaluate warning-severity guardrails pre-wave — warnings are post-wave only
+- C15: Every Agent dispatch MUST include the `model:` parameter per the preset mapping (R2). Omitting `model:` causes the agent to inherit the parent model (opus), violating cost targets.
 
 ## Integration
 

--- a/docs/specs/execute-plan-sdlc.md
+++ b/docs/specs/execute-plan-sdlc.md
@@ -108,7 +108,7 @@
 - C9: Must not write state files for small-plan direct execution (≤3 tasks)
 - C10: Must not auto-override error-severity guardrail violations in `--auto` mode
 - C11: Must not evaluate warning-severity guardrails pre-wave — warnings are post-wave only
-- C15: Every Agent dispatch MUST include the `model:` parameter per the preset mapping (R2). Omitting `model:` causes the agent to inherit the parent model (opus), violating cost targets.
+- C12: Every Agent dispatch MUST include the `model:` parameter per the preset mapping (R2). Omitting `model:` causes the agent to inherit the parent model (opus), violating cost targets.
 
 ## Integration
 

--- a/docs/specs/review-sdlc.md
+++ b/docs/specs/review-sdlc.md
@@ -71,10 +71,10 @@
 - C3: Must not invoke the orchestrator via the Skill tool — must use Agent tool
 - C4: Must not invoke error-report-sdlc for user errors — only for script crashes (exit 2) and repeated orchestrator failures
 - C5: Orchestrator MUST pass `manifest.subagent_model` to each dimension subagent Agent dispatch via the `model:` parameter
-- C5: Must not skip, bypass, or defer prepare script execution — the script must run and exit successfully before any skill phase begins
-- C6: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
-- C7: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
-- C8: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
+- C6: Must not skip, bypass, or defer prepare script execution — the script must run and exit successfully before any skill phase begins
+- C7: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
+- C8: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
+- C9: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 
 ## Step-Emitter Contract
 

--- a/docs/specs/review-sdlc.md
+++ b/docs/specs/review-sdlc.md
@@ -55,6 +55,7 @@
 - P6: `plan_critique.uncovered_files` (string[]) — files not covered by any dimension
 - P7: `plan_critique.over_broad_dimensions` (string[]) — dimensions reviewing too many files
 - P8: `plan_critique.uncovered_suggestions` (array) — suggested additional dimensions
+- P9: `subagent_model` (string) — model for dimension subagent dispatch (default: `"sonnet"`)
 
 ## Error Handling
 
@@ -69,6 +70,7 @@
 - C2: Must not read REFERENCE.md in main context (orchestrator resolves it)
 - C3: Must not invoke the orchestrator via the Skill tool — must use Agent tool
 - C4: Must not invoke error-report-sdlc for user errors — only for script crashes (exit 2) and repeated orchestrator failures
+- C5: Orchestrator MUST pass `manifest.subagent_model` to each dimension subagent Agent dispatch via the `model:` parameter
 - C5: Must not skip, bypass, or defer prepare script execution — the script must run and exit successfully before any skill phase begins
 - C6: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
 - C7: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -30,7 +30,7 @@
 - R7: `--auto` forwarding audit: only forwarded to commit-sdlc, received-review-sdlc, version-sdlc, pr-sdlc (not execute-plan-sdlc, not review-sdlc)
 - R8: Staging gap between execute and commit: `git add -A -- ':!.sdlc/'` required
 - R9: Rebase onto default branch after all commits, before version step; abort and pause on conflict
-- R10: State persistence after each step via `state/ship.js`; cleanup on success, preserve on failure
+- R10: State persistence after each step via `state/ship.js`; cleanup validates pipeline contract before deleting state; state preserved on validation failure
 - R11: Resume via `--resume`: re-enter worktree if applicable, continue from first incomplete step
 - R12: Version step auto-skipped in worktree mode (tags are repo-global); advisory printed post-pipeline
 - R13: Worktree PRs auto-label `skip-version-check` when version auto-skipped
@@ -67,6 +67,7 @@
 - G4: At least one step will run — pipeline is not entirely skipped
 - G5: Flag coherence — `--bump` without version step produces error (exit code 1, blocking)
 - G6: Pipeline contract — every `will_run` step was dispatched as Agent
+- G6a: Pipeline completion gate — `state/ship.js cleanup` validates all steps are in terminal state (`completed`, `skipped`, or `failed`) before deleting the state file. Steps still `pending` or `in_progress` cause cleanup to refuse deletion and exit 1.
 - G7: Staging gap filled — `git add -A -- ':!.sdlc/'` ran between execute and commit
 - G8: Rebase attempted — rebase ran after commits, before version (when applicable)
 
@@ -78,6 +79,7 @@
 - P4: `steps` (array) — pipeline steps, each with `{ skill, status, reason, skipSource, args, invocation, pause }`
 - P5: `steps[].invocation` (string) — exact skill name + computed args for Agent dispatch
 - P6: `config` (object | null) — ship config from `.sdlc/local.json` or null if absent
+- P7: `steps[].model` (string) — model for Agent dispatch per step, computed from skill specs (e.g., `"sonnet"` for review-sdlc, `"haiku"` for commit-sdlc)
 
 ## Error Handling
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.17",
+  "version": "0.17.18",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/review-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/review-orchestrator.md
@@ -107,7 +107,7 @@ For each dimension with `status: "ACTIVE"` or `status: "TRUNCATED"`:
      {end for}
      ```
 
-3. Dispatch via Agent tool (subagent_type: general-purpose)
+3. Dispatch via Agent tool (subagent_type: general-purpose, model: manifest.subagent_model)
 
 **Dispatch ALL active dimensions in a SINGLE message** (multiple Agent tool calls in
 one response). Do not dispatch one at a time.
@@ -230,3 +230,4 @@ Before returning:
 ## DO NOT
 
 - Post the review comment to a PR via `gh api` without explicit user approval
+- Dispatch dimension subagents without `model: manifest.subagent_model` — omitting it defaults to opus

--- a/plugins/sdlc-utilities/scripts/skill/review.js
+++ b/plugins/sdlc-utilities/scripts/skill/review.js
@@ -533,6 +533,7 @@ function main() {
   const manifest = {
     version:        1,
     timestamp:      new Date().toISOString(),
+    subagent_model: 'sonnet',
     scope,
     base_branch:    base || null,
     current_branch: gitState.currentBranch,

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -233,6 +233,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'execute',
       skill: 'execute-plan-sdlc',
+      model: 'opus',
       status: (!flags.hasPlan || skipSet.has('execute')) ? 'skipped' : 'will_run',
       skipSource: !flags.hasPlan && !skipSet.has('execute')
         ? 'none'
@@ -254,6 +255,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'commit',
       skill: 'commit-sdlc',
+      model: 'haiku',
       status: skipSet.has('commit') ? 'skipped' : 'will_run',
       skipSource: skipSource('commit'),
       args: flags.auto ? '--auto' : '',
@@ -263,6 +265,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'review',
       skill: 'review-sdlc',
+      model: 'sonnet',
       status: skipSet.has('review') ? 'skipped' : 'will_run',
       skipSource: skipSource('review'),
       args: '--committed',
@@ -272,6 +275,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'received-review',
       skill: 'received-review-sdlc',
+      model: 'sonnet',
       status: 'conditional',
       skipSource: 'none',
       args: flags.auto ? '--auto' : '',
@@ -281,6 +285,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'commit-fixes',
       skill: 'commit-sdlc',
+      model: 'haiku',
       status: 'conditional',
       skipSource: 'none',
       args: flags.auto ? '--auto' : '',
@@ -290,6 +295,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'version',
       skill: 'version-sdlc',
+      model: 'sonnet',
       status: (skipSet.has('version') || flags.workspace === 'worktree') ? 'skipped' : 'will_run',
       skipSource: skipSet.has('version')
         ? skipSource('version')
@@ -310,6 +316,7 @@ function computeSteps(flags, flagSources) {
     {
       name: 'pr',
       skill: 'pr-sdlc',
+      model: 'sonnet',
       status: skipSet.has('pr') ? 'skipped' : 'will_run',
       skipSource: skipSource('pr'),
       args: [

--- a/plugins/sdlc-utilities/scripts/state/ship.js
+++ b/plugins/sdlc-utilities/scripts/state/ship.js
@@ -310,7 +310,30 @@ function cmdCleanup(opts) {
     process.exit(0);
   }
 
+  // Validate pipeline contract: no step should be pending or in_progress at cleanup
+  const violations = [];
+  for (const step of (found.data.steps || [])) {
+    if (step.status === 'pending' || step.status === 'in_progress') {
+      violations.push({ step: step.name, status: step.status });
+    }
+  }
+
+  if (violations.length > 0) {
+    const result = {
+      valid: false,
+      violations: violations.map(v => ({
+        step: v.step,
+        actualStatus: v.status,
+        message: `Step "${v.step}" has status "${v.status}" — expected completed, skipped, or failed`
+      }))
+    };
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.stderr.write(`Pipeline contract violation: ${violations.length} step(s) not in terminal state. State file preserved.\n`);
+    process.exit(1);
+  }
+
   deleteState(found.filePath);
+  process.stdout.write(JSON.stringify({ valid: true, cleaned: true }, null, 2) + '\n');
   process.exit(0);
 }
 

--- a/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
@@ -296,6 +296,7 @@ Options:
 - Expected deliverable: what changed + how to verify
 - For complex tasks: brief summary of relevant changes from prior waves
 - **Model**: pass `model: "<assigned-model>"` to the Agent tool (haiku, sonnet, or opus per the selected preset)
+  **This is REQUIRED on every dispatch — no exceptions.** Omitting `model:` causes the agent to inherit the parent model (opus), defeating the preset system. Before sending any Agent dispatch message, verify: does every Agent call in this message include `model:`? If not, add it.
 - **Mode**: pass `mode: "bypassPermissions"` to the Agent tool on every dispatch.
 
 **5c. Collect and verify** — After all agents return:
@@ -541,6 +542,7 @@ On failure or interruption (not all tasks completed), preserve the state file. P
 - Write state files for small-plan direct execution (≤3 tasks) — they execute without waves and are fast enough to re-run
 - Auto-override error-severity guardrail violations in `--auto` mode — guardrails exist to prevent drift; always block
 - Evaluate warning-severity guardrails pre-wave — warnings are assessed post-wave against actual changes, not intent
+- Dispatch agents without the `model:` parameter — every agent dispatch must include `model: "<X>"` per the preset table. Omitting it defaults to opus, defeating the cost optimization of the preset system.
 
 ## Gotchas
 

--- a/plugins/sdlc-utilities/skills/execute-plan-sdlc/classifying-and-waving-tasks.md
+++ b/plugins/sdlc-utilities/skills/execute-plan-sdlc/classifying-and-waving-tasks.md
@@ -66,6 +66,10 @@ Always present 3 presets in Step 4, regardless of plan size:
 | **Balanced** | haiku | sonnet | opus | Default — matches complexity to capability |
 | **Quality** | sonnet | opus | opus | Codebase is unfamiliar, tasks are ambiguous |
 
+### Model Dispatch Enforcement
+
+The `model:` parameter is REQUIRED on every Agent tool dispatch — no exception. Omitting it causes the agent to inherit opus from the parent context, defeating the preset system's cost optimization.
+
 ## Wave-Building Algorithm
 
 1. **Build a dependency graph (DAG)** where an edge A → B means "task B depends on outputs from task A"

--- a/plugins/sdlc-utilities/skills/review-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/REFERENCE.md
@@ -15,6 +15,7 @@ See `EXAMPLES.md` (in this directory) for 5 copy-paste-ready example dimension f
 {
   "version": 1,
   "timestamp": "ISO-8601",
+  "subagent_model": "sonnet",
   "scope": "all",
   "base_branch": "main",
   "current_branch": "feat/xyz",

--- a/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
@@ -3,6 +3,7 @@ name: review-sdlc
 description: "Use this skill when reviewing code changes across project-defined dimensions (security, performance, docs, concurrency, etc.). Runs skill/review.js to pre-compute all git data, then delegates to the review-orchestrator agent. Arguments: [--base <branch>] [--committed] [--staged] [--working] [--worktree] [--set-default] [--dimensions <name,...>] [--dry-run]. Triggers on: review changes, code review, review PR, multi-dimension review, run review."
 user-invocable: true
 argument-hint: "[--base <branch>] [--committed] [--staged] [--dimensions <name,...>]"
+model: sonnet
 ---
 
 # Reviewing Changes

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -299,7 +299,7 @@ For each step that will run:
 
 2. **Record step start** via state/ship.js.
 
-3. **Dispatch Agent** with: skill name, args from `step.invocation`, and brief pipeline context (branch, previous step results needed for this step). Agent prompt template:
+3. **Dispatch Agent** with: skill name, args from `step.invocation`, model from `step.model`, and brief pipeline context (branch, previous step results needed for this step). Pass `model: step.model` to the Agent tool on every dispatch. Agent prompt template:
    ```
    You are executing the <skill-name> skill. Invoke `/<skill-name> <args>` using the Skill tool — this loads the SKILL.md automatically. Return a structured result:
    (1) status — success or failure
@@ -444,6 +444,20 @@ Record decisions: `node "$SCRIPT" decide --step <name> --text "<decision>"`
 Defer findings: `node "$SCRIPT" defer --severity <s> --file <f> --title "<t>"`
 
 On successful completion: `node "$SCRIPT" cleanup`
+
+If cleanup exits with code 1 (pipeline contract violation), read the JSON output. Print:
+
+```
+PIPELINE CONTRACT VIOLATION
+The following steps were not resolved:
+  - <step>: status "<status>" (expected: completed, skipped, or failed)
+
+State file preserved for debugging: <path>
+This is a pipeline bug — all will_run steps must be dispatched.
+```
+
+Do NOT proceed to the success summary. The pipeline did not complete correctly.
+
 On failure: preserve the state file for `--resume`.
 
 ---
@@ -554,6 +568,8 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 - Skip pipeline steps that were marked "will run" in the pipeline plan. The pipeline plan is a contract with the user. If a step was planned to run and the user confirmed the pipeline, it MUST run. The LLM does not have authority to skip planned steps based on its own assessment of change complexity or risk. Only the skip set and auto-skip rules (computed by skill/ship.js) control which steps run.
 - Copy example args from this document when dispatching sub-skill Agents — use the `invocation` field from the skill/ship.js output, which contains the exact computed args
 - Add `--skip` flags not present in the user's original invocation or ship config. The skip set is user/config-controlled. If skill/ship.js output shows `skipSource` as unexpected (e.g., `flags.skip.length > 0` but `flagSources.skip === 'default'`), warn before proceeding.
+- Dispatch pipeline step Agents without `model: step.model` — the model field is computed by skill/ship.js from each skill's spec. Omitting it defaults all steps to opus.
+- Ignore cleanup validation failures — if `state/ship.js cleanup` exits with code 1, the pipeline contract was violated. Surface the violation and preserve state.
 
 ---
 

--- a/tests/promptfoo/datasets/execute-plan-sdlc.yaml
+++ b/tests/promptfoo/datasets/execute-plan-sdlc.yaml
@@ -86,3 +86,22 @@
         It may mention "No execution guardrails configured" but does not show guardrail
         evaluation steps or guardrail violations. Execution flows through the standard
         wave dispatch, verification, and reporting steps.
+
+- description: "execute-plan-sdlc: model parameter required on every agent dispatch per preset"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md"
+    project_context: "file://fixtures/feature-branch-with-commits.md"
+    user_request: >
+      Run /execute-plan-sdlc --preset balanced. A plan with 5 tasks (2 Trivial, 2 Standard,
+      1 Complex) is ready. Show the wave structure with model assignments and how
+      agents will be dispatched.
+  assert:
+    - type: icontains
+      value: "model"
+    - type: regex
+      value: "(haiku|sonnet|opus)"
+    - type: llm-rubric
+      value: >
+        The response shows wave structure with explicit model assignments per task:
+        Trivial=haiku, Standard=sonnet, Complex=opus (Balanced preset). The dispatch
+        includes model: as a required parameter for each agent.

--- a/tests/promptfoo/datasets/review-sdlc.yaml
+++ b/tests/promptfoo/datasets/review-sdlc.yaml
@@ -205,6 +205,22 @@
         changed files, over 80%). It suggests tightening the dimension's trigger patterns
         to be more specific. The review plan still shows it as active, but with a warning.
 
+- description: "review-sdlc: orchestrator dispatched with model from manifest"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
+    project_context: "file://fixtures/project-with-dimensions.md"
+    user_request: >
+      Run /review-sdlc on this project. The review-prepare.js manifest includes
+      subagent_model: sonnet. Show how the orchestrator agent is dispatched.
+  assert:
+    - type: regex
+      value: "(model.*sonnet|sonnet.*model|subagent_model)"
+    - type: llm-rubric
+      value: >
+        The response describes dispatching the review-orchestrator agent. The
+        dispatch indicates that dimension subagents should use sonnet as their
+        model (via manifest.subagent_model or explicit model: sonnet).
+
 - description: "review-sdlc: approved verdict completes cleanly without fix offer"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -125,3 +125,49 @@
       value: "version step is skipped"
     - type: icontains
       value: "resolve by removing"
+
+# Pipeline completion validation (issue #159)
+
+- description: "ship-state: cleanup rejects state with pending steps"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/state/ship.js"
+    script_args: "cleanup"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-ship-state-violation"
+  assert:
+    - type: icontains
+      value: '"valid": false'
+    - type: icontains
+      value: '"pending"'
+    - type: icontains
+      value: "version"
+    - type: icontains
+      value: "contract violation"
+
+- description: "ship-state: cleanup succeeds when all steps are terminal"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/state/ship.js"
+    script_args: "cleanup"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-ship-state-valid"
+  assert:
+    - type: icontains
+      value: '"valid": true'
+    - type: icontains
+      value: '"cleaned": true'
+
+# Per-step model field (issue #160)
+
+- description: "ship-prepare: computeSteps includes model field per step"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: '"model": "opus"'
+    - type: icontains
+      value: '"model": "haiku"'
+    - type: icontains
+      value: '"model": "sonnet"'

--- a/tests/promptfoo/datasets/ship-sdlc.yaml
+++ b/tests/promptfoo/datasets/ship-sdlc.yaml
@@ -317,6 +317,27 @@
         suggestion mentions archiving the OpenSpec change and syncing delta specs.
         Both appear in the final summary, not just one of them.
 
+- description: "ship-sdlc: cleanup validation failure surfaces pipeline contract violation"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
+    project_context: "file://fixtures/ship-validation-violation.md"
+    user_request: >
+      Run /ship-sdlc. The pipeline has reached Step 6 (REPORT). Execute, commit,
+      review, and PR steps completed. The version step was planned as will_run but
+      was never executed. When cleanup runs, it exits with code 1 reporting a
+      violation. Show the Step 6 output.
+  assert:
+    - type: regex
+      value: "(CONTRACT VIOLATION|contract violation|VIOLATION|violation)"
+    - type: icontains
+      value: "version"
+    - type: llm-rubric
+      value: >
+        The response shows that cleanup detected a pipeline contract violation —
+        the version step was not resolved. A violation warning is displayed naming
+        the version step. The state file is preserved. The response does NOT
+        print a normal success summary or delete the state file.
+
 - description: "ship-sdlc: pr step includes --draft when --draft CLI flag is passed"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"

--- a/tests/promptfoo/fixtures-fs/project-ship-state-valid/.sdlc/execution/ship-test-valid-branch-20260412T120000Z.json
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-valid/.sdlc/execution/ship-test-valid-branch-20260412T120000Z.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "startedAt": "2026-04-12T12:00:00.000Z",
+  "branch": "test-valid-branch",
+  "flags": {},
+  "steps": [
+    { "name": "execute", "status": "completed", "completedAt": "2026-04-12T12:01:00.000Z" },
+    { "name": "commit", "status": "completed", "completedAt": "2026-04-12T12:02:00.000Z" },
+    { "name": "review", "status": "completed", "completedAt": "2026-04-12T12:03:00.000Z" },
+    { "name": "received-review", "status": "skipped", "reason": "no critical/high findings" },
+    { "name": "commit-fixes", "status": "skipped", "reason": "no review fixes" },
+    { "name": "version", "status": "skipped", "reason": "in skip set" },
+    { "name": "pr", "status": "completed", "completedAt": "2026-04-12T12:05:00.000Z" }
+  ],
+  "decisions": [],
+  "deferredFindings": []
+}

--- a/tests/promptfoo/fixtures-fs/project-ship-state-valid/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-valid/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git checkout -q -b test-valid-branch
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/project-ship-state-valid/src/index.js
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-valid/src/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/tests/promptfoo/fixtures-fs/project-ship-state-violation/.sdlc/execution/ship-test-violation-branch-20260412T120000Z.json
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-violation/.sdlc/execution/ship-test-violation-branch-20260412T120000Z.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "startedAt": "2026-04-12T12:00:00.000Z",
+  "branch": "test-violation-branch",
+  "flags": {},
+  "steps": [
+    { "name": "execute", "status": "completed", "completedAt": "2026-04-12T12:01:00.000Z" },
+    { "name": "commit", "status": "completed", "completedAt": "2026-04-12T12:02:00.000Z" },
+    { "name": "review", "status": "completed", "completedAt": "2026-04-12T12:03:00.000Z" },
+    { "name": "received-review", "status": "skipped", "reason": "no critical/high findings" },
+    { "name": "commit-fixes", "status": "skipped", "reason": "no review fixes" },
+    { "name": "version", "status": "pending" },
+    { "name": "pr", "status": "completed", "completedAt": "2026-04-12T12:05:00.000Z" }
+  ],
+  "decisions": [],
+  "deferredFindings": []
+}

--- a/tests/promptfoo/fixtures-fs/project-ship-state-violation/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-violation/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git checkout -q -b test-violation-branch
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/project-ship-state-violation/src/index.js
+++ b/tests/promptfoo/fixtures-fs/project-ship-state-violation/src/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/tests/promptfoo/fixtures/ship-validation-violation.md
+++ b/tests/promptfoo/fixtures/ship-validation-violation.md
@@ -1,0 +1,48 @@
+# Ship Pipeline Context — Cleanup Validation Violation
+
+## Pipeline State
+
+The ship pipeline has completed Steps 1-5 and 7, but the version step (Step 6) was planned as `will_run` and was never executed. The pipeline is now at Step 6 (REPORT).
+
+## State File
+
+Located at `.sdlc/execution/ship-feat-add-auth-20260412T120000Z.json`:
+
+```json
+{
+  "version": 1,
+  "startedAt": "2026-04-12T12:00:00.000Z",
+  "branch": "feat/add-auth",
+  "flags": { "preset": "balanced", "bump": "patch" },
+  "steps": [
+    { "name": "execute", "status": "completed" },
+    { "name": "commit", "status": "completed" },
+    { "name": "review", "status": "completed" },
+    { "name": "received-review", "status": "skipped", "reason": "no critical/high findings" },
+    { "name": "commit-fixes", "status": "skipped", "reason": "no review fixes" },
+    { "name": "version", "status": "pending" },
+    { "name": "pr", "status": "completed" }
+  ],
+  "decisions": [],
+  "deferredFindings": []
+}
+```
+
+## Cleanup Output
+
+Running `node state/ship.js cleanup` produces exit code 1 with:
+
+```json
+{
+  "valid": false,
+  "violations": [
+    {
+      "step": "version",
+      "actualStatus": "pending",
+      "message": "Step \"version\" has status \"pending\" — expected completed, skipped, or failed"
+    }
+  ]
+}
+```
+
+Stderr: `Pipeline contract violation: 1 step(s) not in terminal state. State file preserved.`


### PR DESCRIPTION
## Summary
Closes two related gaps in the ship-sdlc pipeline: missing validation that all steps actually complete before cleanup exits, and per-step model routing so subagents use the right model rather than defaulting to opus for every step.

## Business Context
N/A — pure internal SDLC automation tooling with no direct end-user or business product dimension.

## Business Benefits
N/A — pure internal SDLC automation tooling with no direct end-user or business product dimension.

## Github Issue
Fixes #159
Fixes #160

## Technical Design
Two distinct mechanisms are fixed:

**Pipeline contract enforcement (#159):** `cmdCleanup` in `state/ship.js` now validates that every step marked `will_run` has reached a terminal state (`completed`, `skipped`, or `failed`) before cleanup completes. Any step still `pending` or `in_progress` causes exit 1 with a JSON violation payload. The state file is preserved (not deleted) on failure, enabling post-mortem inspection.

**Per-step model routing (#160):** `computeSteps()` in `ship.js` now carries a `model` field for each pipeline step. The mapping: `execute-plan` → `opus`; `commit`/`commit-fixes` → `haiku`; `review`/`received-review`/`version`/`pr` → `sonnet`. Each Agent dispatch passes `model: step.model`. The `review-orchestrator` agent gains a `subagent_model` field to propagate the model into dimension subagents. `review-sdlc/SKILL.md` gets `model: sonnet` frontmatter. `execute-plan-sdlc/SKILL.md` is strengthened to require every Agent dispatch to include the `model:` parameter.

Constraint specs (C12 in execute-plan-sdlc, P9 in review-sdlc) and constraint numbering gaps/duplicates are also fixed.

## Technical Impact
No breaking changes to plugin manifests or skill interfaces. The cleanup exit code changes from 0 to 1 when a pipeline contract violation is detected — callers that silently ignore cleanup exit codes will now surface failures they previously missed. All other APIs are backward-compatible.

## Changes Overview
- Pipeline cleanup now validates all `will_run` steps reach a terminal state; violations surface as JSON and exit 1, preserving the state file for debugging
- Each ship pipeline step now carries an explicit model assignment, passed to Agent dispatch to prevent subagents from inheriting the parent (opus) model
- The review orchestrator agent manifest and SKILL.md gain a `subagent_model` field for explicit model routing into dimension subagents
- `execute-plan-sdlc` strengthened with a new constraint (C12) requiring `model:` on every Agent dispatch
- Constraint numbering in `execute-plan-sdlc`, `review-sdlc`, and `ship-sdlc` specs fixed for duplicates and gaps
- Promptfoo test coverage added for pipeline contract violation scenarios and valid state machine transitions

## Testing
Three exec-mode promptfoo tests verify the contract enforcement path:
- Valid state fixture (all steps terminal) → cleanup exits 0
- Violation fixture (pending step present) → cleanup exits 1 with JSON violation detail
- State machine transition coverage

Three behavioral promptfoo tests cover model routing and constraint dispatch in `execute-plan-sdlc` and `review-sdlc`. Fixtures added under `tests/promptfoo/fixtures-fs/`.