### PR TITLE
fix(#164): openspec-detection - harden against contradictory signals

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,13 @@
 This is the append-only learnings log for the `ai-setup-automation` marketplace repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-04-15 — PR #165 (fix/#164 openspec-detection hardening)
+
+The `prConfig.titlePattern` for this repo requires `type(#issue): scope - description` format (e.g. `fix(#164): openspec-detection - harden against contradictory signals`). The dash-separated scope and description is mandatory — titles without the ` - ` separator will fail validation. Conventional commit style alone (without issue number in parens) is not accepted.
+
+## 2026-04-15 — version-sdlc: patch release v0.17.20 via ship pipeline
+Single fix commit for #164 (openspec-detection hardening). Auto mode used; push deferred to ship pipeline's pr step. CI scripts all current. No pre-condition issues.
+
 ## 2026-04-15 — plan-sdlc: fix #152 ship-config missing fields
 Planned a fix for `/setup-sdlc` Step 3b dropping `auto`/`skip`/`bump` questions. Root cause was LLM drift when SKILL.md hand-enumerates 8 `AskUserQuestion` calls — the LLM silently shortens the loop. Fix: emit authoritative field list from `setup.js` (new P7 contract) and make SKILL.md iterate mechanically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.20] - 2026-04-15
+
+### Fixed
+- openspec-detection hardened against contradictory session-start signals; plan-sdlc and ship-sdlc now respect the `openspecAuthoritative` field to override conflicting context (#164)
+
 ## [0.17.19] - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Open `/plugin`, go to **Marketplaces**, and toggle auto-update for `sdlc-marketp
 | [Adding Commands](docs/adding-commands.md) | Create custom slash commands (legacy — prefer skills) |
 | [Adding Hooks](docs/adding-hooks.md) | Set up automated actions on session events |
 | [OpenSpec Integration](docs/openspec-integration.md) | Using SDLC skills with OpenSpec for spec-driven development |
+| [Plugin Interop](docs/plugin-interop.md) | Authority model for OpenSpec detection when multiple plugins coexist |
 
 ## Troubleshooting
 

--- a/docs/plugin-interop.md
+++ b/docs/plugin-interop.md
@@ -1,0 +1,36 @@
+# SDLC Plugin Interop
+
+How the SDLC plugin detects project state and what happens when co-installed plugins disagree.
+
+## Authority model
+
+SDLC detects OpenSpec initialization by checking for `openspec/config.yaml` — the canonical marker file created by `openspec init`. This file is the single evidence path used across all SDLC skills and hooks.
+
+Detection is performed in two layers:
+
+1. **Session-start hook** (`hooks/session-start.js`) — runs `detectActiveChanges` from `scripts/lib/openspec.js` and emits an `INITIALIZED` line into the `<system-reminder>` block with the evidence file path and spec count.
+2. **Prepare scripts** (`scripts/skill/plan.js`, `scripts/skill/ship.js`) — re-run `detectActiveChanges` and include an `authoritative` field in their JSON output, citing `openspec/config.yaml` as the evidence path.
+
+Both layers produce deterministic, script-driven output. Skills consume the prepare-script output and do not independently re-derive OpenSpec state.
+
+## What to do when plugins conflict
+
+When two plugins inject contradictory OpenSpec state into the same session context (one says "initialized", another says "not initialized"), trust the plugin that cites an evidence path.
+
+SDLC's detection always names the exact file it checked (`openspec/config.yaml`). If another plugin's detection disagrees, the likely cause is one of:
+
+- The other plugin checks for a different marker file (e.g., `.openspec/` instead of `openspec/`).
+- The other plugin's detection runs before `openspec init` has completed.
+- The other plugin caches state from a prior session where OpenSpec was not yet initialized.
+
+When SDLC detects a contradictory "not initialized" signal in the session context alongside its own positive detection, it emits an audit line and continues with its own result. This is informational — SDLC does not attempt to correct the other plugin's output.
+
+If you encounter a false-negative detection from another plugin, report it to that plugin's maintainer. SDLC cannot fix detection logic it does not own.
+
+## Known conflicts
+
+The `ai-setup-automation` plugin historically checked for `.openspec/` (dotfile path) instead of the `openspec/` directory that the OpenSpec CLI actually creates. This was fixed in [rnagrodzki/ai-setup-automation#28](https://github.com/rnagrodzki/ai-setup-automation/issues/28). If you see contradictory signals from that plugin, update to the version that includes the fix.
+
+## What SDLC cannot do
+
+SDLC has no mechanism to suppress, override, or reorder output from other plugins. Plugin isolation is a platform-level concern — Claude Code loads plugins independently and concatenates their session-start output into a single `<system-reminder>` block. SDLC can only control its own output and instruct its own skills to prefer its own detection results.

--- a/docs/specs/plan-sdlc.md
+++ b/docs/specs/plan-sdlc.md
@@ -29,6 +29,7 @@
 - R13: After exploration, re-read the plan file's Requirements section before decomposition (re-anchor to counter attention drift)
 - R14: Remove the `## Requirements` working section after task decomposition (temporary scaffolding)
 - R15: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R16: When `openspec/config.yaml` exists AND the injected session-start `<system-reminder>` contains a contradictory signal (regex matching `not initialized` together with `openspec`), the skill MUST emit a single audit line naming the authoritative file path and note that the contradictory signal is being ignored. The override line is informational only — skill flow continues. (Rationale: #164 — defensive hardening against co-installed plugins emitting false-negative OpenSpec detection.)
 
 ## Workflow Phases
 

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -41,6 +41,7 @@
 - R18: Ship config is optional and developer-local (`.sdlc/local.json`); pipeline runs with built-in defaults
 - R19: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R20: `--auto` suppresses pipeline pauses: when `--auto` is active, `pause` must be `false` for every step that accepts `--auto` (per R7 forwarding audit: commit-sdlc, received-review-sdlc, version-sdlc, pr-sdlc). The sub-skill's consent gate is skipped via the forwarded flag, so the pipeline has no reason to pause at that step.
+- R21: When `openspec/config.yaml` exists (as reported by `skill/ship.js` via `context.openspecDetected` or the authoritative field) AND the injected session-start `<system-reminder>` contains a contradictory signal (regex matching `not initialized` together with `openspec`), the skill MUST emit a single audit line naming the authoritative file path and note that the contradictory signal is being ignored. The override line is informational only — pipeline flow continues. (Rationale: #164 — defensive hardening against co-installed plugins emitting false-negative OpenSpec detection.)
 
 ## Workflow Phases
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.19",
+  "version": "0.17.20",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/session-start.js
+++ b/plugins/sdlc-utilities/hooks/session-start.js
@@ -170,14 +170,16 @@ try {
   if (!openspec.present) {
     // No openspec/config.yaml — skip
   } else if (openspec.activeChanges.length === 0) {
-    resumeLines.push('OpenSpec: configured, no active changes');
+    const specPlural = openspec.specsCount !== 1 ? 's' : '';
+    resumeLines.push(`OpenSpec: INITIALIZED — verified via openspec/config.yaml (${openspec.specsCount} spec${specPlural}, 0 active changes)`);
   } else if (openspec.activeChanges.length === 1) {
     const change = openspec.activeChanges[0];
     const stageLabel = typeof STAGE_LABELS[change.stage] === 'function'
       ? STAGE_LABELS[change.stage](change)
       : STAGE_LABELS[change.stage];
     const specLabel = `${change.deltaSpecCount} delta spec${change.deltaSpecCount !== 1 ? 's' : ''}`;
-    resumeLines.push(`OpenSpec active: change "${change.name}" (${stageLabel}, ${specLabel})`);
+    const specPlural = openspec.specsCount !== 1 ? 's' : '';
+    resumeLines.push(`OpenSpec: INITIALIZED (openspec/config.yaml, ${openspec.specsCount} spec${specPlural}) · active: change "${change.name}" (${stageLabel}, ${specLabel})`);
 
     // Branch match (from shared module)
     if (openspec.branchMatch === change.name) {
@@ -212,7 +214,8 @@ try {
     }
   } else {
     const names = openspec.activeChanges.map(c => c.name).join(', ');
-    resumeLines.push(`OpenSpec active: ${openspec.activeChanges.length} changes (${names})`);
+    const specPlural = openspec.specsCount !== 1 ? 's' : '';
+    resumeLines.push(`OpenSpec: INITIALIZED (openspec/config.yaml, ${openspec.specsCount} spec${specPlural}) · active: ${openspec.activeChanges.length} changes (${names})`);
     resumeLines.push('  Pass --spec or --from-openspec <name> to select');
   }
 } catch {

--- a/plugins/sdlc-utilities/scripts/lib/openspec.js
+++ b/plugins/sdlc-utilities/scripts/lib/openspec.js
@@ -138,13 +138,17 @@ function analyzeChange(changeDir, name) {
  * Detect all active OpenSpec changes in a project.
  *
  * @param {string} projectRoot  Absolute path to the project root
- * @returns {{ present: boolean, activeChanges: object[], branchMatch: string|null }}
+ * @returns {{ present: boolean, specsCount: number, activeChanges: object[], branchMatch: string|null }}
  */
 function detectActiveChanges(projectRoot) {
   const configPath = path.join(projectRoot, 'openspec', 'config.yaml');
   if (!fs.existsSync(configPath)) {
-    return { present: false, activeChanges: [], branchMatch: null };
+    return { present: false, specsCount: 0, activeChanges: [], branchMatch: null };
   }
+
+  // Count baseline specs in openspec/specs/
+  const specsDir      = path.join(projectRoot, 'openspec', 'specs');
+  const specsCount    = countMdFiles(specsDir);
 
   const changesDir    = path.join(projectRoot, 'openspec', 'changes');
   const activeChanges = [];
@@ -183,7 +187,7 @@ function detectActiveChanges(projectRoot) {
     // Graceful degradation — skip branch matching if git is unavailable
   }
 
-  return { present: true, activeChanges, branchMatch };
+  return { present: true, specsCount, activeChanges, branchMatch };
 }
 
 /**

--- a/plugins/sdlc-utilities/scripts/skill/plan.js
+++ b/plugins/sdlc-utilities/scripts/skill/plan.js
@@ -57,6 +57,14 @@ function main() {
   // 1. OpenSpec detection
   const openspec = detectActiveChanges(projectRoot);
 
+  // Add authoritative evidence when OpenSpec is present
+  if (openspec.present) {
+    openspec.authoritative = {
+      path: 'openspec/config.yaml',
+      specsCount: openspec.specsCount,
+    };
+  }
+
   // 2. --from-openspec validation
   let fromOpenspecResult = null;
   if (fromOpenspec) {

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -39,6 +39,7 @@ const { resolveMainWorktree } = require(path.join(LIB, 'state'));
 const { readSection, normalizePreset } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
 const { VALID_SKIP, BUILT_IN_DEFAULTS } = require(path.join(LIB, 'ship-fields'));
+const { detectActiveChanges } = require(path.join(LIB, 'openspec'));
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -530,8 +531,12 @@ function main() {
     }
   }
 
-  // Check OpenSpec
-  const openspecDetected = fs.existsSync(path.join(projectRoot, 'openspec', 'config.yaml'));
+  // Check OpenSpec (use shared lib for consistent detection)
+  const openspecResult = detectActiveChanges(projectRoot);
+  const openspecDetected = openspecResult.present;
+  const openspecAuthoritative = openspecResult.present
+    ? { path: 'openspec/config.yaml', specsCount: openspecResult.specsCount }
+    : null;
 
   // Check .sdlc/ gitignore status
   // git check-ignore returns non-null (empty string) if ignored, null if not ignored.
@@ -552,6 +557,7 @@ function main() {
     ghAuthenticated,
     ghUser,
     openspecDetected,
+    openspecAuthoritative,
     sdlcGitignored,
     worktree: worktreeInfo,
   };

--- a/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
@@ -109,6 +109,10 @@ Context detection (from skill/plan.js):
 
 Extract `guardrails` from the output → store as `activeGuardrails`. If the array is non-empty, print: "Loaded N plan guardrails." If empty: "No plan guardrails configured."
 
+**Contradictory-signal override (implements R16):** After reading the prepare output, IF `openspec.authoritative.path` is set AND the current session-start `<system-reminder>` contains a line matching `/openspec.*not initialized|not initialized.*openspec/i`, print exactly one line:
+`Ignoring contradictory 'not initialized' signal in session context — openspec/config.yaml exists (authoritative source: SDLC's own check via plan.js prepare output).`
+Then continue the flow. If the contradictory phrase is absent, emit nothing.
+
 **`--from-openspec` handling (after prepare output, before gate check):**
 
 If `fromOpenspec.valid` is true in the prepare output:

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -113,6 +113,10 @@ Context detection (from skill/ship.js):
   .sdlc/ gitignored:   yes
 ```
 
+**Contradictory-signal override (implements R21):** After printing the context detection block, IF `context.openspecAuthoritative.path` is set AND the current session-start `<system-reminder>` contains a line matching `/openspec.*not initialized|not initialized.*openspec/i`, print exactly one line:
+`Ignoring contradictory 'not initialized' signal in session context — openspec/config.yaml exists (authoritative source: SDLC's own check via ship.js prepare output).`
+Then continue the flow. If the contradictory phrase is absent, emit nothing.
+
 ### 1g. Auto-skip logic
 
 Print each step from the `steps` array in the `skill/ship.js` output with its `status`, `reason`, and `skipSource`:

--- a/tests/promptfoo/datasets/plan-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/plan-prepare-exec.yaml
@@ -1,0 +1,27 @@
+# Script execution tests for plan-prepare.js (plan.js).
+# These tests run plan.js directly against fixture directories (no LLM).
+# Covers: OpenSpec authoritative output (issue #164).
+
+- description: "plan-prepare: openspec present emits authoritative field with path and specsCount"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-openspec-baseline"
+  assert:
+    - type: icontains
+      value: '"authoritative"'
+    - type: icontains
+      value: '"path": "openspec/config.yaml"'
+    - type: icontains
+      value: '"specsCount": 2'
+
+- description: "plan-prepare: no openspec omits authoritative field"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-commit-config"
+  assert:
+    - type: icontains
+      value: '"present": false'
+    - type: not-icontains
+      value: '"authoritative"'

--- a/tests/promptfoo/datasets/plan-sdlc.yaml
+++ b/tests/promptfoo/datasets/plan-sdlc.yaml
@@ -88,3 +88,36 @@
         reads the proposal for scope and uses the ADDED sections from delta specs to derive
         tasks. It does NOT error out or ask the user to create tasks.md first. The gate
         check is still bypassed because --from-openspec was passed.
+
+- description: "plan-sdlc: emits override audit line when contradictory signal present"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md"
+    project_context: "file://fixtures/plan-contradictory-signal.md"
+    user_request: >
+      Run /plan-sdlc. The plan-prepare.js output and session-start context are provided above.
+      The prepare output shows openspec.authoritative.path is set to "openspec/config.yaml".
+      The session-start system-reminder contains both SDLC's "OpenSpec: INITIALIZED" line and
+      a contradictory "openspec: not initialized" line from a co-installed plugin. Process
+      Step 0 (context detection) and show how you handle the contradictory signal before
+      proceeding to the gate check.
+  assert:
+    # Must emit the override audit line
+    - type: icontains
+      value: "Ignoring contradictory"
+    - type: icontains
+      value: "not initialized"
+    # Must reference the authoritative source
+    - type: icontains
+      value: "openspec/config.yaml"
+    # Must NOT suggest initializing OpenSpec (it's already initialized)
+    - type: not-icontains
+      value: "Initialize OpenSpec"
+    # Behavioral: contradictory signal is dismissed, not acted upon
+    - type: llm-rubric
+      value: >
+        The response detects the contradictory "openspec: not initialized" signal in the
+        session context and emits exactly one audit line noting that it is being ignored,
+        citing openspec/config.yaml as the authoritative source from the plan.js prepare
+        output. The response does NOT treat OpenSpec as uninitialized, does NOT suggest
+        running openspec init, and does NOT add an "initialize OpenSpec" task to the plan.
+        The skill flow continues normally with OpenSpec detected as present.

--- a/tests/promptfoo/datasets/session-start-exec.yaml
+++ b/tests/promptfoo/datasets/session-start-exec.yaml
@@ -1,0 +1,47 @@
+# Script execution tests for session-start.js hook.
+# These tests run session-start.js directly against fixture directories (no LLM).
+# Covers: OpenSpec detection output strings (issue #164).
+
+- description: "session-start: no openspec/config.yaml produces no OpenSpec line"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/session-start.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-commit-config"
+  assert:
+    - type: not-icontains
+      value: "OpenSpec"
+
+- description: "session-start: openspec baseline (no active changes) emits INITIALIZED with spec count"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/session-start.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-openspec-baseline"
+  assert:
+    - type: icontains
+      value: "INITIALIZED"
+    - type: icontains
+      value: "openspec/config.yaml"
+    - type: icontains
+      value: "2 specs, 0 active changes"
+
+- description: "session-start: openspec with active change emits INITIALIZED prefix and change details"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/session-start.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-openspec-active"
+  assert:
+    - type: icontains
+      value: "INITIALIZED (openspec/config.yaml"
+    - type: icontains
+      value: "1 spec)"
+    - type: icontains
+      value: "add-auth"
+
+- description: "session-start: openspec baseline returns specsCount 2 from lib"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/hooks/session-start.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-openspec-baseline"
+  assert:
+    - type: icontains
+      value: "2 specs"

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -207,3 +207,33 @@
       value: '"workspace": "prompt"'
     - type: icontains
       value: '"rebase": "auto"'
+
+# OpenSpec authoritative output (issue #164)
+
+- description: "ship-prepare: openspec present emits openspecAuthoritative with path and specsCount"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-openspec-baseline"
+  assert:
+    - type: icontains
+      value: '"openspecDetected": true'
+    - type: icontains
+      value: '"openspecAuthoritative"'
+    - type: icontains
+      value: '"path": "openspec/config.yaml"'
+    - type: icontains
+      value: '"specsCount": 2'
+
+- description: "ship-prepare: no openspec emits null openspecAuthoritative"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: icontains
+      value: '"openspecDetected": false'
+    - type: icontains
+      value: '"openspecAuthoritative": null'

--- a/tests/promptfoo/datasets/ship-sdlc.yaml
+++ b/tests/promptfoo/datasets/ship-sdlc.yaml
@@ -359,3 +359,36 @@
         the user explicitly passed the --draft CLI flag. The flag resolution shows
         draft: true with source: cli. The pipeline table correctly reflects the
         --draft flag in the pr step's args column.
+
+- description: "ship-sdlc: emits override audit line when contradictory OpenSpec signal present"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
+    project_context: "file://fixtures/ship-contradictory-signal.md"
+    user_request: >
+      Run /ship-sdlc --dry-run --workspace branch. The ship-prepare.js output and session-start
+      context are provided above. The prepare output shows context.openspecAuthoritative.path
+      is set to "openspec/config.yaml". The session-start system-reminder contains both SDLC's
+      "OpenSpec: INITIALIZED" line and a contradictory "openspec: not initialized" line from a
+      co-installed plugin. Process Step 1 (context detection in 1f) and show how you handle the
+      contradictory signal. Then show the dry-run pipeline table.
+  assert:
+    # Must emit the override audit line
+    - type: icontains
+      value: "Ignoring contradictory"
+    - type: icontains
+      value: "not initialized"
+    # Must reference the authoritative source
+    - type: icontains
+      value: "openspec/config.yaml"
+    # Must still show OpenSpec as detected in context detection
+    - type: regex
+      value: "(openspecDetected.*true|OpenSpec.*detected|INITIALIZED)"
+    # Behavioral: contradictory signal is dismissed, pipeline continues
+    - type: llm-rubric
+      value: >
+        The response detects the contradictory "openspec: not initialized" signal in the
+        session context and emits exactly one audit line noting that it is being ignored,
+        citing openspec/config.yaml as the authoritative source from the ship.js prepare
+        output. The context detection section still shows OpenSpec as detected (true).
+        The pipeline proceeds normally — the contradictory signal does not cause the
+        pipeline to treat OpenSpec as absent.

--- a/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/changes/add-auth/proposal.md
+++ b/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/changes/add-auth/proposal.md
@@ -1,0 +1,3 @@
+# Add Auth
+
+Proposal for adding authentication.

--- a/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/changes/add-auth/specs/auth-spec.md
+++ b/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/changes/add-auth/specs/auth-spec.md
@@ -1,0 +1,3 @@
+# Auth Delta Spec
+
+Authentication delta spec.

--- a/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/config.yaml
+++ b/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/config.yaml
@@ -1,0 +1,2 @@
+version: "1.0"
+project: test-project

--- a/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/specs/core.md
+++ b/tests/promptfoo/fixtures-fs/project-openspec-active/openspec/specs/core.md
@@ -1,0 +1,3 @@
+# Core Spec
+
+Core requirements for the test project.

--- a/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/config.yaml
+++ b/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/config.yaml
@@ -1,0 +1,2 @@
+version: "1.0"
+project: test-project

--- a/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/specs/auth.md
+++ b/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/specs/auth.md
@@ -1,0 +1,3 @@
+# Auth Spec
+
+Authentication requirements for the test project.

--- a/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/specs/billing.md
+++ b/tests/promptfoo/fixtures-fs/project-openspec-baseline/openspec/specs/billing.md
@@ -1,0 +1,3 @@
+# Billing Spec
+
+Billing requirements for the test project.

--- a/tests/promptfoo/fixtures/plan-contradictory-signal.md
+++ b/tests/promptfoo/fixtures/plan-contradictory-signal.md
@@ -1,0 +1,41 @@
+# Contradictory OpenSpec Signal Test Context
+
+## Session-start system-reminder (simulated)
+
+The following simulates two plugins injecting conflicting OpenSpec detection into the same session:
+
+```
+<system-reminder>
+sdlc: v0.17.19 (10 skills loaded)
+Plan mode routing: always invoke plan-sdlc via the Skill tool when plan mode is active.
+OpenSpec: INITIALIZED — verified via openspec/config.yaml (2 specs, 0 active changes)
+Git: branch feat/add-auth (clean) [snapshot]
+</system-reminder>
+
+<system-reminder>
+ai-setup-automation: v1.2.0
+openspec: not initialized
+</system-reminder>
+```
+
+## plan-prepare.js Output (pre-computed)
+
+```json
+{
+  "openspec": {
+    "present": true,
+    "specsCount": 2,
+    "activeChanges": [],
+    "branchMatch": null,
+    "authoritative": {
+      "path": "openspec/config.yaml",
+      "specsCount": 2
+    }
+  },
+  "fromOpenspec": null,
+  "guardrails": [],
+  "errors": []
+}
+```
+
+The plan-prepare.js output confirms OpenSpec is present with 2 baseline specs and provides the authoritative evidence path. The session-start context contains a contradictory "openspec: not initialized" line from a co-installed plugin.

--- a/tests/promptfoo/fixtures/ship-contradictory-signal.md
+++ b/tests/promptfoo/fixtures/ship-contradictory-signal.md
@@ -1,0 +1,98 @@
+# Contradictory OpenSpec Signal Test Context (Ship)
+
+## Session-start system-reminder (simulated)
+
+```
+<system-reminder>
+sdlc: v0.17.19 (10 skills loaded)
+Plan mode routing: always invoke plan-sdlc via the Skill tool when plan mode is active.
+OpenSpec: INITIALIZED — verified via openspec/config.yaml (2 specs, 0 active changes)
+Git: branch feat/add-auth (clean) [snapshot]
+</system-reminder>
+
+<system-reminder>
+ai-setup-automation: v1.2.0
+openspec: not initialized
+</system-reminder>
+```
+
+## ship-prepare.js Output (pre-computed)
+
+```json
+{
+  "errors": [],
+  "warnings": [],
+  "config": {
+    "source": "built-in defaults",
+    "values": {
+      "preset": "balanced",
+      "skip": [],
+      "bump": "patch",
+      "draft": false,
+      "auto": false,
+      "reviewThreshold": "high",
+      "workspace": "prompt",
+      "rebase": "auto"
+    }
+  },
+  "flags": {
+    "auto": false,
+    "preset": "balanced",
+    "skip": [],
+    "bump": "patch",
+    "draft": false,
+    "dryRun": true,
+    "resume": false,
+    "hasPlan": true,
+    "workspace": "branch",
+    "rebase": "auto",
+    "sources": {
+      "auto": "default",
+      "preset": "default",
+      "skip": "default",
+      "bump": "default",
+      "draft": "default",
+      "dryRun": "cli",
+      "hasPlan": "cli",
+      "workspace": "cli",
+      "rebase": "default"
+    }
+  },
+  "context": {
+    "currentBranch": "feat/add-auth",
+    "defaultBranch": "main",
+    "uncommittedChanges": 5,
+    "dirtyFiles": ["src/auth.ts", "src/middleware.ts", "tests/auth.test.ts", "package.json", "README.md"],
+    "ghAuthenticated": true,
+    "ghUser": "testuser",
+    "openspecDetected": true,
+    "openspecAuthoritative": {
+      "path": "openspec/config.yaml",
+      "specsCount": 2
+    },
+    "sdlcGitignored": true,
+    "worktree": null
+  },
+  "steps": [
+    {"skill": "execute-plan-sdlc", "status": "will_run", "reason": "plan detected in context", "skipSource": "none", "args": "--preset balanced", "invocation": "/execute-plan-sdlc --preset balanced", "pause": false, "model": "opus"},
+    {"skill": "commit-sdlc", "status": "will_run", "reason": "uncommitted changes detected", "skipSource": "none", "args": "", "invocation": "/commit-sdlc", "pause": false, "model": "haiku"},
+    {"skill": "review-sdlc", "status": "will_run", "reason": "not in skip set", "skipSource": "none", "args": "--committed", "invocation": "/review-sdlc --committed", "pause": false, "model": "sonnet"},
+    {"skill": "received-review-sdlc", "status": "conditional", "reason": "depends on review verdict", "skipSource": "condition", "args": "", "invocation": "/received-review-sdlc", "pause": true, "model": "sonnet"},
+    {"skill": "commit-sdlc", "status": "conditional", "reason": "depends on received-review changes", "skipSource": "condition", "args": "--scope fixes", "invocation": "/commit-sdlc --scope fixes", "pause": false, "model": "haiku"},
+    {"skill": "version-sdlc", "status": "will_run", "reason": "not in skip set", "skipSource": "none", "args": "patch", "invocation": "/version-sdlc patch", "pause": false, "model": "sonnet"},
+    {"skill": "pr-sdlc", "status": "will_run", "reason": "not in skip set", "skipSource": "none", "args": "", "invocation": "/pr-sdlc", "pause": false, "model": "sonnet"}
+  ],
+  "validation": {
+    "ghAuth": true,
+    "notOnDefault": true,
+    "skipValuesRecognized": true,
+    "atLeastOneStepRuns": true,
+    "coherentFlags": true,
+    "warnings": []
+  },
+  "resume": {
+    "found": false,
+    "stateFile": null
+  }
+}
+```

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -27,7 +27,9 @@ tests:
   - file://datasets/guardrails-prepare-exec.yaml
   - file://datasets/setup-init-exec.yaml
   - file://datasets/setup-prepare-exec.yaml
+  - file://datasets/plan-prepare-exec.yaml
   - file://datasets/plan-format-exec.yaml
   - file://datasets/hook-git-guard-exec.yaml
   - file://datasets/hook-error-report-exec.yaml
+  - file://datasets/session-start-exec.yaml
   - file://datasets/markdown-to-adf-exec.yaml


### PR DESCRIPTION
## Summary

Hardens OpenSpec detection in the SDLC plugin against false-negative signals emitted by co-installed plugins. When a co-installed plugin (such as `ai-setup-automation`) injects "openspec: not initialized" into the session context alongside SDLC's own positive detection, plan-sdlc and ship-sdlc previously had no mechanism to resolve the conflict. This fix adds an authoritative evidence field to the prepare scripts and overrides the contradictory signal with a single informational audit line.

## Business Context

Users running the SDLC plugin alongside other Claude Code plugins encountered situations where the session context contained contradictory OpenSpec state: SDLC's session-start hook correctly detected OpenSpec as initialized, but a co-installed plugin emitted "not initialized" into the same `<system-reminder>` block. This caused plan-sdlc and ship-sdlc to behave inconsistently — sometimes treating OpenSpec as absent and skipping spec-linked workflow steps even when the project was properly initialized. The issue was reported in #164 and traced to the `ai-setup-automation` plugin checking a different marker path (`.openspec/` vs `openspec/`).

## Business Benefits

- Plan and ship pipelines now correctly recognize OpenSpec initialization regardless of what other plugins report in the session context.
- The session-start hook emits an `INITIALIZED` prefix with a concrete evidence path (`openspec/config.yaml`) and spec count, making the detection auditable.
- Skills emit one informational override line when overriding a contradictory signal — no hidden behavior changes.
- New `docs/plugin-interop.md` documents the authority model so users and plugin authors understand how conflicts are resolved.

## Github Issue

Fixes #164

## Technical Design

Detection is hardened at three layers:

1. **`openspec.js` library** — `detectActiveChanges` now returns `specsCount` (count of baseline `.md` files in `openspec/specs/`) alongside existing fields. This gives prepare scripts a concrete count to surface.
2. **Prepare scripts** (`plan.js`, `ship.js`) — both now include an `authoritative` / `openspecAuthoritative` field in their JSON output, naming `openspec/config.yaml` as the evidence path and including `specsCount`. Skills must prefer this field over anything in the session context.
3. **Session-start hook** — output format changed from the ambiguous `OpenSpec active: ...` to `OpenSpec: INITIALIZED (openspec/config.yaml, N specs) · active: ...`, making the evidence path explicit in the `<system-reminder>` line that downstream skills consume.
4. **SKILL.md overrides** (plan-sdlc, ship-sdlc) — each skill now includes a "Contradictory-signal override" block instructing the LLM to emit one audit line and continue when `authoritative.path` is set but the session context contains a regex-matched "not initialized" phrase.

The `docs/plugin-interop.md` document formalizes the authority model: SDLC trusts its own prepare-script output over any other plugin's session-start injection.

## Technical Impact

- **`openspec.js` return shape** — adds `specsCount: number` to the return value of `detectActiveChanges`. New field, no removals — existing callers are unaffected.
- **`ship.js` output shape** — adds `openspecAuthoritative: { path, specsCount } | null` to the prepare JSON. Callers reading only `openspecDetected` are unaffected.
- **`plan.js` output shape** — adds `openspec.authoritative: { path, specsCount }` when OpenSpec is present.
- **Session-start hook output** — the `OpenSpec:` line format changes. Skills that regex-match the old `OpenSpec active:` prefix need to accommodate the new `OpenSpec: INITIALIZED ·` prefix. Plan-sdlc and ship-sdlc SKILL.md files are updated accordingly.
- No breaking changes to public plugin manifest or skill invocation interfaces.

## Changes Overview

- OpenSpec library extended with baseline spec count so prepare scripts and the session-start hook can surface concrete evidence alongside the config file path
- Session-start hook output format hardened: all OpenSpec states now emit `INITIALIZED` with an explicit evidence path and spec count, replacing the ambiguous former prefix
- Plan and ship prepare scripts augmented with an `authoritative` field citing the evidence file path, giving skills a single authoritative source to prefer over session-context signals from other plugins
- Plan-sdlc and ship-sdlc skill instructions updated with contradictory-signal override logic (implements spec requirements R16 and R21): emit one audit line and continue when a co-installed plugin's signal conflicts with SDLC's own detection
- New `docs/plugin-interop.md` documents the authority model for OpenSpec detection when multiple plugins coexist
- Promptfoo exec datasets added for session-start hook and plan/ship prepare scripts covering the new authoritative output fields
- Promptfoo behavioral datasets extended with contradictory-signal scenarios for plan-sdlc and ship-sdlc
- Test fixture directories created for projects with and without active OpenSpec changes

## Testing

- New exec test dataset (`session-start-exec.yaml`) verifies the hook emits `INITIALIZED` with spec count and evidence path across three fixture states: no OpenSpec, baseline-only, and active change.
- New exec test dataset (`plan-prepare-exec.yaml`) verifies `plan.js` emits `authoritative` when OpenSpec is present and omits it when absent.
- Extended `ship-prepare-exec.yaml` with two cases verifying `openspecAuthoritative` is non-null when present and null when absent.
- New behavioral test cases in `plan-sdlc.yaml` and `ship-sdlc.yaml` assert override audit line emission, correct evidence path reference, and no false-negative treatment — using string match and llm-rubric assertions.
- Fixture directories `project-openspec-baseline` and `project-openspec-active` created with realistic OpenSpec structures to back the exec tests.