### PR TITLE
fix(#152): setup-sdlc - extract ship-config fields into shared lib

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,17 @@
 This is the append-only learnings log for the `ai-setup-automation` marketplace repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-04-15 — plan-sdlc: fix #152 ship-config missing fields
+Planned a fix for `/setup-sdlc` Step 3b dropping `auto`/`skip`/`bump` questions. Root cause was LLM drift when SKILL.md hand-enumerates 8 `AskUserQuestion` calls — the LLM silently shortens the loop. Fix: emit authoritative field list from `setup.js` (new P7 contract) and make SKILL.md iterate mechanically.
+
+Cross-model plan review (sonnet reviewing opus plan) caught two real blockers that self-review missed:
+1. `rebase` field: SKILL.md currently says `yes/no/prompt` but `ship.js` only accepts `auto/skip/prompt` strings (or booleans mapped via legacy logic). Writing `"yes"` would silently fall through to the `'auto'` fallback — user's choice ignored. Lesson: when moving enum field definitions into a new source of truth, verify the runtime consumer's accepted value set, not just the documented-in-SKILL.md set.
+2. Schema path: self-review assumed `plugins/sdlc-utilities/scripts/schemas/` existed (pattern inferred from other plugin layouts) when the actual location is `schemas/` at repo root. Lesson: verify path claims with `ls` even in comments — reviewers flag inaccurate references as noise.
+
+Plan also revealed a pre-existing inconsistency between `ship.js` `VALID_SKIP` (5 items) and SKILL.md Step 3b `skip` options (7 items). Scoped out as follow-up, not fixed.
+
+---
+
 ## 2026-03-19 — execute-plan-sdlc: 7-improvement upgrade + plan-sdlc new skill
 Executed a 9-task, 2-wave plan upgrading execute-plan-sdlc and creating plan-sdlc. All tasks classified Standard/Complex; no Trivial tasks, so no batching or pre-wave needed. Wave 1 (7 parallel agents) completed cleanly. Spec compliance review found 1 minor issue in plan-reviewer-prompt.md (9-row table vs 8 specified — agent added "Decomposition balance" row not in spec); fixed inline. Wave 2 (2 parallel docs agents) completed cleanly. README update was required post-execution per AGENTS.md — add this check to standard plan-sdlc output for skill additions.
 Key outcome: grouping improvements by target file (not by improvement letter) was the right decomposition strategy — avoided wave conflicts without over-splitting.
@@ -62,3 +73,6 @@ Key outcome: grouping improvements by target file (not by improvement letter) wa
 - **Impact**: LOW — confusing to contributors and AI agents reading the file.
 - **Action**: Remove hardcoded branch metadata from AGENTS.md. If branch context is needed, use git commands instead of hardcoding in docs.
 - **Status**: STALE
+
+## 2026-04-13 — version-sdlc: branch with no upstream requires --set-upstream on first push
+Branch fix/pipeline-contract-enforcement-and-model-assignment had no upstream. First `git push` failed with exit 128; recovered by running `git push --set-upstream origin <branch>` then `git push --tags` separately. Tag pushed successfully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.19] - 2026-04-15
+
+### Fixed
+- Ship-config fields (auto, skip, bump) extracted into shared `ship-fields.js` library to prevent setup-sdlc from silently dropping questions during configuration (#152)
+
 ## [0.17.18] - 2026-04-13
 
 ### Fixed

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -35,6 +35,7 @@
 - R12: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R13: Content sub-flows (setup-dimensions, setup-pr-template, setup-guardrails) inherit the parent skill's permission mode. Sub-flows MUST NOT call ExitPlanMode, change permission settings, or exit any mode.
 - R14: Scan phase (R10) MUST use the Glob tool for all file/directory existence checks. Bash MUST NOT be used with glob patterns — zsh errors on unmatched globs. Bash is permitted only for `git`, `gh`, and `which` commands.
+- R15: Ship config field enumeration (Step 3b) is authoritative from prepare script output P7 (`shipFields`). The skill MUST iterate every entry in `shipFields` and dispatch one `AskUserQuestion` per field — it MUST NOT hand-enumerate the field list or short-circuit the loop. Ship config writes use answers collected in this loop plus defaults for any field the user explicitly deferred.
 
 ## Workflow Phases
 
@@ -73,6 +74,7 @@
 - P4: `content` (object) — `{ reviewDimensions: { count, path }, prTemplate: { exists, path }, jiraTemplates: { count, path } }`
 - P5: `detected` (object) — `{ versionFile, fileType, tagPrefix, defaultBranch }` auto-detected project settings
 - P6: `needsMigration` (boolean) — true when any legacy file exists or any misplaced section found
+- P7: `shipFields` (array) — authoritative list of interactive ship-config fields sourced from `scripts/lib/ship-fields.js`. Each entry: `{ name, label, type, options, default, description }`. `name` is the local-config key; `options` is an array of valid values; `default` is the value applied if the user accepts the default answer.
 
 ## Error Handling
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.18",
+  "version": "0.17.19",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/ship-fields.js
+++ b/plugins/sdlc-utilities/scripts/lib/ship-fields.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// Single source of truth for ship-config fields.
+// Consumed by:
+//   - scripts/skill/setup.js  → emits as P7 `shipFields` (Step 3b questions)
+//   - scripts/skill/ship.js   → imports VALID_SKIP and BUILT_IN_DEFAULTS
+//
+// Keep schemas/sdlc-local.schema.json (repo root) in sync when adding,
+// removing, or renaming fields.
+
+const SHIP_FIELDS = [
+  {
+    name: 'preset',
+    label: 'Pipeline variant',
+    type: 'enum',
+    options: ['full', 'balanced', 'minimal'],
+    default: 'balanced',
+    description: 'full (all steps), balanced (skip version), minimal (execute + commit + PR)',
+  },
+  {
+    name: 'skip',
+    label: 'Additional steps to skip',
+    type: 'multi-select',
+    options: ['execute', 'commit', 'review', 'version', 'pr'],
+    default: [],
+    description: 'Only top-level pipeline steps are user-skippable. received-review and commit-fixes run conditionally based on review verdict and are not in this list by design.',
+  },
+  {
+    name: 'bump',
+    label: 'Default version bump level',
+    type: 'enum',
+    options: ['patch', 'minor', 'major'],
+    default: 'patch',
+    description: 'Applied by /version-sdlc when no explicit bump argument is passed',
+  },
+  {
+    name: 'draft',
+    label: 'Open PRs as drafts?',
+    type: 'boolean',
+    options: ['yes', 'no'],
+    default: false,
+    description: 'Default value for the --draft flag on /pr-sdlc',
+  },
+  {
+    name: 'auto',
+    label: 'Run pipeline non-interactively?',
+    type: 'boolean',
+    options: ['yes', 'no'],
+    default: false,
+    description: 'Skip interactive approval prompts throughout the ship pipeline',
+  },
+  {
+    name: 'workspace',
+    label: 'Working environment',
+    type: 'enum',
+    options: ['branch', 'worktree', 'prompt'],
+    default: 'branch',
+    description: 'branch (current branch), worktree (isolated git worktree), prompt (ask each time)',
+  },
+  {
+    name: 'rebase',
+    label: 'Rebase before shipping?',
+    type: 'enum',
+    options: ['auto', 'skip', 'prompt'],
+    default: 'auto',
+    description: 'auto (rebase automatically), skip (never rebase), prompt (ask each time). Runtime values ship.js expects; do NOT write yes/no.',
+  },
+  {
+    name: 'reviewThreshold',
+    label: 'Minimum severity that blocks the pipeline',
+    type: 'enum',
+    options: ['critical', 'high', 'medium'],
+    default: 'high',
+    description: 'Findings at or above this severity halt the pipeline',
+  },
+];
+
+// Derived: values user may legally pass to --skip or write into ship.skip[].
+const VALID_SKIP = SHIP_FIELDS.find(f => f.name === 'skip').options.slice();
+
+// Runtime resolver defaults consumed by ship.js mergeDefaults().
+// Byte-identical to the pre-refactor inline constant in ship.js (lines 48-57).
+// Preserving wire shape means ship.js runtime behavior is unchanged after
+// the Task 4 refactor.
+//
+// Two fields intentionally diverge from SHIP_FIELDS[i].default:
+//   - rebase: `true` here (legacy boolean, mapped to 'auto' by ship.js
+//     line 191-192) vs 'auto' in SHIP_FIELDS (user-facing question default).
+//     Same effective value, different storage form.
+//   - workspace: 'prompt' here (runtime fallback — ask each time if no
+//     config) vs 'branch' in SHIP_FIELDS (user-facing question default).
+//     Different intents — don't collapse these without migration analysis.
+const BUILT_IN_DEFAULTS = {
+  preset: 'balanced',
+  skip: [],
+  bump: 'patch',
+  draft: false,
+  auto: false,
+  reviewThreshold: 'high',
+  workspace: 'prompt',
+  rebase: true,
+};
+
+module.exports = { SHIP_FIELDS, VALID_SKIP, BUILT_IN_DEFAULTS };

--- a/plugins/sdlc-utilities/scripts/skill/setup.js
+++ b/plugins/sdlc-utilities/scripts/skill/setup.js
@@ -16,6 +16,7 @@ const LIB = path.join(__dirname, '..', 'lib');
 const { detectVersionFile } = require(path.join(LIB, 'version'));
 const { LEGACY, PROJECT_CONFIG_PATH, LOCAL_CONFIG_PATH, PROJECT_SECTIONS } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
+const { SHIP_FIELDS } = require(path.join(LIB, 'ship-fields'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,6 +145,7 @@ function detect(projectRoot) {
       tagPrefix,
       defaultBranch,
     },
+    shipFields: SHIP_FIELDS,
   };
 
   result.needsMigration =

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -38,23 +38,7 @@ const { exec, checkGitState, detectBaseBranch } = require(path.join(LIB, 'git'))
 const { resolveMainWorktree } = require(path.join(LIB, 'state'));
 const { readSection, normalizePreset } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const VALID_SKIP = ['execute', 'commit', 'review', 'version', 'pr'];
-
-const BUILT_IN_DEFAULTS = {
-  preset: 'balanced',
-  skip: [],
-  bump: 'patch',
-  draft: false,
-  auto: false,
-  reviewThreshold: 'high',
-  workspace: 'prompt',
-  rebase: true,
-};
+const { VALID_SKIP, BUILT_IN_DEFAULTS } = require(path.join(LIB, 'ship-fields'));
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -244,19 +244,25 @@ On **skip**: do not write a version section.
 
 #### 3b. Ship section
 
-Use AskUserQuestion for each setting. Note to the user: "Ship config is stored in `.sdlc/local.json` (developer-local, gitignored). Each developer has their own ship preferences."
+Note to the user: "Ship config is stored in `.sdlc/local.json` (developer-local, gitignored). Each developer has their own ship preferences."
 
-Ask about each field:
-1. **preset** -- Pipeline variant: full (all steps), balanced (skip version), minimal (execute + commit + PR). Default: balanced
-2. **skip** -- Additional steps to skip (comma-separated). Valid: execute, commit, review, received-review, commit-fixes, version, pr. Default: none
-3. **bump** -- Default version bump level: patch, minor, major. Default: patch
-4. **draft** -- Open PRs as drafts? yes/no. Default: no
-5. **auto** -- Run pipeline non-interactively? yes/no. Default: no
-6. **workspace** -- Working environment: branch (current branch), worktree (isolated git worktree), prompt (ask each time). Default: branch
-7. **rebase** -- Rebase before shipping? yes/no/prompt. Default: prompt
-8. **reviewThreshold** -- Minimum severity that blocks pipeline: critical, high, medium. Default: high
+Iterate over every entry in `prepare.shipFields` (the P7 contract field from Step 0 prepare output). For each entry, dispatch exactly one `AskUserQuestion` using:
+- **Question prompt:** the entry's `label`
+- **Helper text / description:** the entry's `description`
+- **Answer choices:** the entry's `options`
+- **Default answer:** the entry's `default`
 
-Use AskUserQuestion with all options for each field. Collect answers and write the ship section.
+You must issue exactly `prepare.shipFields.length` `AskUserQuestion` calls. Do not skip, reorder, batch, or infer answers. Do not hand-enumerate the field list — the shared lib owns it.
+
+**Answer mapping when writing `.sdlc/local.json`:**
+- `enum` fields → write the selected option string verbatim (no translation)
+- `multi-select` fields → write the selected options as a JSON array
+- `boolean` fields (`draft`, `auto`) → map `yes`→`true`, `no`→`false`
+- For `rebase` specifically, write the selected string (`auto`, `skip`, or `prompt`) verbatim — do NOT translate to `yes`/`no`, as `ship.js` only accepts those three strings or legacy booleans
+
+After the loop, collect answers into a `ship` object (keys = entry `name`, values = normalized per above) and write via the existing `setup-init.js --local-config '{"ship":{...}}'` path.
+
+Implements R15; reads P7.
 
 #### 3c. Jira section
 

--- a/tests/promptfoo/datasets/setup-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/setup-prepare-exec.yaml
@@ -1,0 +1,68 @@
+# Script execution tests for setup.js P7 contract (shipFields).
+# These tests run setup.js directly against fixture directories (no LLM).
+# Covers: P7 shipFields emission, field shape, order, and backward compatibility (issue #152).
+
+- description: "setup-prepare: emits shipFields with 8 entries"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: icontains
+      value: '"shipFields"'
+    - type: javascript
+      value: "JSON.parse(output).shipFields.length === 8"
+
+- description: "setup-prepare: shipFields order is stable (preset → reviewThreshold)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: javascript
+      value: |
+        const names = JSON.parse(output).shipFields.map(f => f.name);
+        const expected = ['preset','skip','bump','draft','auto','workspace','rebase','reviewThreshold'];
+        JSON.stringify(names) === JSON.stringify(expected)
+
+- description: "setup-prepare: shipFields entries have the full 6-key descriptor shape"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: javascript
+      value: |
+        const keys = ['name','label','type','options','default','description'];
+        JSON.parse(output).shipFields.every(f => keys.every(k => k in f))
+
+- description: "setup-prepare: shipFields.skip has exactly 5 options"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: javascript
+      value: |
+        const skip = JSON.parse(output).shipFields.find(f => f.name === 'skip');
+        const expected = ['execute','commit','review','version','pr'];
+        JSON.stringify(skip.options) === JSON.stringify(expected)
+
+- description: "setup-prepare: still emits P1-P6 fields alongside shipFields"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-setup-empty"
+  assert:
+    - type: icontains
+      value: '"projectConfig"'
+    - type: icontains
+      value: '"localConfig"'
+    - type: icontains
+      value: '"legacy"'
+    - type: icontains
+      value: '"content"'
+    - type: icontains
+      value: '"detected"'
+    - type: icontains
+      value: '"needsMigration"'

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -171,3 +171,39 @@
       value: '"model": "haiku"'
     - type: icontains
       value: '"model": "sonnet"'
+
+# Shared lib import regression tests (issue #152)
+
+- description: "ship-prepare: rejects skip values not in VALID_SKIP (post-refactor)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --skip received-review"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: "Unrecognized skip value"
+    - type: icontains
+      value: "received-review"
+
+- description: "ship-prepare: BUILT_IN_DEFAULTS resolve unchanged (post-refactor)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: '"preset": "balanced"'
+    - type: icontains
+      value: '"bump": "patch"'
+    - type: icontains
+      value: '"draft": false'
+    - type: icontains
+      value: '"auto": false'
+    - type: icontains
+      value: '"reviewThreshold": "high"'
+    - type: icontains
+      value: '"workspace": "prompt"'
+    - type: icontains
+      value: '"rebase": "auto"'

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -26,6 +26,7 @@ tests:
   - file://datasets/ship-prepare-exec.yaml
   - file://datasets/guardrails-prepare-exec.yaml
   - file://datasets/setup-init-exec.yaml
+  - file://datasets/setup-prepare-exec.yaml
   - file://datasets/plan-format-exec.yaml
   - file://datasets/hook-git-guard-exec.yaml
   - file://datasets/hook-error-report-exec.yaml


### PR DESCRIPTION
## Summary
Extracts ship-config field definitions (preset, skip, bump, draft, auto, workspace, rebase, reviewThreshold) from inline constants into a shared `ship-fields.js` library, consumed by both `setup.js` and `ship.js`. This prevents setup-sdlc from silently dropping AskUserQuestion calls when the LLM drifts on hand-enumerated field lists.

## Business Context
When users run `/setup-sdlc` to configure their ship pipeline, the skill was silently dropping questions for `auto`, `skip`, and `bump` fields. The root cause: SKILL.md hand-enumerated 8 AskUserQuestion calls, and the LLM would truncate the loop. This resulted in incomplete `.sdlc/local.json` configurations, causing unexpected pipeline behavior for users who believed they had configured all settings.

## Business Benefits
- Users now reliably configure all 8 ship-config fields during setup, eliminating silent configuration gaps
- Field definitions are maintained in one place, preventing future drift between setup and ship runtime
- Cross-model plan review caught two real blockers (wrong `rebase` values, wrong schema path), validating the critique-gate workflow

## Github Issue
Fixes #152

## Technical Design
The fix introduces a shared source of truth (`scripts/lib/ship-fields.js`) that exports three artifacts: `SHIP_FIELDS` (the 8-field descriptor array), `VALID_SKIP` (derived from the skip field's options), and `BUILT_IN_DEFAULTS` (runtime defaults for ship.js). `setup.js` emits `SHIP_FIELDS` as a new P7 contract field (`shipFields`), and `SKILL.md` iterates that array mechanically rather than hand-enumerating fields. `ship.js` imports `VALID_SKIP` and `BUILT_IN_DEFAULTS` from the same lib, replacing its inline constants.

## Technical Impact
- New P7 (`shipFields`) added to setup.js prepare-script contract — existing P1-P6 unchanged
- `ship.js` inline `VALID_SKIP` and `BUILT_IN_DEFAULTS` replaced with imports from shared lib — runtime values are byte-identical, so no behavioral change
- `rebase` field options corrected from `yes/no/prompt` to `auto/skip/prompt` to match what `ship.js` actually accepts
- Spec updated with R15 requirement for authoritative field enumeration

## Changes Overview
- Introduced shared ship-fields library as single source of truth for all 8 ship-config field definitions, valid skip values, and built-in defaults
- Modified setup prepare script to emit the field list as a new P7 contract field, enabling mechanical iteration by the skill
- Refactored ship prepare script to import skip validation and defaults from the shared library instead of maintaining inline copies
- Updated setup-sdlc SKILL.md to iterate `shipFields` from prepare output instead of hand-enumerating AskUserQuestion calls
- Added spec requirement R15 and P7 contract definition to the setup-sdlc specification
- Added promptfoo execution tests verifying field emission shape, order, and backward compatibility
- Version bumped to 0.17.19 with changelog entry

## Testing
- New `setup-prepare-exec.yaml` dataset: 5 test cases verifying P7 emission (field count, order stability, descriptor shape, skip options, P1-P6 coexistence)
- Extended `ship-prepare-exec.yaml` dataset: 2 regression tests verifying VALID_SKIP rejection and BUILT_IN_DEFAULTS resolution after the refactor
- Test config (`promptfooconfig-exec.yaml`) updated to include the new dataset