### PR TITLE
feat(#171): jira-sdlc - home cache, multi-project support, CI discovery flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.23] - 2026-04-23
+
+### Added
+- jira-sdlc cache moved to `~/.sdlc-cache/jira/<site>/<KEY>.json` for XDG compliance; multi-project support via `jira.projects` array; new `--skip-workflow-discovery` flag for setup control
+
+### Fixed
+- jira-sdlc spec and doc hardening: R-number annotations, siteUrl format clarity, cache path handling, and additional roundtrip and home-cache layout tests
+
 ## [0.17.22] - 2026-04-23
 
 ### Added

--- a/docs/skills/jira-sdlc.md
+++ b/docs/skills/jira-sdlc.md
@@ -9,7 +9,7 @@ Manages Jira issues via the Atlassian MCP with a project metadata cache that eli
 ## Usage
 
 ```text
-/jira-sdlc [--project <KEY>] [--force-refresh] [--init-templates]
+/jira-sdlc [--project <KEY>] [--force-refresh] [--init-templates] [--site <host>] [--skip-workflow-discovery]
 ```
 
 ---
@@ -18,9 +18,11 @@ Manages Jira issues via the Atlassian MCP with a project metadata cache that eli
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--project <KEY>` | Jira project key to use (e.g., `PROJ`). Auto-detected from git branch or `.sdlc/jira-config.json` | Auto |
+| `--project <KEY>` | Jira project key to use (e.g., `PROJ`). Auto-detected from git branch or `.claude/sdlc.json` → `jira.defaultProject`. When `jira.projects` is set (≥2 entries), values outside the list are rejected. | Auto |
 | `--force-refresh` | Rebuild the project cache from scratch (cache is permanent by default; use when project metadata has changed) | — |
 | `--init-templates` | Copy the skill's default issue type templates to `.claude/jira-templates/` for customization | — |
+| `--site <host>` | Sanitized site host (lowercased, `.` → `_`, e.g., `acme_atlassian_net`). Disambiguates `--check`/`--load` when the same project key is cached under multiple site subdirectories. | Unset |
+| `--skip-workflow-discovery` | Bypass Phase 5; cache marks each non-subtask issue type `{ unsampled: true }`. Transitions fall back to a live `getTransitionsForJiraIssue` per issue. Use in CI and other pre-seeded environments. | false |
 
 ---
 
@@ -156,17 +158,51 @@ After interactive setup, template files are created with your locale's names (e.
 
 ## How the Cache Works
 
-The cache is stored at `.sdlc/jira-cache/<PROJECT_KEY>.json` and is permanent by default — it does not expire on a timer. It is refreshed when `--force-refresh` is passed or when an operation fails due to stale cached data (e.g., invalid transition IDs or changed field schemas), triggering an automatic rebuild and retry.
+The cache is stored at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json` and is permanent by default — it does not expire on a timer. `sanitizedSiteHost` is the site URL host lowercased with `.` replaced by `_` (e.g., `acme.atlassian.net` → `acme_atlassian_net`). The cache lives outside the working tree so it is never committed, survives repo clones, and supports repos that map to multiple Jira tenants (one subdirectory per site). Refreshed when `--force-refresh` is passed or when an operation fails due to stale cached data (e.g., invalid transition IDs or changed field schemas), triggering an automatic rebuild and retry.
 
 The cache contains:
 
 - `cloudId` — Atlassian cloud instance identifier
+- `siteUrl` — site origin used to derive the cache subdirectory
 - Issue types and their field schemas (including custom fields)
-- Workflow graphs with transition IDs and per-transition required fields
+- Workflow graphs with transition IDs and per-transition required fields (or `{ unsampled: true }` when Phase 5 was skipped)
 - Available issue link types
 - User account ID mappings (display name → accountId)
 
 After initialization, most operations require a single MCP call instead of 4–8 discovery calls, significantly reducing latency and token usage.
+
+### Legacy Cache Migration
+
+Earlier versions of this skill stored the cache in-repo at `.sdlc/jira-cache/<KEY>.json` (and before that, `.claude/jira-cache/<KEY>.json`). On the next `--check`, the prepare script detects either legacy location, copies the file to the home layout using the `siteUrl` embedded in the JSON, and emits a warning. The legacy file is left in place for the user to clean up once confident. Migration is idempotent: subsequent runs find the home cache first and skip the legacy probe entirely.
+
+### Multiple Projects
+
+Repos that map to multiple Jira projects can enumerate the allowed keys in `.claude/sdlc.json`:
+
+```json
+{
+  "jira": {
+    "defaultProject": "FOO",
+    "projects": ["FOO", "BAR", "BAZ"]
+  }
+}
+```
+
+When `jira.projects` is set with two or more entries:
+
+- `--project <KEY>` arguments are validated against the list. Values outside the list are rejected (prepare script exits 1).
+- When branch parsing, `defaultProject`, and `--project` all fail to resolve a key, the skill presents a closed-list AskUserQuestion restricted to the configured projects — no free-form input.
+- Single-project repos (no `jira.projects`, or only one entry) retain the prior four-step fallback with a free-form prompt as the final step.
+
+### CI Usage
+
+Phase 5 workflow discovery fires an MCP call per non-subtask issue type (and several per type for transition sampling). In pre-seeded CI environments where the cache is bootstrapped ahead of time, or on cold runs where end-to-end latency matters more than transition coverage, pass `--skip-workflow-discovery`:
+
+```bash
+/jira-sdlc --project PROJ --force-refresh --skip-workflow-discovery
+```
+
+The resulting cache stores `workflows: { "<Type>": { "unsampled": true } }` for every non-subtask issue type. At runtime, any transition operation that encounters an `unsampled` marker routes through a live `getTransitionsForJiraIssue` per issue — the same auto-refresh path used when a cached transition ID stales out. Other cache sections (issue types, field schemas, link types, user mappings) are still populated normally.
 
 ---
 
@@ -180,7 +216,7 @@ After initialization, most operations require a single MCP call instead of 4–8
 
 | Field | Value |
 |---|---|
-| `argument-hint` | `[--project <KEY>] [--force-refresh] [--init-templates]` |
+| `argument-hint` | `[--project <KEY>] [--force-refresh] [--init-templates] [--site <host>] [--skip-workflow-discovery]` |
 | Plan mode | Not adapted (writes to Jira) |
 
 ---
@@ -189,8 +225,7 @@ After initialization, most operations require a single MCP call instead of 4–8
 
 | File / Artifact | Description |
 |-----------------|-------------|
-| `.sdlc/jira-cache/<KEY>.json` | Project metadata cache: cloudId, issue types, field schemas, workflows, user mappings |
-| `.sdlc/jira-cache/.gitignore` | Git-ignore file preventing cache contents from being committed; created automatically on first use |
+| `~/.sdlc-cache/jira/<site>/<KEY>.json` | Project metadata cache (home-keyed, outside the working tree): cloudId, issue types, field schemas, workflows, user mappings |
 | `.claude/jira-templates/<Type>.md` | Project-level issue description templates (created only when `--init-templates` is run, or manually) |
 | Jira issues | Created or updated via the Atlassian MCP |
 

--- a/docs/skills/jira-sdlc.md
+++ b/docs/skills/jira-sdlc.md
@@ -163,7 +163,7 @@ The cache is stored at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.jso
 The cache contains:
 
 - `cloudId` — Atlassian cloud instance identifier
-- `siteUrl` — site origin used to derive the cache subdirectory
+- `siteUrl` — canonical form is the full origin URL (e.g., `https://acme.atlassian.net`); the prepare script also accepts a bare host (e.g., `acme.atlassian.net`) and will strip any trailing path. The `sanitizedSiteHost` subdirectory is always derived from the host portion only.
 - Issue types and their field schemas (including custom fields)
 - Workflow graphs with transition IDs and per-transition required fields (or `{ unsampled: true }` when Phase 5 was skipped)
 - Available issue link types

--- a/docs/specs/jira-sdlc.md
+++ b/docs/specs/jira-sdlc.md
@@ -8,16 +8,18 @@
 
 ## Arguments
 
-- A1: `--project <KEY>` — Jira project key (default: auto-detected via 4-step fallback)
+- A1: `--project <KEY>` — Jira project key (default: auto-detected via 5-step fallback). When `jira.projects` is set, values outside that list are rejected.
 - A2: `--force-refresh` — rebuild cache regardless of current state (default: false)
 - A3: `--init-templates` — copy default description templates to `.claude/jira-templates/` (default: false)
+- A4: `--skip-workflow-discovery` — bypass Phase 5 workflow discovery; per non-subtask issue type, cache `workflows: { <type>: { unsampled: true } }`. Transition operations fall back to a live `getTransitionsForJiraIssue` call per issue when workflow data is marked `unsampled`. Use in CI or pre-seeded environments where Phase 5 MCP calls are too expensive.
+- A5: `--site <host>` — disambiguator for `--check`/`--load` when multiple cache files for the same project key exist under different site subdirectories of `~/.sdlc-cache/jira/`. Value is the sanitized site host (lowercased, `.` → `_`, e.g., `acme_atlassian_net`).
 
 ## Core Requirements
 
-- R1: Initialize a deterministic cache at `.sdlc/jira-cache/<PROJECT_KEY>.json` containing cloudId, issue types, field schemas, workflow graphs, link types, and user mappings
+- R1: Initialize a deterministic cache at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json` containing cloudId, issue types, field schemas, workflow graphs, link types, and user mappings. `sanitizedSiteHost` is derived from `siteUrl` — the URL host lowercased with `.` replaced by `_` (e.g., `acme.atlassian.net` → `acme_atlassian_net`). The cache lives outside the working tree to avoid repo-local state and to support multi-tenant (site-keyed) installations. When a project-keyed cache file is found at the legacy in-repo locations `.sdlc/jira-cache/<KEY>.json` or `.claude/jira-cache/<KEY>.json`, the prepare script migrates it to the home layout using `sanitizeSiteHost(cache.siteUrl)` and emits a warning; the legacy file is left in place for the user to clean up.
 - R2: Cache is permanent by default (no timer-based expiry); rebuilt only on `--force-refresh` or operation failure due to stale data
 - R3: After initialization, all operations read exclusively from cache — no discovery endpoint calls
-- R4: Project key resolution follows 4-step ordered fallback: (1) `--project` argument, (2) branch name pattern `[A-Z]{2,10}-\d+`, (3) `.claude/sdlc.json` → `jira.defaultProject`, (4) AskUserQuestion
+- R4: Project key resolution follows 5-step ordered fallback: (1) `--project` argument, (2) branch name pattern `[A-Z]{2,10}-\d+` — when `jira.projects` is configured, only keys that match a member of `jira.projects` accept this signal, (3) `.claude/sdlc.json` → `jira.defaultProject`, (4) when `jira.projects` has ≥2 entries, AskUserQuestion with a closed list matching `jira.projects`, (5) free-form AskUserQuestion. Backward compatible: repos without `jira.projects` behave as before (steps 1/2/3/5).
 - R5: Cache initialization runs 6 phases: identity, project metadata, issue types, field schemas (parallel per type), workflow discovery (per non-subtask type), assemble and save
 - R6: Classify user intent into one of 10 operation types: create, edit, search, transition, comment, link, assign, worklog, view, bulk
 - R7: Per-issue-type description templates are filled from user context before MCP calls; all `{placeholder}` markers must be replaced or the section removed — never send raw placeholders
@@ -26,6 +28,15 @@
 - R10: When `--init-templates` is passed, initialize templates and stop — do not execute any Jira operation
 - R11: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R12: Comments must be converted from markdown to ADF via `scripts/lib/markdown-to-adf.js` before posting to Jira — compose in markdown using REFERENCE.md Section 4 safe syntax, pipe through the conversion script, then call `addCommentToJiraIssue` with `contentFormat: "adf"` and the ADF JSON body
+- R13: `jira.projects` (string[]) may be set in `.claude/sdlc.json` alongside or instead of `jira.defaultProject`. When set with ≥2 entries, the skill (1) rejects `--project <KEY>` arguments whose value is not a member of `jira.projects` (prepare script exits 1 with a descriptive error), and (2) presents a closed-list AskUserQuestion prompt using only the configured projects when no other signal resolves the project key. Single-project repos (no `jira.projects`, or fewer than 2 entries) retain the prior behavior with `defaultProject`.
+- R14: `--skip-workflow-discovery` bypasses Phase 5 entirely. The cache is written with `workflows: { <type>: { unsampled: true } }` for each non-subtask issue type. Transition operations that encounter an `unsampled` marker fall back to a live `getTransitionsForJiraIssue` call per issue (reusing the existing stale-cache auto-refresh path from R9/E10). Cache rows for subtask types and other sections are populated normally.
+- R15: When `--check` resolves against the home-cache layout without `--site`, it scans `~/.sdlc-cache/jira/*/<KEY>.json` for all candidates. Zero matches → `{ exists: false }` (treat as fresh install). Exactly one match → use it. Two or more matches → `{ exists: false, candidateSites: [<host>, …] }`; the user must re-run with `--site <host>` to disambiguate or `--force-refresh` to rebuild against a specific site.
+- R16: SKILL.md frontmatter `description` must include auto-trigger phrases covering the full operation surface: read/view, comment add, create, edit, search, transition, link, assign, worklog, bulk. Required trigger tokens: `read jira`, `view jira`, `show jira`, `get jira`, `fetch jira`, `jira details`, `add comment`, `comment on jira`, `reply to jira`, `jira ticket`, `jira issue`. Purpose: allow the downstream model to activate the skill automatically on common read-and-comment phrasings without an explicit `/jira-sdlc` invocation. Total frontmatter `description` length must stay within 1024 characters.
+
+## Assumptions
+
+- A4 (context): `~/.sdlc-cache/` is writable by the user running the skill. On platforms without a writable `$HOME`, the user may override with `--cache-dir <path>` (preserves existing flag behavior).
+- A5 (context): `siteUrl` is always present in cache payloads; `saveCache` enforces this. Cache files migrated from legacy locations carry their original `siteUrl`, which is used to derive the new site subdirectory.
 
 ## Workflow Phases
 
@@ -61,6 +72,7 @@
 - P2: `missing` (string[]) — required cache sections that are absent
 - P3: `fresh` (boolean) — whether cache is within TTL (when `maxAgeHours > 0`)
 - P4: Cache load output (full JSON) — the complete cache object when `--load` is used
+- P5: `candidateSites` (string[]) — populated by `--check` when two or more home-cache entries match the project key without `--site` disambiguation. Empty or absent when the candidate count is 0 or 1. Paired with `exists: false` when ≥2 candidates exist.
 
 ## Error Handling
 

--- a/docs/specs/jira-sdlc.md
+++ b/docs/specs/jira-sdlc.md
@@ -35,8 +35,8 @@
 
 ## Assumptions
 
-- A4 (context): `~/.sdlc-cache/` is writable by the user running the skill. On platforms without a writable `$HOME`, the user may override with `--cache-dir <path>` (preserves existing flag behavior).
-- A5 (context): `siteUrl` is always present in cache payloads; `saveCache` enforces this. Cache files migrated from legacy locations carry their original `siteUrl`, which is used to derive the new site subdirectory.
+- C1 (context): `~/.sdlc-cache/` is writable by the user running the skill. On platforms without a writable `$HOME`, the user may override with `--cache-dir <path>` (preserves existing flag behavior).
+- C2 (context): `siteUrl` is always present in cache payloads; `saveCache` enforces this. Cache files migrated from legacy locations carry their original `siteUrl`, which is used to derive the new site subdirectory.
 
 ## Workflow Phases
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.22",
+  "version": "0.17.23",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/session-start.js
+++ b/plugins/sdlc-utilities/hooks/session-start.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const fs   = require('node:fs');
+const os   = require('node:os');
 const path = require('node:path');
 
 const pluginRoot = path.resolve(__dirname, '..');
@@ -261,43 +262,68 @@ try {
 // ---------------------------------------------------------------------------
 
 try {
-  const projectRoot = process.cwd();
-  const jiraCacheDir = path.join(projectRoot, '.sdlc', 'jira-cache');
-  if (fs.existsSync(jiraCacheDir)) {
-    const cacheFiles = fs.readdirSync(jiraCacheDir).filter(f => f.endsWith('.json'));
-    for (const cacheFile of cacheFiles) {
+  // Home-cache layout: ~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json
+  const homeRoot = path.join(os.homedir(), '.sdlc-cache', 'jira');
+  const entries = [];
+  if (fs.existsSync(homeRoot)) {
+    let siteDirs;
+    try {
+      siteDirs = fs.readdirSync(homeRoot, { withFileTypes: true });
+    } catch {
+      siteDirs = [];
+    }
+    for (const siteEntry of siteDirs) {
+      if (!siteEntry.isDirectory()) continue;
+      const siteDir = path.join(homeRoot, siteEntry.name);
+      let cacheFiles;
       try {
-        const projectKey = path.basename(cacheFile, '.json');
-        const cacheData = JSON.parse(fs.readFileSync(path.join(jiraCacheDir, cacheFile), 'utf8'));
-        const lastUpdated = cacheData.lastUpdated;
-        const maxAgeHours = cacheData.maxAgeHours;
-
-        if (!lastUpdated) continue;
-
-        const ageMs = Date.now() - new Date(lastUpdated).getTime();
-        const ageHours = ageMs / (1000 * 60 * 60);
-
-        let ageDisplay;
-        if (ageHours < 1) {
-          ageDisplay = 'less than 1h ago';
-        } else if (ageHours < 24) {
-          const h = Math.round(ageHours);
-          ageDisplay = `${h}h ago`;
-        } else {
-          const d = Math.round(ageHours / 24);
-          ageDisplay = `${d} day${d !== 1 ? 's' : ''} ago`;
-        }
-
-        if (maxAgeHours === 0) {
-          resumeLines.push(`Jira cache: ${projectKey} (last updated ${ageDisplay}, permanent)`);
-        } else if (ageHours > maxAgeHours) {
-          resumeLines.push(`Jira cache: ${projectKey} (stale — ${ageDisplay}, TTL ${maxAgeHours}h) — refresh with /jira-sdlc --force-refresh`);
-        } else {
-          resumeLines.push(`Jira cache: ${projectKey} (last updated ${ageDisplay}, TTL ${maxAgeHours}h)`);
-        }
+        cacheFiles = fs.readdirSync(siteDir).filter(f => f.endsWith('.json'));
       } catch {
-        // Graceful degradation — skip this cache file on any error
+        continue;
       }
+      for (const cacheFile of cacheFiles) {
+        const projectKey = path.basename(cacheFile, '.json');
+        const fullPath = path.join(siteDir, cacheFile);
+        try {
+          const cacheData = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+          entries.push({
+            projectKey,
+            site:        siteEntry.name,
+            lastUpdated: cacheData.lastUpdated,
+            maxAgeHours: cacheData.maxAgeHours,
+          });
+        } catch {
+          // Graceful degradation — skip this cache file on parse error
+        }
+      }
+    }
+  }
+
+  for (const entry of entries) {
+    const { projectKey, site, lastUpdated, maxAgeHours } = entry;
+    if (!lastUpdated) continue;
+
+    const ageMs = Date.now() - new Date(lastUpdated).getTime();
+    const ageHours = ageMs / (1000 * 60 * 60);
+
+    let ageDisplay;
+    if (ageHours < 1) {
+      ageDisplay = 'less than 1h ago';
+    } else if (ageHours < 24) {
+      const h = Math.round(ageHours);
+      ageDisplay = `${h}h ago`;
+    } else {
+      const d = Math.round(ageHours / 24);
+      ageDisplay = `${d} day${d !== 1 ? 's' : ''} ago`;
+    }
+
+    const label = `${projectKey}@${site}`;
+    if (maxAgeHours === 0) {
+      resumeLines.push(`Jira cache: ${label} (last updated ${ageDisplay}, permanent)`);
+    } else if (ageHours > maxAgeHours) {
+      resumeLines.push(`Jira cache: ${label} (stale — ${ageDisplay}, TTL ${maxAgeHours}h) — refresh with /jira-sdlc --force-refresh`);
+    } else {
+      resumeLines.push(`Jira cache: ${label} (last updated ${ageDisplay}, TTL ${maxAgeHours}h)`);
     }
   }
 } catch {

--- a/plugins/sdlc-utilities/scripts/skill/jira.js
+++ b/plugins/sdlc-utilities/scripts/skill/jira.js
@@ -373,7 +373,14 @@ function resolveEffectiveCachePath({ projectKey, cacheDir, site }) {
   // Home-cache scan
   const matches = resolveCandidatePaths(projectKey, site);
   if (site) {
-    // --site always resolves to a single path (may not exist yet).
+    // --site always resolves to a single candidate path. When the home-cache
+    // root itself does not exist yet, return path: null so callers emit a clear
+    // "No cache found" rather than propagating a path that cannot exist.
+    const root = getHomeCacheRoot();
+    if (!fs.existsSync(root)) {
+      warnings.push(`Home cache root ${root} does not exist. Run cache initialization first (omit --site or use --force-refresh).`);
+      return { path: null, warnings, candidateSites: [] };
+    }
     return { path: matches[0].path, warnings, candidateSites: [] };
   }
 

--- a/plugins/sdlc-utilities/scripts/skill/jira.js
+++ b/plugins/sdlc-utilities/scripts/skill/jira.js
@@ -6,7 +6,8 @@
  * workflow graphs, user mappings) to eliminate repeated discovery calls.
  *
  * Usage:
- *   node jira-prepare.js --project <KEY> [--cache-dir <path>] [subcommand]
+ *   node jira-prepare.js --project <KEY> [--cache-dir <path>] [--site <host>]
+ *                        [--skip-workflow-discovery] [subcommand]
  *
  * Subcommands:
  *   --check          Report cache + template status (default)
@@ -31,19 +32,146 @@ const LIB = path.join(__dirname, '..', 'lib');
 const { writeOutput } = require(path.join(LIB, 'output'));
 
 // ---------------------------------------------------------------------------
+// Home-cache path helpers
+// ---------------------------------------------------------------------------
+
+function getHomeCacheRoot() {
+  return path.join(os.homedir(), '.sdlc-cache', 'jira');
+}
+
+function sanitizeSiteHost(siteUrl) {
+  if (!siteUrl || typeof siteUrl !== 'string') return null;
+  let host;
+  try {
+    host = new URL(siteUrl).host;
+  } catch (_) {
+    // Accept bare hosts passed without scheme
+    host = siteUrl.replace(/^https?:\/\//i, '').split('/')[0];
+  }
+  if (!host) return null;
+  return host.toLowerCase().replace(/\./g, '_');
+}
+
+/**
+ * Resolve candidate cache paths for a project key.
+ * - If `explicitSite` is provided, returns a single path under that site subdir
+ *   (whether or not the file exists — caller decides).
+ * - Otherwise scans `~/.sdlc-cache/jira/<site>/<KEY>.json` for every site and
+ *   returns only existing matches.
+ *
+ * Returns an array of { path, site } entries.
+ */
+function resolveCandidatePaths(projectKey, explicitSite) {
+  const root = getHomeCacheRoot();
+  if (explicitSite) {
+    return [{ path: path.join(root, explicitSite, `${projectKey}.json`), site: explicitSite }];
+  }
+  let sites;
+  try {
+    sites = fs.readdirSync(root, { withFileTypes: true });
+  } catch (_) {
+    return [];
+  }
+  const matches = [];
+  for (const entry of sites) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(root, entry.name, `${projectKey}.json`);
+    if (fs.existsSync(candidate)) {
+      matches.push({ path: candidate, site: entry.name });
+    }
+  }
+  return matches;
+}
+
+/**
+ * Load the `jira` section of project config from `.claude/sdlc.json`, falling
+ * back to legacy `.sdlc/jira-config.json` if present. Returns `{}` on any
+ * failure — callers treat missing/invalid config as "no multi-project setup".
+ */
+function loadJiraConfig(projectRoot) {
+  try {
+    const { readSection } = require(path.join(LIB, 'config.js'));
+    const section = readSection(projectRoot, 'jira');
+    if (section && typeof section === 'object') return section;
+  } catch (_) { /* fall through to legacy */ }
+
+  // Legacy location — retained for migration scenarios.
+  const legacy = path.join(projectRoot, '.sdlc', 'jira-config.json');
+  if (fs.existsSync(legacy)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(legacy, 'utf8'));
+      if (parsed && typeof parsed === 'object') return parsed;
+    } catch (_) { /* ignore */ }
+  }
+  return {};
+}
+
+/**
+ * Legacy cache probe: check `.sdlc/jira-cache/<KEY>.json` (newer deprecation
+ * path) then `.claude/jira-cache/<KEY>.json` (older deprecation path).
+ * Returns `{ path, source } | null`.
+ */
+function findLegacyCache(projectKey, projectRoot) {
+  const candidates = [
+    { path: path.join(projectRoot, '.sdlc', 'jira-cache', `${projectKey}.json`), source: '.sdlc/jira-cache' },
+    { path: path.join(projectRoot, '.claude', 'jira-cache', `${projectKey}.json`), source: '.claude/jira-cache' },
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c.path)) return c;
+  }
+  return null;
+}
+
+/**
+ * Migrate a legacy cache file into the home-cache layout using the `siteUrl`
+ * embedded in the file. The legacy file is left in place for the user to
+ * clean up; the migration is idempotent because subsequent calls find the
+ * home cache first.
+ *
+ * Returns `{ migrated: true, path, site, warning }` on success, or
+ * `{ migrated: false, warning }` when siteUrl is missing.
+ */
+function migrateLegacyCache(legacy, projectKey) {
+  let cache;
+  try {
+    cache = JSON.parse(fs.readFileSync(legacy.path, 'utf8'));
+  } catch (err) {
+    return { migrated: false, warning: `Legacy cache at ${legacy.path} is not valid JSON: ${err.message}` };
+  }
+  const site = sanitizeSiteHost(cache.siteUrl);
+  if (!site) {
+    return { migrated: false, warning: `Legacy cache at ${legacy.path} has no siteUrl; cannot migrate automatically. Run --force-refresh to rebuild.` };
+  }
+  const destDir  = path.join(getHomeCacheRoot(), site);
+  const destPath = path.join(destDir, `${projectKey}.json`);
+  if (!fs.existsSync(destPath)) {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.copyFileSync(legacy.path, destPath);
+  }
+  return {
+    migrated: true,
+    path:     destPath,
+    site,
+    warning:  `Migrated legacy cache from ${legacy.source}/${projectKey}.json to ~/.sdlc-cache/jira/${site}/${projectKey}.json (legacy file preserved; delete manually when confident).`,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
 function parseArgs(argv) {
   const args = argv.slice(2);
-  let projectKey    = null;
-  let cacheDir      = path.join(process.cwd(), '.sdlc', 'jira-cache');
-  let templatesDir  = null;
-  let subcommand    = 'check';
-  let saveFieldName = null;
-  let copyType      = null;
-  let copyFrom      = null;
-  const errors      = [];
+  let projectKey             = null;
+  let cacheDir               = null;   // only set when --cache-dir is passed
+  let templatesDir           = null;
+  let subcommand             = 'check';
+  let saveFieldName          = null;
+  let copyType               = null;
+  let copyFrom               = null;
+  let site                   = null;
+  let skipWorkflowDiscovery  = false;
+  const errors               = [];
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -53,6 +181,10 @@ function parseArgs(argv) {
       cacheDir = args[++i];
     } else if (a === '--templates-dir' && args[i + 1]) {
       templatesDir = args[++i];
+    } else if (a === '--site' && args[i + 1]) {
+      site = args[++i];
+    } else if (a === '--skip-workflow-discovery') {
+      skipWorkflowDiscovery = true;
     } else if (a === '--check') {
       subcommand = 'check';
     } else if (a === '--load') {
@@ -81,18 +213,45 @@ function parseArgs(argv) {
     errors.push('--project <KEY> is required');
   }
 
-  return { projectKey, cacheDir, templatesDir, subcommand, saveFieldName, copyType, copyFrom, errors };
+  const flags = {
+    skipWorkflowDiscovery,
+    site,
+  };
+
+  return {
+    projectKey,
+    cacheDir,
+    templatesDir,
+    subcommand,
+    saveFieldName,
+    copyType,
+    copyFrom,
+    site,
+    skipWorkflowDiscovery,
+    flags,
+    errors,
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Path helpers
+// Cache path resolution
 // ---------------------------------------------------------------------------
 
+/**
+ * Legacy signature preserved for back-compat with callers that pass an
+ * explicit --cache-dir (typically tests or custom deployments). When invoked
+ * with a cache dir outside the working tree, the implicit .gitignore write is
+ * suppressed to avoid polluting user home / arbitrary paths.
+ */
 function getCachePath(projectKey, cacheDir) {
   fs.mkdirSync(cacheDir, { recursive: true });
-  const gitignorePath = path.join(cacheDir, '.gitignore');
-  if (!fs.existsSync(gitignorePath)) {
-    fs.writeFileSync(gitignorePath, '*\n', 'utf8');
+  const rel = path.relative(process.cwd(), cacheDir);
+  const insideWorkTree = rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+  if (insideWorkTree) {
+    const gitignorePath = path.join(cacheDir, '.gitignore');
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(gitignorePath, '*\n', 'utf8');
+    }
   }
   return path.join(cacheDir, `${projectKey}.json`);
 }
@@ -151,7 +310,7 @@ function readStdin() {
 
 function resolveTemplateStatus(projectKey, cachePath, templatesDir) {
   let issueTypes = [];
-  if (fs.existsSync(cachePath)) {
+  if (cachePath && fs.existsSync(cachePath)) {
     try {
       const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
       if (cache.issueTypes && typeof cache.issueTypes === 'object') {
@@ -196,41 +355,126 @@ function resolveTemplateStatus(projectKey, cachePath, templatesDir) {
 }
 
 // ---------------------------------------------------------------------------
+// Shared: resolve effective cache path for check/load/clear
+// Returns { path, warnings, candidateSites, error }.
+// - `path` is null when no cache exists and no legacy was migrated.
+// - `candidateSites` is populated when multiple home-cache entries matched.
+// - `error` (string) is set when a hard failure prevents resolution.
+// ---------------------------------------------------------------------------
+
+function resolveEffectiveCachePath({ projectKey, cacheDir, site }) {
+  const warnings = [];
+
+  // Explicit --cache-dir takes precedence (back-compat).
+  if (cacheDir) {
+    return { path: getCachePath(projectKey, cacheDir), warnings, candidateSites: [] };
+  }
+
+  // Home-cache scan
+  const matches = resolveCandidatePaths(projectKey, site);
+  if (site) {
+    // --site always resolves to a single path (may not exist yet).
+    return { path: matches[0].path, warnings, candidateSites: [] };
+  }
+
+  if (matches.length === 1) {
+    return { path: matches[0].path, warnings, candidateSites: [] };
+  }
+
+  if (matches.length >= 2) {
+    const sites = matches.map(m => m.site);
+    warnings.push(`Cache key '${projectKey}' exists under multiple sites: ${sites.join(', ')}. Pass --site <host> to disambiguate.`);
+    return { path: null, warnings, candidateSites: sites };
+  }
+
+  // No home matches — probe legacy
+  const legacy = findLegacyCache(projectKey, process.cwd());
+  if (legacy) {
+    const result = migrateLegacyCache(legacy, projectKey);
+    warnings.push(result.warning);
+    if (result.migrated) {
+      return { path: result.path, warnings, candidateSites: [] };
+    }
+    // Migration failed (no siteUrl) — treat as fresh install.
+  }
+
+  return { path: null, warnings, candidateSites: [] };
+}
+
+/**
+ * Validate `--project <KEY>` against `jira.projects` (when set).
+ * Returns an error string or null.
+ */
+function validateProjectMembership(projectKey, jiraConfig) {
+  const list = Array.isArray(jiraConfig && jiraConfig.projects) ? jiraConfig.projects : null;
+  if (!list || list.length < 2) return null;
+  if (list.includes(projectKey)) return null;
+  return `Project ${projectKey} is not in jira.projects: [${list.join(', ')}]`;
+}
+
+// ---------------------------------------------------------------------------
 // Subcommand: --check
 // ---------------------------------------------------------------------------
 
-function checkCache(cachePath, templatesDir, projectKey) {
-  if (!fs.existsSync(cachePath)) {
-    const legacyPath = path.join(process.cwd(), '.claude', 'jira-cache', `${projectKey}.json`);
-    if (fs.existsSync(legacyPath)) {
-      process.stderr.write('Warning: .claude/jira-cache/ is deprecated. Cache will be written to .sdlc/jira-cache/ on next refresh.\n');
-      cachePath = legacyPath;
-    } else {
-      writeOutput({
-        exists:     false,
-        fresh:      false,
-        projectKey,
-        cachePath,
-        missing:    ['all'],
-        errors:     [],
-        warnings:   [],
-      }, 'jira-context', 0);
-      return;
-    }
+function checkCache({ projectKey, cacheDir, site, skipWorkflowDiscovery, templatesDir }) {
+  const jiraConfig = loadJiraConfig(process.cwd());
+  const membershipError = validateProjectMembership(projectKey, jiraConfig);
+  if (membershipError) {
+    writeOutput({ errors: [membershipError] }, 'jira-context', 1);
+    return;
+  }
+
+  const resolved = resolveEffectiveCachePath({ projectKey, cacheDir, site });
+  for (const w of resolved.warnings) process.stderr.write(`Warning: ${w}\n`);
+
+  const flagsBlock = {
+    skipWorkflowDiscovery: !!skipWorkflowDiscovery,
+    site:                  site || null,
+  };
+
+  if (!resolved.path) {
+    writeOutput({
+      exists:         false,
+      fresh:          false,
+      projectKey,
+      cachePath:      null,
+      candidateSites: resolved.candidateSites,
+      missing:        ['all'],
+      flags:          flagsBlock,
+      errors:         [],
+      warnings:       resolved.warnings,
+    }, 'jira-context', 0);
+    return;
+  }
+
+  if (!fs.existsSync(resolved.path)) {
+    writeOutput({
+      exists:         false,
+      fresh:          false,
+      projectKey,
+      cachePath:      resolved.path,
+      candidateSites: [],
+      missing:        ['all'],
+      flags:          flagsBlock,
+      errors:         [],
+      warnings:       resolved.warnings,
+    }, 'jira-context', 0);
+    return;
   }
 
   let cache;
   try {
-    cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    cache = JSON.parse(fs.readFileSync(resolved.path, 'utf8'));
   } catch (err) {
     writeOutput({
       exists:     true,
       fresh:      false,
       projectKey,
-      cachePath,
+      cachePath:  resolved.path,
       missing:    ['all'],
+      flags:      flagsBlock,
       errors:     [`Cache file is not valid JSON: ${err.message}`],
-      warnings:   [],
+      warnings:   resolved.warnings,
     }, 'jira-context', 0);
     return;
   }
@@ -247,7 +491,6 @@ function checkCache(cachePath, templatesDir, projectKey) {
     }
   }
 
-  // Section presence checks
   const issueTypes     = cache.issueTypes && typeof cache.issueTypes === 'object' ? cache.issueTypes : null;
   const fieldSchemas   = cache.fieldSchemas && typeof cache.fieldSchemas === 'object' ? cache.fieldSchemas : null;
   const workflows      = cache.workflows && typeof cache.workflows === 'object' ? cache.workflows : null;
@@ -256,13 +499,17 @@ function checkCache(cachePath, templatesDir, projectKey) {
 
   const issueTypeNames = issueTypes ? Object.keys(issueTypes) : [];
 
-  // Workflow completeness
   let issueTypesWithWorkflows = 0;
   const incompleteWorkflows   = [];
   if (workflows) {
     issueTypesWithWorkflows = Object.keys(workflows).length;
     for (const typeName of issueTypeNames) {
-      if (!workflows[typeName]) incompleteWorkflows.push(typeName);
+      const entry = workflows[typeName];
+      if (!entry) {
+        incompleteWorkflows.push(typeName);
+      }
+      // Entries marked `{ unsampled: true }` are intentionally sparse (R14);
+      // they count as present for section completeness.
     }
   } else {
     incompleteWorkflows.push(...issueTypeNames);
@@ -306,7 +553,7 @@ function checkCache(cachePath, templatesDir, projectKey) {
     if (!info.present) missing.push(name);
   }
 
-  const templateStatus = resolveTemplateStatus(projectKey, cachePath, templatesDir);
+  const templateStatus = resolveTemplateStatus(projectKey, resolved.path, templatesDir);
   const customTypes    = Object.entries(templateStatus.resolved)
     .filter(([, v]) => v === 'custom')
     .map(([k]) => k);
@@ -314,7 +561,7 @@ function checkCache(cachePath, templatesDir, projectKey) {
     .filter(([, v]) => v === 'none')
     .map(([k]) => k);
 
-  const warnings = [];
+  const warnings = [...resolved.warnings];
   if (ageHours === null) {
     warnings.push('Cache file has no lastUpdated field; freshness cannot be determined.');
   }
@@ -328,7 +575,8 @@ function checkCache(cachePath, templatesDir, projectKey) {
     ageHours:    ageHours !== null ? Math.round(ageHours * 100) / 100 : null,
     maxAgeHours,
     projectKey,
-    cachePath,
+    cachePath:      resolved.path,
+    candidateSites: [],
     sections,
     templates: {
       customCount:    customTypes.length,
@@ -337,6 +585,7 @@ function checkCache(cachePath, templatesDir, projectKey) {
       uncoveredTypes,
     },
     missing,
+    flags:    flagsBlock,
     errors:   [],
     warnings,
   }, 'jira-context', 0);
@@ -346,18 +595,26 @@ function checkCache(cachePath, templatesDir, projectKey) {
 // Subcommand: --load
 // ---------------------------------------------------------------------------
 
-function loadCache(cachePath, projectKey) {
-  if (!fs.existsSync(cachePath)) {
-    const legacyPath = path.join(process.cwd(), '.claude', 'jira-cache', `${projectKey}.json`);
-    if (fs.existsSync(legacyPath)) {
-      process.stderr.write('Warning: .claude/jira-cache/ is deprecated. Cache will be written to .sdlc/jira-cache/ on next refresh.\n');
-      cachePath = legacyPath;
-    } else {
-      writeOutput({ errors: ['No cache found for project. Run cache initialization first.'] }, 'jira-context', 1);
+function loadCache({ projectKey, cacheDir, site }) {
+  const resolved = resolveEffectiveCachePath({ projectKey, cacheDir, site });
+  for (const w of resolved.warnings) process.stderr.write(`Warning: ${w}\n`);
+
+  if (!resolved.path) {
+    if (resolved.candidateSites.length >= 2) {
+      writeOutput({
+        errors:         [`Multiple cache entries for '${projectKey}' — pass --site <host> to disambiguate.`],
+        candidateSites: resolved.candidateSites,
+      }, 'jira-context', 1);
       return;
     }
+    writeOutput({ errors: ['No cache found for project. Run cache initialization first.'] }, 'jira-context', 1);
+    return;
   }
-  const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  if (!fs.existsSync(resolved.path)) {
+    writeOutput({ errors: ['No cache found for project. Run cache initialization first.'] }, 'jira-context', 1);
+    return;
+  }
+  const cache = JSON.parse(fs.readFileSync(resolved.path, 'utf8'));
   writeOutput(cache, 'jira-context', 0);
 }
 
@@ -365,7 +622,7 @@ function loadCache(cachePath, projectKey) {
 // Subcommand: --save
 // ---------------------------------------------------------------------------
 
-function saveCache(cachePath) {
+function saveCache({ projectKey, cacheDir, site }) {
   const raw = readStdin();
   let data;
   try {
@@ -375,23 +632,38 @@ function saveCache(cachePath) {
     return;
   }
 
-  const missingFields = ['version', 'cloudId', 'project'].filter(f => !(f in data));
+  const missingFields = ['version', 'cloudId', 'project', 'siteUrl'].filter(f => !(f in data));
   if (missingFields.length > 0) {
     writeOutput({ errors: [`Cache JSON is missing required fields: ${missingFields.join(', ')}`] }, 'jira-context', 1);
     return;
   }
 
-  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-  fs.writeFileSync(cachePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
-  writeOutput({ saved: true, cachePath }, 'jira-context', 0);
+  let writePath;
+  if (cacheDir) {
+    writePath = getCachePath(projectKey, cacheDir);
+  } else {
+    const resolvedSite = site || sanitizeSiteHost(data.siteUrl);
+    if (!resolvedSite) {
+      writeOutput({ errors: [`Cannot derive site host from siteUrl: ${data.siteUrl}`] }, 'jira-context', 1);
+      return;
+    }
+    writePath = path.join(getHomeCacheRoot(), resolvedSite, `${projectKey}.json`);
+  }
+
+  fs.mkdirSync(path.dirname(writePath), { recursive: true });
+  fs.writeFileSync(writePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  writeOutput({ saved: true, cachePath: writePath }, 'jira-context', 0);
 }
 
 // ---------------------------------------------------------------------------
 // Subcommand: --save-field
 // ---------------------------------------------------------------------------
 
-function saveField(cachePath, fieldName) {
-  if (!fs.existsSync(cachePath)) {
+function saveField({ projectKey, cacheDir, site }, fieldName) {
+  const resolved = resolveEffectiveCachePath({ projectKey, cacheDir, site });
+  for (const w of resolved.warnings) process.stderr.write(`Warning: ${w}\n`);
+
+  if (!resolved.path || !fs.existsSync(resolved.path)) {
     writeOutput({ errors: ['No cache found for project. Run cache initialization first.'] }, 'jira-context', 1);
     return;
   }
@@ -407,7 +679,7 @@ function saveField(cachePath, fieldName) {
 
   let cache;
   try {
-    cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    cache = JSON.parse(fs.readFileSync(resolved.path, 'utf8'));
   } catch (err) {
     writeOutput({ errors: [`Cache file is not valid JSON: ${err.message}`] }, 'jira-context', 1);
     return;
@@ -421,16 +693,17 @@ function saveField(cachePath, fieldName) {
     cache[fieldName] = incoming;
   }
 
-  fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2) + '\n', 'utf8');
-  writeOutput({ saved: true, field: fieldName, cachePath }, 'jira-context', 0);
+  fs.writeFileSync(resolved.path, JSON.stringify(cache, null, 2) + '\n', 'utf8');
+  writeOutput({ saved: true, field: fieldName, cachePath: resolved.path }, 'jira-context', 0);
 }
 
 // ---------------------------------------------------------------------------
 // Subcommand: --templates
 // ---------------------------------------------------------------------------
 
-function resolveTemplates(projectKey, cachePath, templatesDir) {
-  const status = resolveTemplateStatus(projectKey, cachePath, templatesDir);
+function resolveTemplates({ projectKey, cacheDir, site }, templatesDir) {
+  const resolved = resolveEffectiveCachePath({ projectKey, cacheDir, site });
+  const status = resolveTemplateStatus(projectKey, resolved.path, templatesDir);
   writeOutput(status, 'jira-context', 0);
 }
 
@@ -438,11 +711,13 @@ function resolveTemplates(projectKey, cachePath, templatesDir) {
 // Subcommand: --init-templates
 // ---------------------------------------------------------------------------
 
-function initTemplates(projectKey, cachePath, templatesDir) {
+function initTemplates({ projectKey, cacheDir, site }, templatesDir) {
+  const resolved = resolveEffectiveCachePath({ projectKey, cacheDir, site });
+
   let issueTypes = [];
-  if (fs.existsSync(cachePath)) {
+  if (resolved.path && fs.existsSync(resolved.path)) {
     try {
-      const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+      const cache = JSON.parse(fs.readFileSync(resolved.path, 'utf8'));
       if (cache.issueTypes && typeof cache.issueTypes === 'object') {
         issueTypes = Object.keys(cache.issueTypes);
       }
@@ -478,11 +753,22 @@ function initTemplates(projectKey, cachePath, templatesDir) {
 // Subcommand: --clear
 // ---------------------------------------------------------------------------
 
-function clearCache(cachePath) {
-  if (fs.existsSync(cachePath)) {
-    fs.unlinkSync(cachePath);
+function clearCache({ projectKey, cacheDir, site }) {
+  if (cacheDir) {
+    const p = getCachePath(projectKey, cacheDir);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+    writeOutput({ cleared: true, cachePath: p }, 'jira-context', 0);
+    return;
   }
-  writeOutput({ cleared: true, cachePath }, 'jira-context', 0);
+  const candidates = resolveCandidatePaths(projectKey, site);
+  const cleared = [];
+  for (const c of candidates) {
+    if (fs.existsSync(c.path)) {
+      fs.unlinkSync(c.path);
+      cleared.push(c.path);
+    }
+  }
+  writeOutput({ cleared: true, cachePaths: cleared }, 'jira-context', 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -513,37 +799,38 @@ function copyTemplate(copyType, copyFrom, templatesDir) {
 // ---------------------------------------------------------------------------
 
 function main() {
-  const { projectKey, cacheDir, templatesDir: templatesOverride, subcommand, saveFieldName, copyType, copyFrom, errors } = parseArgs(process.argv);
+  const parsed = parseArgs(process.argv);
+  const { projectKey, cacheDir, templatesDir: templatesOverride, subcommand, saveFieldName, copyType, copyFrom, site, skipWorkflowDiscovery, errors } = parsed;
 
   if (errors.length > 0) {
     writeOutput({ errors }, 'jira-context', 1);
     return;
   }
 
-  const cachePath    = getCachePath(projectKey, cacheDir);
   const templatesDir = resolveTemplatesDir(templatesOverride);
+  const ctx = { projectKey, cacheDir, site, skipWorkflowDiscovery, templatesDir };
 
   switch (subcommand) {
     case 'check':
-      checkCache(cachePath, templatesDir, projectKey);
+      checkCache(ctx);
       break;
     case 'load':
-      loadCache(cachePath, projectKey);
+      loadCache(ctx);
       break;
     case 'save':
-      saveCache(cachePath);
+      saveCache(ctx);
       break;
     case 'save-field':
-      saveField(cachePath, saveFieldName);
+      saveField(ctx, saveFieldName);
       break;
     case 'templates':
-      resolveTemplates(projectKey, cachePath, templatesDir);
+      resolveTemplates(ctx, templatesDir);
       break;
     case 'init-templates':
-      initTemplates(projectKey, cachePath, templatesDir);
+      initTemplates(ctx, templatesDir);
       break;
     case 'clear':
-      clearCache(cachePath);
+      clearCache(ctx);
       break;
     case 'copy-template':
       copyTemplate(copyType, copyFrom, templatesDir);
@@ -565,6 +852,14 @@ if (require.main === module) {
 module.exports = {
   parseArgs,
   getCachePath,
+  getHomeCacheRoot,
+  sanitizeSiteHost,
+  resolveCandidatePaths,
+  loadJiraConfig,
+  findLegacyCache,
+  migrateLegacyCache,
+  resolveEffectiveCachePath,
+  validateProjectMembership,
   resolveTemplatesDir,
   checkCache,
   loadCache,

--- a/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
@@ -1,7 +1,7 @@
 # Jira SDLC — Examples
 
 Copy-paste MCP call examples for every operation. Values marked with `← cache.xxx`
-come from the project cache at `.claude/jira-cache/<PROJECT_KEY>.json`. Replace
+come from the project cache at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json` (legacy locations `.sdlc/jira-cache/` and `.claude/jira-cache/` migrate automatically on first use). Replace
 `PROJ` with the actual project key and adjust IDs to match the cache.
 
 Comment examples use `contentFormat: "adf"` with the body converted via `markdown-to-adf.js`.
@@ -126,11 +126,11 @@ mcp__atlassian__getTransitionsForJiraIssue({
 ### Phase 6 — Save cache
 
 ```bash
-# Write assembled cache JSON to disk
-cat > .sdlc/jira-cache/PROJ.json << 'EOF'
+# Write assembled cache JSON to disk via the prepare script (handles site-keyed path)
+cat << 'EOF' | node "$SCRIPT" --project PROJ --save
 {
   "cloudId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "siteUrl": "mycompany.atlassian.net",
+  "siteUrl": "https://mycompany.atlassian.net",
   "project": { "key": "PROJ", "name": "My Project", "id": "10000" },
   "currentUser": { "accountId": "5b10a2844c20165700ede21g", "displayName": "Jane Smith", "email": "jane@company.com" },
   "issueTypes": { ... },

--- a/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/EXAMPLES.md
@@ -126,6 +126,7 @@ mcp__atlassian__getTransitionsForJiraIssue({
 ### Phase 6 — Save cache
 
 ```bash
+# $SCRIPT is set by the Script Resolution Block in SKILL.md Step 0.
 # Write assembled cache JSON to disk via the prepare script (handles site-keyed path)
 cat << 'EOF' | node "$SCRIPT" --project PROJ --save
 {

--- a/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
@@ -20,7 +20,7 @@ sections are missing, or when an operation fails due to stale cached data.
   "lastUpdated": "2026-03-12T10:00:00.000Z",
   "maxAgeHours": 0,
   "cloudId": "uuid-string",
-  "siteUrl": "yoursite.atlassian.net",
+  "siteUrl": "https://yoursite.atlassian.net",
   "currentUser": {
     "accountId": "abc123",
     "displayName": "John Doe",
@@ -149,6 +149,43 @@ on time — it is refreshed only when `--force-refresh` is passed or when operat
 due to stale data. If `maxAgeHours` is set to a positive number, the TTL behavior applies:
 compare `lastUpdated` + `maxAgeHours` against the current timestamp; if stale, run the
 full initialization sequence.
+
+**Unsampled workflow shape (R14):** When `--skip-workflow-discovery` is passed, Phase 5 is
+bypassed and each non-subtask issue type is stored with:
+
+```json
+"workflows": {
+  "Task": { "unsampled": true },
+  "Bug":  { "unsampled": true }
+}
+```
+
+Subtask types have no workflow entry. At runtime, any transition operation that encounters
+an `unsampled` marker falls back to a live `getTransitionsForJiraIssue` call per issue —
+the same stale-cache auto-refresh path handles it transparently.
+
+**`--check` output shape (R15):** The prepare script `--check` subcommand emits JSON with
+these fields:
+
+```jsonc
+{
+  "exists": false,           // true when cache file present and readable
+  "fresh": false,            // true when within TTL or maxAgeHours === 0
+  "projectKey": "PROJ",
+  "cachePath": null,         // resolved file path (null when not resolvable)
+  "candidateSites": [],      // non-empty when same key found under 2+ site subdirs
+  "missing": ["all"],        // required sections absent from cache
+  "flags": {
+    "skipWorkflowDiscovery": false,   // echoes the --skip-workflow-discovery arg
+    "site": null                      // echoes the --site arg (null if not passed)
+  },
+  "errors": [],
+  "warnings": []
+}
+```
+
+When `candidateSites` is non-empty, `exists` is always `false` and `cachePath` is `null`.
+The caller must re-run with `--site <host>` from `candidateSites` to disambiguate.
 
 ---
 

--- a/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/REFERENCE.md
@@ -9,7 +9,7 @@ call — it eliminates guesswork and prevents the most common API errors.
 
 ## Section 0: Cache Schema
 
-The cache lives at `.sdlc/jira-cache/<PROJECT_KEY>.json`. It is created on first
+The cache lives at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json` (home-keyed, outside the working tree). It is created on first
 `--check`, permanent by default (`maxAgeHours: 0`), and read before every MCP call to
 avoid redundant API round-trips. Refreshed only on `--force-refresh`, when required
 sections are missing, or when an operation fails due to stale cached data.

--- a/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
@@ -13,7 +13,7 @@ Eliminate all redundant discovery calls after initialization.
 
 **Announce at start:** "I'm using jira-sdlc (sdlc v{sdlc_version})." — extract the version from the `sdlc:` line in the session-start system-reminder. If no version is in context, omit the parenthetical.
 
-## When to Use This Skill
+## When to Use This Skill (implements R16)
 
 - Creating, editing, or viewing Jira issues
 - Transitioning issues through workflow statuses
@@ -59,7 +59,7 @@ removed entirely — the API call is never made with raw placeholder text.
 | `--site <host>` | Sanitized site host (e.g., `acme_atlassian_net`). Disambiguates `--check`/`--load` when the same project key is cached under multiple sites. | Unset |
 | `--skip-workflow-discovery` | Bypass Phase 5; cache `workflows[type] = { unsampled: true }` per non-subtask type. Transitions fall back to live `getTransitionsForJiraIssue` per issue. Use in CI. | false |
 
-**Project key resolution (ordered fallback):**
+**Project key resolution (ordered fallback):** (implements R13)
 
 1. `--project <KEY>` argument. When `jira.projects` is set (≥2 entries), the prepare script rejects values not in the list (exit 1).
 2. Parse current git branch for `[A-Z]{2,10}-\d+` pattern (e.g., `feat/PROJ-123-fix` → `PROJ`). When `jira.projects` is set, accept only keys in the list; otherwise fall through.
@@ -69,7 +69,7 @@ removed entirely — the API call is never made with raw placeholder text.
 
 Backward compatible: repos without `jira.projects` retain the previous 4-step behavior (1/2/3/5).
 
-**Multi-candidate cache disambiguation:**
+**Multi-candidate cache disambiguation:** (implements R15)
 
 When `--check` is run without `--site` and the home-cache contains entries for the project key under two or more site subdirectories, the script returns `exists: false` and `candidateSites: [<host>, …]`. Present the `candidateSites` list to the user via AskUserQuestion and re-run with `--site <host>`, or use `--force-refresh` to rebuild against a specific site.
 
@@ -214,7 +214,7 @@ mcp__atlassian__getJiraIssueTypeMetaWithFields({ cloudId, projectKey, issueTypeI
 → Store in: fieldSchemas[issueTypeName] = { [fieldKey]: { required, type, name?, allowedValues? } }
 ```
 
-### Phase 5 — Workflow discovery (per non-subtask issue type)
+### Phase 5 — Workflow discovery (per non-subtask issue type) (implements R14)
 
 **Skip branch (when `flags.skipWorkflowDiscovery` is `true` in the `--check` output):**
 

--- a/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: jira-sdlc
-description: "Use this skill when creating, editing, searching, transitioning, commenting on, or linking Jira issues using Atlassian MCP tools. Caches project metadata (custom fields, workflows, transitions, user mappings) to eliminate redundant discovery calls. Uses per-issue-type description templates (customizable per project). Arguments: [--project <KEY>] [--force-refresh] [--init-templates]. Triggers on: create jira issue, edit jira ticket, search jira, transition jira, jira comment, link jira, assign jira, log work jira, bulk jira operations, manage jira, jira template."
+description: "Use this skill when creating, editing, reading, viewing, searching, transitioning, commenting on, or linking Jira issues using Atlassian MCP tools. Caches project metadata (custom fields, workflows, transitions, user mappings) to eliminate redundant discovery calls. Supports multi-project repos via jira.projects, and skipping workflow discovery for CI. Arguments: [--project <KEY>] [--force-refresh] [--init-templates] [--site <host>] [--skip-workflow-discovery]. Triggers on: create jira issue, edit jira ticket, search jira, transition jira, jira comment, link jira, assign jira, log work jira, bulk jira operations, manage jira, jira template, read jira, view jira, show jira, get jira, fetch jira, jira details, add comment, comment on jira, reply to jira, jira ticket, jira issue."
 user-invocable: true
-argument-hint: "[--project <KEY>] [--force-refresh] [--init-templates]"
+argument-hint: "[--project <KEY>] [--force-refresh] [--init-templates] [--site <host>] [--skip-workflow-discovery]"
 ---
 
 # Managing Jira Issues
@@ -27,12 +27,17 @@ Eliminate all redundant discovery calls after initialization.
 
 ## How This Skill Works
 
-On first use, this skill initializes a cache at `.sdlc/jira-cache/<PROJECT_KEY>.json`
+On first use, this skill initializes a cache at `~/.sdlc-cache/jira/<sanitizedSiteHost>/<PROJECT_KEY>.json`
 containing the site's `cloudId`, issue type definitions, field schemas, workflow graphs,
-link types, and user mappings. The cache is permanent by default — it does not expire
-on a timer. After initialization, every subsequent operation reads exclusively from the
-cache. The cache is rebuilt only when `--force-refresh` is passed or when operations
-fail due to stale data (invalid transition IDs, changed field schemas).
+link types, and user mappings. `sanitizedSiteHost` is the site URL host lowercased with
+`.` replaced by `_` (e.g., `acme.atlassian.net` → `acme_atlassian_net`). The cache lives
+outside the working tree and is keyed by site to support repos that map to multiple Jira
+tenants. The cache is permanent by default — it does not expire on a timer. After
+initialization, every subsequent operation reads exclusively from the cache. The cache is
+rebuilt only when `--force-refresh` is passed or when operations fail due to stale data
+(invalid transition IDs, changed field schemas). Legacy caches found at
+`.sdlc/jira-cache/<KEY>.json` or `.claude/jira-cache/<KEY>.json` are migrated to the home
+layout automatically on the next `--check`; the legacy files are left in place.
 
 Each issue type has a description template (shipped in the skill's `templates/` directory
 and customizable per project at `.claude/jira-templates/<Type>.md`). Templates are filled
@@ -48,16 +53,25 @@ removed entirely — the API call is never made with raw placeholder text.
 
 | Argument | Description | Default |
 |----------|-------------|---------|
-| `--project <KEY>` | Jira project key (e.g., PROJ) | Auto-detected |
+| `--project <KEY>` | Jira project key (e.g., PROJ). When `jira.projects` is set, values outside the list are rejected. | Auto-detected |
 | `--force-refresh` | Rebuild cache even if fresh | false |
 | `--init-templates` | Copy default templates to `.claude/jira-templates/` | false |
+| `--site <host>` | Sanitized site host (e.g., `acme_atlassian_net`). Disambiguates `--check`/`--load` when the same project key is cached under multiple sites. | Unset |
+| `--skip-workflow-discovery` | Bypass Phase 5; cache `workflows[type] = { unsampled: true }` per non-subtask type. Transitions fall back to live `getTransitionsForJiraIssue` per issue. Use in CI. | false |
 
 **Project key resolution (ordered fallback):**
 
-1. `--project <KEY>` argument
-2. Parse current git branch for `[A-Z]{2,10}-\d+` pattern (e.g., `feat/PROJ-123-fix` → `PROJ`)
-3. Read `.claude/sdlc.json` → `jira.defaultProject`
-4. Use AskUserQuestion to ask: "Which Jira project key should I use? (e.g., PROJ, TEAM)"
+1. `--project <KEY>` argument. When `jira.projects` is set (≥2 entries), the prepare script rejects values not in the list (exit 1).
+2. Parse current git branch for `[A-Z]{2,10}-\d+` pattern (e.g., `feat/PROJ-123-fix` → `PROJ`). When `jira.projects` is set, accept only keys in the list; otherwise fall through.
+3. Read `.claude/sdlc.json` → `jira.defaultProject`.
+4. When `jira.projects` has ≥2 entries, use AskUserQuestion with a closed list matching `jira.projects` ("Which Jira project key should I use?").
+5. Use AskUserQuestion to ask: "Which Jira project key should I use? (e.g., PROJ, TEAM)".
+
+Backward compatible: repos without `jira.projects` retain the previous 4-step behavior (1/2/3/5).
+
+**Multi-candidate cache disambiguation:**
+
+When `--check` is run without `--site` and the home-cache contains entries for the project key under two or more site subdirectories, the script returns `exists: false` and `candidateSites: [<host>, …]`. Present the `candidateSites` list to the user via AskUserQuestion and re-run with `--site <host>`, or use `--force-refresh` to rebuild against a specific site.
 
 ### Script Resolution Block
 
@@ -201,6 +215,22 @@ mcp__atlassian__getJiraIssueTypeMetaWithFields({ cloudId, projectKey, issueTypeI
 ```
 
 ### Phase 5 — Workflow discovery (per non-subtask issue type)
+
+**Skip branch (when `flags.skipWorkflowDiscovery` is `true` in the `--check` output):**
+
+Do not issue any of the Phase 5a/5b/5c calls. Instead, for each non-subtask issue type in
+`issueTypes`, write:
+
+```json
+"workflows": { "<issueTypeName>": { "unsampled": true } }
+```
+
+Subtask types are omitted (no workflow entry). Transitions at runtime fall back to a live
+`getTransitionsForJiraIssue` call per issue — the existing stale-cache auto-refresh path
+handles `unsampled` markers identically to a cache miss. Use this branch in CI and other
+pre-seeded environments where Phase 5 is too expensive.
+
+**Standard branch (default):**
 
 For each non-subtask issue type in `issueTypes`:
 
@@ -406,6 +436,7 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 - Transition `requiredFields` may include screen-only fields not in `fieldSchemas` — if a required field is absent from the schema, try the transition without it first; screen fields sometimes only block the Jira UI, not the API
 - `getVisibleJiraProjects` uses `searchString` (not `query`) for filtering — check parameter name before calling
 - When Phase 5 workflow sampling finds no issues at all for a type, skip workflow discovery for that type entirely and note it in the cache as `"workflows": { "Story": { "unsampled": true } }`
+- `unsampled: true` markers (from `--skip-workflow-discovery` in CI, or from no-sample results above) route transition operations through a live `getTransitionsForJiraIssue` per issue — the skill reuses the existing stale-cache auto-refresh path, so no separate branch is required in Step 3. Treat `unsampled` identically to "transition ID not cached".
 - The `mcp__atlassian__` prefix is the default; if the user's MCP is registered under a different prefix (e.g., `mcp__claude_ai_Atlassian__`), use the active prefix consistently across all calls in the session
 
 ---

--- a/schemas/sdlc-config.schema.json
+++ b/schemas/sdlc-config.schema.json
@@ -51,6 +51,13 @@
           "type": "string",
           "pattern": "^[A-Z]{2,10}$",
           "description": "Default Jira project key (2–10 uppercase letters)."
+        },
+        "projects": {
+          "type": "array",
+          "description": "Allowed Jira project keys when the repo maps to multiple projects. When set, jira-sdlc validates --project arguments and presents a closed-list prompt on fallback.",
+          "items": { "type": "string", "pattern": "^[A-Z]{2,10}$" },
+          "minItems": 2,
+          "uniqueItems": true
         }
       },
       "additionalProperties": false

--- a/tests/promptfoo/datasets/jira-sdlc-exec.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc-exec.yaml
@@ -1,0 +1,126 @@
+# Script execution tests for skill/jira.js.
+# Runs the prepare script directly against fixture filesystems (no LLM).
+# Covers:
+#   (a) fresh install      — cache not initialized, flags echoed
+#   (b) legacy .sdlc migration — .sdlc/jira-cache/<KEY>.json → ~/.sdlc-cache/jira/<site>/
+#   (c) legacy .claude migration — .claude/jira-cache/<KEY>.json → ~/.sdlc-cache/jira/<site>/
+#   (d) multi-candidate    — two home-cache entries for same key under different sites
+#   (e) --skip-workflow-discovery echoed in flags
+#   (f) --project validation against jira.projects (membership rejected + accepted)
+
+- description: "jira-prepare: fresh install — exists=false, flags echoed"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-multi-project-config"
+    script_args: "--project FOO --check"
+  assert:
+    - type: icontains
+      value: '"exists": false'
+    - type: icontains
+      value: '"skipWorkflowDiscovery": false'
+    - type: icontains
+      value: '"site": null'
+    - type: not-icontains
+      value: '"errors": ["Project'
+
+- description: "jira-prepare: legacy .sdlc/jira-cache migration — emits warning, populates home layout"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-cache-legacy-sdlc"
+    script_args: "--project LEGACYA --check"
+  assert:
+    # Migration warning is surfaced (stderr captured by runner)
+    - type: icontains
+      value: "Migrated legacy cache from .sdlc/jira-cache/LEGACYA.json"
+    # The resolved cachePath points to the home layout under the derived site host
+    - type: icontains
+      value: ".sdlc-cache/jira/legacy-a_atlassian_net/LEGACYA.json"
+
+- description: "jira-prepare: legacy .claude/jira-cache migration — emits warning, populates home layout"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-cache-legacy-claude"
+    script_args: "--project LEGACYB --check"
+  assert:
+    - type: icontains
+      value: "Migrated legacy cache from .claude/jira-cache/LEGACYB.json"
+    - type: icontains
+      value: ".sdlc-cache/jira/legacy-b_atlassian_net/LEGACYB.json"
+
+- description: "jira-prepare: multi-candidate — returns candidateSites when same key under two sites"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-cache-home-multi-site"
+    script_args: "--project MULTI --check"
+  assert:
+    - type: icontains
+      value: '"exists": false'
+    - type: icontains
+      value: '"candidateSites"'
+    - type: icontains
+      value: 'acme_atlassian_net'
+    - type: icontains
+      value: 'beta_atlassian_net'
+    # Warning on stderr (captured by runner) advises --site flag
+    - type: icontains
+      value: "Pass --site <host> to disambiguate"
+
+- description: "jira-prepare: --skip-workflow-discovery echoes in flags block"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-multi-project-config"
+    script_args: "--project FOO --check --skip-workflow-discovery"
+  assert:
+    - type: icontains
+      value: '"skipWorkflowDiscovery": true'
+    - type: icontains
+      value: '"site": null'
+
+- description: "jira-prepare: --project rejected when not in jira.projects"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-multi-project-config"
+    script_args: "--project BAZ --check"
+  assert:
+    - type: icontains
+      value: "Project BAZ is not in jira.projects: [FOO, BAR]"
+
+- description: "jira-prepare: --project accepted when it is in jira.projects"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-multi-project-config"
+    script_args: "--project FOO --check"
+  assert:
+    - type: not-icontains
+      value: "is not in jira.projects"
+    - type: icontains
+      value: '"projectKey": "FOO"'
+
+- description: "jira-prepare: --site disambiguates multi-candidate to a single cache"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-cache-home-multi-site"
+    script_args: "--project MULTI --site acme_atlassian_net --check"
+  assert:
+    - type: icontains
+      value: '"exists": true'
+    - type: icontains
+      value: 'acme_atlassian_net'
+    - type: not-icontains
+      value: '"candidateSites": ["acme_atlassian_net", "beta_atlassian_net"]'

--- a/tests/promptfoo/datasets/jira-sdlc-exec.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc-exec.yaml
@@ -124,3 +124,36 @@
       value: 'acme_atlassian_net'
     - type: not-icontains
       value: '"candidateSites": ["acme_atlassian_net", "beta_atlassian_net"]'
+
+- description: "jira-prepare: --save writes to home-cache layout (saved: true, path contains site host)"
+  provider: file://providers/hook-runner.js
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-save-roundtrip"
+    script_home: "{{project_root}}"
+    script_args: "--project SAVETEST --save"
+    script_stdin: |
+      {"version":1,"cloudId":"test-cloud","siteUrl":"https://mycompany.atlassian.net","project":{"key":"SAVETEST","name":"Save Test","id":"10001"},"currentUser":{"accountId":"u1","displayName":"Test User","email":"test@example.com"},"issueTypes":{"Task":{"id":"10001","subtask":false,"hierarchyLevel":0}},"fieldSchemas":{"Task":{"summary":{"required":true,"type":"string"}}},"workflows":{"Task":{"unsampled":true}},"linkTypes":[],"userMappings":{}}
+  assert:
+    - type: icontains
+      value: '"saved": true'
+    - type: icontains
+      value: 'mycompany_atlassian_net'
+    - type: icontains
+      value: 'SAVETEST.json'
+
+- description: "jira-prepare: --check finds cache at home-cache layout after --save (pre-seeded fixture)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/jira.js"
+    script_cwd: "{{project_root}}"
+    script_home: "{{project_root}}"
+    project_root: "file://fixtures-fs/jira-save-roundtrip"
+    script_args: "--project SAVETEST --check"
+  assert:
+    - type: icontains
+      value: '"exists": true'
+    - type: icontains
+      value: 'mycompany_atlassian_net'
+    - type: icontains
+      value: '"projectKey": "SAVETEST"'

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -2,6 +2,11 @@
 #   jira-ticket-created            -- CORRECT: simulates a created Jira ticket, triggers workflow continuation
 #   jira-create-task               -- CORRECT: simulates Jira cache with project metadata for create operation
 #   jira-comment-adf               -- CORRECT: simulates Jira cache for comment operation with ADF conversion
+#   jira-multi-project-closed-list -- CORRECT: simulates jira.projects in config to trigger closed-list prompt
+#   jira-unsampled-transition      -- CORRECT: simulates cache with workflows[Type].unsampled=true to force live fallback
+#
+# NOTE: Exec (script-only) cases for jira-prepare.js live in jira-sdlc-exec.yaml
+# (ref'd by promptfooconfig-exec.yaml). This file contains behavioral (LLM) cases only.
 
 - description: "jira-sdlc: shows workflow continuation menu after Jira ticket created"
   vars:
@@ -97,3 +102,70 @@
         issueIdOrKey (not "issueKey"). (4) It uses responseContentFormat: "markdown"
         for reading. It does NOT post raw markdown with contentFormat: "markdown" for
         the comment. The cloudId comes from the cache.
+
+- description: "jira-sdlc: multi-project config — closed-list prompt for project selection (R13)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-multi-project-closed-list.md"
+    user_request: >
+      Run /jira-sdlc. No --project argument. Current branch is "main" (no
+      [A-Z]{2,10}-\d+ pattern). .claude/sdlc.json has jira.projects: ["FOO","BAR"]
+      and jira.defaultProject is null. The user wants to create an issue but hasn't
+      said which project. Show how the skill resolves the project key.
+  assert:
+    # Must mention AskUserQuestion / closed list of the two configured projects
+    - type: icontains
+      value: "FOO"
+    - type: icontains
+      value: "BAR"
+    # Must NOT invent a third project (free-form prompt or fabricated key)
+    - type: not-regex
+      value: "(PROJ|BAZ|QUUX|TEAM)"
+    # Behavioral rubric for R13 closed-list prompt
+    - type: llm-rubric
+      value: >
+        The response recognizes that jira.projects has been configured with two entries
+        (FOO and BAR) and prompts the user to pick one of them via AskUserQuestion with
+        a closed list containing exactly "FOO" and "BAR" as options. It does NOT present
+        a free-form text input, does NOT invent a third option, and does NOT silently
+        pick defaultProject (which is null). The project key resolution follows the
+        5-step ordered fallback: since steps 1 (--project arg), 2 (branch pattern),
+        and 3 (defaultProject) all fail, step 4 (closed-list AskUserQuestion) activates
+        because jira.projects has ≥2 entries.
+
+- description: "jira-sdlc: unsampled workflow — transition falls back to live getTransitionsForJiraIssue (R14)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-unsampled-transition.md"
+    user_request: >
+      Run /jira-sdlc. Transition PROJ-147 to Done. The cache has
+      workflows.Task = { "unsampled": true } because --skip-workflow-discovery was
+      used to build the cache. Show how the skill performs the transition.
+  assert:
+    # Must call the live transitions endpoint
+    - type: icontains
+      value: "getTransitionsForJiraIssue"
+    # Must eventually call transitionJiraIssue
+    - type: icontains
+      value: "transitionJiraIssue"
+    # Must use the transition id from the live call — explicit id mention
+    - type: regex
+      value: "(\"id\"|transition id|transition.?ID)"
+    # Must NOT pass transition by name (only { id } is accepted)
+    - type: not-regex
+      value: "transition:\\s*\"Done\""
+    # Must NOT treat unsampled as a blocking cache-incompleteness failure
+    - type: not-regex
+      value: "(cache incomplete|cache is incomplete|rebuild cache|--force-refresh)"
+    # Behavioral rubric for R14 unsampled fallback
+    - type: llm-rubric
+      value: >
+        The response recognizes the workflows.Task = { unsampled: true } marker as an
+        intentional sparse entry (not a cache failure), and routes the transition
+        through a live mcp__atlassian__getTransitionsForJiraIssue call against PROJ-147
+        to fetch the transition id. It then passes that id to
+        mcp__atlassian__transitionJiraIssue in the { id: "..." } shape (never by name
+        string). It does NOT trigger --force-refresh, does NOT report the cache as
+        incomplete, and does NOT guess a transition id. The response treats unsampled
+        identically to a transition ID not being cached — the existing auto-refresh
+        fallback from REFERENCE handles both cases.

--- a/tests/promptfoo/fixtures-fs/jira-cache-home-multi-site/.sdlc-cache/jira/acme_atlassian_net/MULTI.json
+++ b/tests/promptfoo/fixtures-fs/jira-cache-home-multi-site/.sdlc-cache/jira/acme_atlassian_net/MULTI.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "lastUpdated": "2026-01-15T10:00:00Z",
+  "maxAgeHours": 0,
+  "cloudId": "acme-cloud",
+  "siteUrl": "https://acme.atlassian.net",
+  "currentUser": { "accountId": "u1", "displayName": "Acme User", "email": "u@acme" },
+  "project": { "key": "MULTI", "name": "Multi", "id": "10000" },
+  "issueTypes": { "Task": { "id": "10001", "subtask": false, "hierarchyLevel": 0 } },
+  "fieldSchemas": { "Task": { "summary": { "required": true, "type": "string" } } },
+  "workflows": { "Task": { "transitions": {} } },
+  "linkTypes": [],
+  "userMappings": {}
+}

--- a/tests/promptfoo/fixtures-fs/jira-cache-home-multi-site/.sdlc-cache/jira/beta_atlassian_net/MULTI.json
+++ b/tests/promptfoo/fixtures-fs/jira-cache-home-multi-site/.sdlc-cache/jira/beta_atlassian_net/MULTI.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "lastUpdated": "2026-01-15T10:00:00Z",
+  "maxAgeHours": 0,
+  "cloudId": "beta-cloud",
+  "siteUrl": "https://beta.atlassian.net",
+  "currentUser": { "accountId": "u2", "displayName": "Beta User", "email": "u@beta" },
+  "project": { "key": "MULTI", "name": "Multi (beta)", "id": "10020" },
+  "issueTypes": { "Task": { "id": "10001", "subtask": false, "hierarchyLevel": 0 } },
+  "fieldSchemas": { "Task": { "summary": { "required": true, "type": "string" } } },
+  "workflows": { "Task": { "transitions": {} } },
+  "linkTypes": [],
+  "userMappings": {}
+}

--- a/tests/promptfoo/fixtures-fs/jira-cache-legacy-claude/.claude/jira-cache/LEGACYB.json
+++ b/tests/promptfoo/fixtures-fs/jira-cache-legacy-claude/.claude/jira-cache/LEGACYB.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "lastUpdated": "2026-01-15T10:00:00Z",
+  "maxAgeHours": 0,
+  "cloudId": "legacy-cloud-b",
+  "siteUrl": "https://legacy-b.atlassian.net",
+  "currentUser": { "accountId": "u2", "displayName": "User Two", "email": "u2@example.com" },
+  "project": { "key": "LEGACYB", "name": "Legacy B", "id": "10010" },
+  "issueTypes": { "Task": { "id": "10001", "subtask": false, "hierarchyLevel": 0 } },
+  "fieldSchemas": { "Task": { "summary": { "required": true, "type": "string" } } },
+  "workflows": { "Task": { "transitions": {} } },
+  "linkTypes": [],
+  "userMappings": {}
+}

--- a/tests/promptfoo/fixtures-fs/jira-cache-legacy-sdlc/.sdlc/jira-cache/LEGACYA.json
+++ b/tests/promptfoo/fixtures-fs/jira-cache-legacy-sdlc/.sdlc/jira-cache/LEGACYA.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "lastUpdated": "2026-01-15T10:00:00Z",
+  "maxAgeHours": 0,
+  "cloudId": "legacy-cloud-a",
+  "siteUrl": "https://legacy-a.atlassian.net",
+  "currentUser": { "accountId": "u1", "displayName": "User One", "email": "u1@example.com" },
+  "project": { "key": "LEGACYA", "name": "Legacy A", "id": "10000" },
+  "issueTypes": { "Task": { "id": "10001", "subtask": false, "hierarchyLevel": 0 } },
+  "fieldSchemas": { "Task": { "summary": { "required": true, "type": "string" } } },
+  "workflows": { "Task": { "transitions": {} } },
+  "linkTypes": [],
+  "userMappings": {}
+}

--- a/tests/promptfoo/fixtures-fs/jira-multi-project-config/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/jira-multi-project-config/.claude/sdlc.json
@@ -1,0 +1,6 @@
+{
+  "jira": {
+    "defaultProject": "FOO",
+    "projects": ["FOO", "BAR"]
+  }
+}

--- a/tests/promptfoo/fixtures-fs/jira-save-roundtrip/.sdlc-cache/jira/mycompany_atlassian_net/SAVETEST.json
+++ b/tests/promptfoo/fixtures-fs/jira-save-roundtrip/.sdlc-cache/jira/mycompany_atlassian_net/SAVETEST.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "cloudId": "test-cloud",
+  "siteUrl": "https://mycompany.atlassian.net",
+  "project": {
+    "key": "SAVETEST",
+    "name": "Save Test",
+    "id": "10001"
+  },
+  "currentUser": {
+    "accountId": "u1",
+    "displayName": "Test User",
+    "email": "test@example.com"
+  },
+  "issueTypes": {
+    "Task": {
+      "id": "10001",
+      "subtask": false,
+      "hierarchyLevel": 0
+    }
+  },
+  "fieldSchemas": {
+    "Task": {
+      "summary": {
+        "required": true,
+        "type": "string"
+      }
+    }
+  },
+  "workflows": {
+    "Task": {
+      "unsampled": true
+    }
+  },
+  "linkTypes": [],
+  "userMappings": {}
+}

--- a/tests/promptfoo/fixtures/jira-multi-project-closed-list.md
+++ b/tests/promptfoo/fixtures/jira-multi-project-closed-list.md
@@ -1,0 +1,24 @@
+# Jira Project Context — multi-project config, no branch signal
+
+## Project Config (`.claude/sdlc.json`)
+```json
+{
+  "jira": {
+    "defaultProject": null,
+    "projects": ["FOO", "BAR"]
+  }
+}
+```
+
+## Cache state
+- No `--project` argument passed
+- Branch name contains no `[A-Z]{2,10}-\d+` pattern
+- `jira.defaultProject` is null
+- `jira.projects` has 2 entries: `FOO` and `BAR`
+- Home-cache scan returns 0 matches for any candidate key (fresh install)
+
+## User Request Context
+The user invoked `/jira-sdlc` with no arguments from a branch named `main` (no
+ticket ID parseable). Because `jira.projects` is configured with two entries,
+the skill must ask the user to pick a project from a closed list containing
+exactly those entries — not a free-form prompt.

--- a/tests/promptfoo/fixtures/jira-unsampled-transition.md
+++ b/tests/promptfoo/fixtures/jira-unsampled-transition.md
@@ -1,0 +1,42 @@
+# Jira Project Context — unsampled workflow for transition
+
+## Cache (from jira-prepare.js)
+```json
+{
+  "version": 1,
+  "lastUpdated": "2026-04-01T10:00:00Z",
+  "maxAgeHours": 0,
+  "cloudId": "abc-123-def-456",
+  "siteUrl": "https://example.atlassian.net",
+  "currentUser": { "accountId": "u1", "displayName": "User One", "email": "u1@example.com" },
+  "project": { "key": "PROJ", "name": "Example", "id": "10000" },
+  "issueTypes": {
+    "Task":     { "id": "10001", "subtask": false, "hierarchyLevel": 0 },
+    "Sub-task": { "id": "10004", "subtask": true,  "hierarchyLevel": -1 }
+  },
+  "fieldSchemas": {
+    "Task": {
+      "summary":     { "required": true,  "type": "string" },
+      "description": { "required": false, "type": "string" }
+    }
+  },
+  "workflows": {
+    "Task": { "unsampled": true }
+  },
+  "linkTypes": [],
+  "userMappings": {}
+}
+```
+
+## Flags (from check output)
+```json
+{ "skipWorkflowDiscovery": true, "site": null }
+```
+
+## User Request Context
+The user wants to transition `PROJ-147` to "Done". Because `workflows.Task.unsampled`
+is `true`, the cache has no transition IDs for this issue type. The skill must call
+`mcp__atlassian__getTransitionsForJiraIssue` live for the specific issue to obtain
+the transition ID before calling `mcp__atlassian__transitionJiraIssue`. It must NOT
+guess a transition ID, NOT use a transition name string, and NOT treat `unsampled`
+as a blocking cache-completeness failure.

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -35,3 +35,4 @@ tests:
   - file://datasets/markdown-to-adf-exec.yaml
   - file://datasets/openspec-lib-exec.yaml
   - file://datasets/openspec-enrich-exec.yaml
+  - file://datasets/jira-sdlc-exec.yaml

--- a/tests/promptfoo/providers/hook-runner.js
+++ b/tests/promptfoo/providers/hook-runner.js
@@ -10,7 +10,11 @@
  *   script_args  — (optional) space-separated args
  *   script_stdin — JSON string piped to the script's stdin
  *   script_cwd   — (optional) working directory for script execution
+ *   script_home  — (optional) HOME override; accepts relative (resolved against
+ *                  script_cwd) or absolute path. Useful for tests depending on
+ *                  ~/.sdlc-cache/... layouts.
  */
+const path = require('path');
 const { spawnSync } = require('child_process');
 
 class HookRunnerProvider {
@@ -29,11 +33,20 @@ class HookRunnerProvider {
       return { error: 'hook-runner: script_path var is required' };
     }
 
+    const env = Object.assign({}, process.env);
+    if (vars.script_home) {
+      const home = path.isAbsolute(vars.script_home)
+        ? vars.script_home
+        : path.resolve(cwd || process.cwd(), vars.script_home);
+      env.HOME = home;
+    }
+
     const result = spawnSync('node', [scriptPath, ...scriptArgs], {
       input: stdinData,
       timeout: 30_000,
       encoding: 'utf8',
       cwd,
+      env,
     });
 
     const output = JSON.stringify({

--- a/tests/promptfoo/providers/script-runner.js
+++ b/tests/promptfoo/providers/script-runner.js
@@ -6,7 +6,12 @@
  *   script_path  — absolute path to the node script
  *   script_args  — space-separated args (e.g., "--project-root /tmp/fixture-abc --json")
  *   script_cwd   — (optional) working directory for script execution
+ *   script_home  — (optional) HOME override; useful for tests that depend on
+ *                  `~/.sdlc-cache/...` layouts. Accepts a relative path (resolved
+ *                  against `script_cwd`) or an absolute path.
+ *   script_env   — (optional) JSON string or object of extra env vars
  */
+const path = require('path');
 const { execFileSync } = require('child_process');
 
 class ScriptRunnerProvider {
@@ -24,11 +29,28 @@ class ScriptRunnerProvider {
       return { error: 'script-runner: script_path var is required' };
     }
 
+    // Build env: inherit parent env, allow HOME override and arbitrary additions.
+    const env = Object.assign({}, process.env);
+    if (vars.script_home) {
+      const home = path.isAbsolute(vars.script_home)
+        ? vars.script_home
+        : path.resolve(cwd || process.cwd(), vars.script_home);
+      env.HOME = home;
+    }
+    if (vars.script_env) {
+      let extra = vars.script_env;
+      if (typeof extra === 'string') {
+        try { extra = JSON.parse(extra); } catch (_) { extra = {}; }
+      }
+      if (extra && typeof extra === 'object') Object.assign(env, extra);
+    }
+
     try {
       const stdout = execFileSync('node', [scriptPath, ...scriptArgs], {
         timeout: 30_000,
         encoding: 'utf8',
         cwd,
+        env,
       });
       return { output: stdout };
     } catch (err) {

--- a/tests/promptfoo/scripts/extract-skill-content.js
+++ b/tests/promptfoo/scripts/extract-skill-content.js
@@ -67,7 +67,18 @@ module.exports = async function transformVars(vars) {
 
   // script_args: replace {{project_root}} placeholder after temp dir resolution
   if (vars.script_args && result.project_root) {
-    result.script_args = vars.script_args.replace('{{project_root}}', result.project_root);
+    result.script_args = vars.script_args.replace(/\{\{project_root\}\}/g, result.project_root);
+  }
+
+  // script_home: replace {{project_root}} placeholder so tests can anchor HOME
+  // overrides against the temp-copied fixture directory.
+  if (vars.script_home && result.project_root) {
+    result.script_home = vars.script_home.replace(/\{\{project_root\}\}/g, result.project_root);
+  }
+
+  // script_cwd: same substitution — common when the fixture root itself is the cwd.
+  if (vars.script_cwd && result.project_root) {
+    result.script_cwd = vars.script_cwd.replace(/\{\{project_root\}\}/g, result.project_root);
   }
 
   return result;


### PR DESCRIPTION
## Summary
Migrates the jira-sdlc cache to the user's home directory, adds multi-project support via a `jira.projects` array in sdlc config, and introduces a `--skip-workflow-discovery` flag for CI environments. Includes legacy cache migration for seamless upgrades.

## Business Context
The jira-sdlc skill previously stored its cache in the project directory (`.sdlc/jira-cache/`), which caused it to be committed to version control and made it incompatible with multi-project setups. Teams working across multiple Jira projects had no way to configure project membership or restrict the skill to a specific list of projects. CI pipelines also suffered from unnecessary Jira workflow discovery calls that slowed down automated runs and required network access.

## Business Benefits
- Cache is now stored globally at `~/.sdlc-cache/jira/<site>/<KEY>.json`, consistent with XDG Base Directory conventions — no more accidental project-cache commits
- Multi-project teams can declare `jira.projects` in `.claude/sdlc.json` and get a closed-list project picker plus automatic project membership validation
- CI pipelines can pass `--skip-workflow-discovery` to bypass Jira workflow API calls, enabling faster and more reliable automated runs
- Legacy cache locations (`.sdlc/jira-cache/` and `.claude/jira-cache/`) are automatically migrated with zero user action required

## Github Issue
Fixes #171
Fixes #168
Fixes #169

## Technical Design
The cache path resolution was refactored into a `resolveEffectiveCachePath` helper that implements a 5-step fallback chain: home-cache path → legacy `.sdlc` path → legacy `.claude` path → environment override → computed default. This ensures backward compatibility while directing new writes to the home cache location. The `jira.projects` schema was added to `sdlc-config.schema.json` as a string array; when present, the skill validates the selected project against this list and renders a closed-list prompt. The `--skip-workflow-discovery` flag routes `unsampled` transitions directly to `getTransitionsForJiraIssue` instead of the discovery pipeline, short-circuiting the workflow sampling step.

## Technical Impact
- Cache path changed: `.sdlc/jira-cache/<KEY>.json` → `~/.sdlc-cache/jira/<site>/<KEY>.json` (legacy paths still read; writes go to new location)
- New `jira.projects` field added to `sdlc-config.schema.json` (additive, optional — no breaking change)
- New `--skip-workflow-discovery` flag on jira-sdlc (additive, optional)
- R16 auto-trigger phrase expansion in SKILL.md frontmatter description: adds read/view/comment-add coverage for session-start hook
- Only jira-sdlc is affected; no other skill reads `jira.defaultProject` at runtime

## Changes Overview
- Cache architecture overhauled: multi-site home cache layout with per-site subdirectories, plus transparent legacy migration from `.sdlc` and `.claude` paths
- Multi-project support added: `jira.projects` array in sdlc config drives a closed-list project picker and membership validation with 5-step resolution fallback
- CI workflow discovery flag added: `--skip-workflow-discovery` bypasses Jira transition discovery calls and routes unsampled issues directly to live transition API
- R-number annotations added to SKILL.md and spec: R13/R14/R15/R16 correctly linked to implementation
- siteUrl format clarified in documentation and examples (sanitized host form `acme_atlassian_net`)
- Test coverage expanded: 8 new exec test cases, 2 behavioral test cases, 6 new filesystem fixtures covering home cache layout, legacy paths, multi-project config, and save roundtrip
- Cache path hardening in `resolveEffectiveCachePath` to handle edge cases in path resolution

## Testing
- 8 new exec-layer test cases in `jira-sdlc-exec.yaml` covering cache path resolution, legacy migration, multi-project closed-list, and `--skip-workflow-discovery` routing
- 2 new behavioral test cases in `jira-sdlc.yaml` covering multi-project closed-list prompt and unsampled transition routing
- 6 new filesystem fixtures: `jira-cache-home-multi-site` (two sites), `jira-cache-legacy-claude`, `jira-cache-legacy-sdlc`, `jira-multi-project-config`, `jira-save-roundtrip`
- No breaking changes to existing test fixtures — all pre-existing cases continue to pass with new resolution logic