### PR TITLE
feat(#131): received-review-sdlc - auto-execute Step 12 without gate

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,14 @@
 This is the append-only learnings log for the `ai-setup-automation` marketplace repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-04-23 — pr-sdlc auto-switch account detection
+**Trigger:** `gh pr create` failed with permissions error because active gh account was `rnagrodzkicl` (work account) rather than `rnagrodzki` (personal account where the repo lives). The auto-switch logic in `pr.js` did not switch because the branch had already been pushed with the remote set.
+**Rule:** When `gh pr create` fails with a permissions error, check `gh auth status` and switch to the account matching the repo owner before retrying. The skill should detect this and switch automatically; when it doesn't, manual `gh auth switch --user <login>` is the fix.
+**Example:** Repo owner is `rnagrodzki`; active account was `rnagrodzkicl`; fix was `gh auth switch --user rnagrodzki`.
+
+## 2026-04-23 — version-sdlc: patch bump on feature branch without upstream
+Branch feat/131-received-review-auto-step12 had no upstream configured. `git push` failed with exit 128; recovered with `git push --set-upstream origin <branch>` then `git push --tags`. The `remoteState.hasUpstream: false` in the version context was the correct pre-condition warning. No data lost.
+
 ## 2026-04-15 — PR #165 (fix/#164 openspec-detection hardening)
 
 The `prConfig.titlePattern` for this repo requires `type(#issue): scope - description` format (e.g. `fix(#164): openspec-detection - harden against contradictory signals`). The dash-separated scope and description is mandatory — titles without the ` - ` separator will fail validation. Conventional commit style alone (without issue number in parens) is not accepted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.22] - 2026-04-23
+
+### Added
+- received-review-sdlc now auto-executes Step 12 (reply to PR threads and resolve addressed items) when `--auto` is active, without an interactive consent gate (#131)
+
 ## [0.17.21] - 2026-04-15
 
 ### Added

--- a/docs/skills/received-review-sdlc.md
+++ b/docs/skills/received-review-sdlc.md
@@ -24,7 +24,7 @@ Provide review feedback in one of three ways:
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--pr <number>` | PR number to fetch review threads from. Enables thread-aware mode: pre-computes thread resolution state, filters to outstanding comments only on re-run. | Auto-detected from current branch |
-| `--auto` | Skip the consent gate (Step 10) and auto-implement all "will fix" items. Critique gates still run. "Disagree" and "won't fix" items are displayed but not auto-actioned. | Off |
+| `--auto` | Skip consent gates at Step 10 and Step 12. Auto-implement all "will fix" items and auto-post in-thread replies (resolving only "agree, will fix" threads). Critique gates still run. "Disagree" and "won't fix" items are displayed but not auto-implemented; their threads are replied to but left open. | Off |
 
 ---
 
@@ -95,7 +95,7 @@ When invoked from `/ship-sdlc` with `--auto`, the consent gate is skipped and "w
 /received-review-sdlc --pr 42 --auto
 ```
 
-Claude runs the full analysis pipeline (Steps 2–9), displays the action plan for visibility, then proceeds directly to implement "will fix" items. Items with "disagree" or "won't fix" verdicts are displayed but not auto-actioned. Critique gates still run.
+Claude runs the full analysis pipeline (Steps 2–9), displays the action plan for visibility, then proceeds directly to implement "will fix" items. Items with "disagree" or "won't fix" verdicts are displayed but not auto-actioned. Critique gates still run. Step 12 also runs automatically: Claude posts in-thread replies and resolves "agree, will fix" threads without a second consent prompt.
 
 ### Re-run on a partially addressed PR
 

--- a/docs/specs/received-review-sdlc.md
+++ b/docs/specs/received-review-sdlc.md
@@ -9,7 +9,7 @@
 ## Arguments
 
 - A1: `--pr <number>` — PR number to process review comments from (default: none, falls back to manual gathering)
-- A2: `--auto` — auto-implement "will fix" items without interactive consent; "disagree"/"needs discussion"/"won't fix" items are displayed but never auto-actioned (default: false)
+- A2: `--auto` — auto-implement "will fix" items without Step 10 consent; also auto-runs Step 12 (post in-thread replies and resolve "agree, will fix" threads) without consent. "disagree"/"needs discussion"/"won't fix" items are displayed but never auto-implemented; their threads are replied to but not resolved (default: false)
 
 ## Core Requirements
 
@@ -28,6 +28,7 @@
 - R13: Forbidden openers: no performative language ("Great catch!", "You're right!", "Thanks!")
 - R14: YAGNI check for feature requests: grep codebase for actual usage before accepting
 - R15: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R16: Under `--auto`, Step 12 posts in-thread replies for all action-plan items and resolves only "agree, will fix" threads without an AskUserQuestion gate; pushback and "won't fix" threads are replied to but left open for the reviewer
 
 ## Workflow Phases
 
@@ -100,6 +101,7 @@ Critique #2 (responses):
 - C11: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
 - C12: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C13: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
+- C14: Must not present Step 12 consent gate when `flags.auto` is true — the reply/resolve step auto-executes under the same policy as manual `yes`
 
 ## Step-Emitter Contract
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.21",
+  "version": "0.17.22",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/received-review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/received-review-sdlc/SKILL.md
@@ -331,7 +331,16 @@ Review feedback processing complete:
 - K comments intentionally skipped (agree, won't fix)
 ```
 
-2. **Consent gate** — Use AskUserQuestion:
+2. **Consent gate:**
+
+**Auto mode:** When `flags.auto` is true (from manifest or arguments), skip the AskUserQuestion
+consent gate. Still display the summary block above for visibility, then proceed directly to
+step 3 below as if the user selected `yes`: post in-thread replies for every action-plan item
+and resolve only "agree, will fix" threads. Pushback and "won't fix" threads are replied to
+but left open for the reviewer. Pipeline context does NOT override this behavior — only the
+explicit `flags.auto` signal skips the gate.
+
+**Manual mode (default):** When `flags.auto` is false or absent, use AskUserQuestion:
 
 > Should I reply to all addressed review comments on the PR and resolve the threads?
 
@@ -340,7 +349,7 @@ Options:
 - **skip** — do not post replies (user will handle manually)
 - **selective** — let me choose which threads to reply to
 
-3. **If yes or selective:** For each comment in the action plan:
+3. **If yes, selective, or auto mode:** For each comment in the action plan:
 
    **For addressed comments (agree, will fix):**
    - Post a reply describing what was changed:

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -171,7 +171,7 @@ Not all sub-skills support `--auto`. This table is the source of truth:
 | execute-plan-sdlc | No | Forwards `--preset` only. Preset selection prompt is skipped when preset is provided. |
 | commit-sdlc | Yes | `--auto` forwarded. Skips commit approval prompt. |
 | review-sdlc | No | No interactive prompts to skip — runs fully automatically already. |
-| received-review-sdlc | Yes | `--auto` forwarded. Skips consent prompt. Critique gates and verification still run. Only "will fix" items auto-implemented. |
+| received-review-sdlc | Yes | `--auto` forwarded. Skips Step 10 consent prompt and Step 12 reply/resolve prompt. Critique gates and verification still run. Only "will fix" items auto-implemented; threads for "will fix" items auto-resolved. |
 | version-sdlc | Yes | `--auto` forwarded. Skips release plan approval prompt. Pre-condition checks and critique gates still run. |
 | pr-sdlc | Yes | `--auto` forwarded. Skips PR approval prompt. |
 
@@ -618,7 +618,7 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 
 **Verdict detection is text-based.** Parse the conversation for a line matching `Verdict: <VERDICT>`. The review-sdlc orchestrator always emits this. If the conversation is compacted between review and verdict parsing, the verdict may be lost — treat missing verdict as APPROVED WITH NOTES and warn the user.
 
-**received-review-sdlc supports `--auto`.** When `--auto` is forwarded, the consent prompt (Step 10) is skipped and only "will fix" items are auto-implemented. "Disagree" and "won't fix" items are displayed but not auto-actioned. Critique gates and verification still run. Without `--auto`, the pipeline pauses for human approval.
+**received-review-sdlc supports `--auto`.** When `--auto` is forwarded, both the Step 10 consent prompt and the Step 12 reply/resolve prompt are skipped. "Will fix" items are auto-implemented and their threads are auto-resolved via in-thread replies. "Disagree" and "won't fix" items are displayed but not auto-implemented; their threads are replied to but left open for the reviewer. Critique gates and verification still run. Without `--auto`, the pipeline pauses for human approval at both gates.
 
 **Double commit is intentional.** Feature commit (step 2) and review fix commit (step 5) are separate. This keeps feature work and review fixes distinct in git history. Do not squash them.
 

--- a/tests/promptfoo/datasets/received-review-sdlc.yaml
+++ b/tests/promptfoo/datasets/received-review-sdlc.yaml
@@ -243,3 +243,35 @@
         the ship-sdlc pipeline, the consent gate is NOT skipped and there is no inference
         that automatic execution is expected. The response does not reference pipeline
         context as a reason to bypass the consent gate.
+
+- description: "received-review-sdlc: --auto mode auto-executes Step 12 without reply/resolve consent gate"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/received-review-sdlc/SKILL.md"
+    project_context: "file://fixtures/pr-review-reply-step.md"
+    user_request: >
+      Run /received-review-sdlc --auto. The prepare script manifest includes
+      flags: { auto: true }. Review fixes have been implemented and verified.
+      Proceed to Step 12 (reply to PR threads and resolve addressed ones).
+  assert:
+    # Must still display the Step 12 summary
+    - type: regex
+      value: "(addressed|fixed|implemented|summary)"
+    # Must NOT present the yes/skip/selective consent prompt
+    - type: not-regex
+      value: "(yes.*skip.*selective|Should I reply|How to proceed)"
+    # Must proceed to post replies and resolve threads
+    - type: regex
+      value: "(reply|resolve|post|threadId|gh api)"
+    # Must still distinguish resolved vs left-open threads
+    - type: regex
+      value: "(push.?back|disagree|left open|reviewer)"
+    - type: llm-rubric
+      value: >
+        The response demonstrates --auto mode behavior in Step 12: the summary of
+        addressed/pushback/skipped comments is displayed, but the yes/skip/selective
+        AskUserQuestion consent gate is NOT presented. The skill proceeds directly to
+        posting in-thread replies for every action-plan item and resolves only the
+        "agree, will fix" threads via GraphQL mutation. Pushback and "won't fix"
+        threads are replied to but left open for the reviewer. No pipeline-context
+        reasoning is used to justify skipping — the behavior is driven by
+        flags.auto === true from the prepare script manifest.


### PR DESCRIPTION
## Summary
Adds `--auto` mode support for Step 12 of `received-review-sdlc`, which posts in-thread replies to reviewed PR comments and resolves "agree, will fix" threads. Previously, `--auto` only skipped the Step 10 implementation consent gate but still paused at Step 12 for reply/resolve approval. This change makes the full pipeline non-interactive when `--auto` is active.

## Business Context
Plugin users running automated SDLC pipelines (e.g., via `ship-sdlc --auto`) expect the entire workflow to execute without manual intervention. The Step 12 consent gate was a gap — it blocked pipeline automation even after Step 10 was already auto-executed, requiring the user to interact manually to post replies and resolve threads.

## Business Benefits
- Fully automated review-response cycle: implement fixes and close review threads in a single non-interactive pipeline run
- Eliminates a manual step that blocked `ship-sdlc --auto` from completing end-to-end
- "Disagree" and "won't fix" threads are still replied to but deliberately left open for the reviewer — preserving review integrity

## Github Issue
Closes #131
Closes #117

## Technical Design
Step 12 of `received-review-sdlc` gained an auto-mode branch that checks `flags.auto` from the prepare script manifest. When true, the `AskUserQuestion` consent gate is skipped entirely; the summary block is still displayed for visibility. Only "agree, will fix" threads are resolved; pushback and "won't fix" threads receive a reply but remain open. The spec was updated with R16 (behavior requirement) and C14 (critique gate). The `ship-sdlc` auto audit table row was updated to document both gates that are now skipped. No changes to the prepare script or schema.

## Technical Impact
None. No breaking changes to skill interfaces, hook payloads, or script APIs. The `--auto` flag behavior is additive — existing manual-mode users are unaffected.

## Changes Overview
- `received-review-sdlc` Step 12 now auto-executes when `flags.auto` is true, skipping the reply/resolve consent gate and proceeding directly to post replies and resolve "agree, will fix" threads
- Spec updated with new requirement R16 (auto-mode Step 12 behavior) and critique gate C14 (must not present consent gate under `--auto`)
- Argument spec A2 updated to document that `--auto` now covers both Step 10 and Step 12
- `ship-sdlc` auto audit table and Gotcha section updated to reflect that both consent gates are skipped under `--auto`
- Skill reference docs flags table and example description updated to describe the expanded `--auto` scope
- New promptfoo test case covering auto-mode Step 12: verifies summary display, no consent prompt, thread resolution behavior, and pushback handling

## Testing
New promptfoo test case added to `received-review-sdlc.yaml` dataset. The test asserts: Step 12 summary is displayed, the `yes/skip/selective` AskUserQuestion is NOT presented, replies and thread resolution proceed, and "disagree"/"won't fix" threads are left open. Existing test cases for the Step 12 consent-gate enforcement (manual mode) are preserved.