### PR TITLE
fix(#167): review-sdlc - post-confirm handling moved to main context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.24] - 2026-04-23
+
+### Fixed
+- review-sdlc post-confirm handling moved to the skill's main context, preventing the orchestrator from re-running the full review pipeline when the user confirms posting the PR comment; includes branch-name escaping for save paths, corrected field reference in review-orchestrator, and stale pipeline step types in skills-meta.ts (#167)
+
 ## [0.17.23] - 2026-04-23
 
 ### Added

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -182,6 +182,51 @@ These suggestions are informational during a review run. To act on them, run `/s
 
 ---
 
+## PR Posting Flow
+
+After the orchestrator finishes, the skill (not the orchestrator) handles posting in the main context. What you see depends on whether a PR exists for the current branch and the review scope.
+
+### When a PR exists
+
+The skill prints the full consolidated comment, then prompts:
+
+```text
+Post this review comment to PR #{number}? (yes / save / cancel)
+```
+
+| Reply | Effect |
+|-------|--------|
+| `yes` | Posts the comment to the PR via `gh api repos/{owner}/{repo}/issues/{number}/comments -F body=@{comment_file}`. The `-F body=@<path>` form reads the body from the file, so markdown with backticks, quotes, or long content posts reliably — no shell escaping. |
+| `save` | Copies the comment to `.claude/reviews/<branch>-<YYYY-MM-DD>.md`. Does not post. |
+| `cancel` | No action. The review remains visible in the terminal only. |
+
+No additional orchestrator or dimension subagent is dispatched after your reply — the comment body was computed during the single orchestrator run and persisted to disk.
+
+### When no PR exists — branch scope (`all` / `committed` / `worktree`)
+
+```text
+No PR found. Options:
+  1. Create a draft PR and attach this review as a comment
+  2. Save review to .claude/reviews/<branch>-<YYYY-MM-DD>.md
+  3. Keep in terminal only
+```
+
+Option 1 invokes `/pr-sdlc` in draft mode, then posts the comment to the newly created PR.
+
+### When no PR exists — local scope (`staged` / `working`)
+
+```text
+Reviewing local changes — no PR to post to. Options:
+  1. Save review to .claude/reviews/<branch>-<YYYY-MM-DD>.md
+  2. Keep in terminal only
+```
+
+### Comment persistence
+
+During the run, the consolidated comment body is written to `${diff_dir}/review-comment.md` (a temporary location under `$TMPDIR`). The skill reads this path from the orchestrator summary and uses it for `gh api -F body=@…` or `save` copies. The file is discarded along with the diff dir after the terminal branch — including when you reply `cancel` or the command fails.
+
+---
+
 ## Post-Review Self-Fix
 
 After a review completes with actionable findings (verdict **CHANGES REQUESTED** or **APPROVED WITH NOTES**), the skill prompts:

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -197,7 +197,7 @@ Post this review comment to PR #{number}? (yes / save / cancel)
 | Reply | Effect |
 |-------|--------|
 | `yes` | Posts the comment to the PR via `gh api repos/{owner}/{repo}/issues/{number}/comments -F body=@{comment_file}`. The `-F body=@<path>` form reads the body from the file, so markdown with backticks, quotes, or long content posts reliably — no shell escaping. |
-| `save` | Copies the comment to `.claude/reviews/<branch>-<YYYY-MM-DD>.md`. Does not post. |
+| `save` | Copies the comment to `.claude/reviews/<branch>-<YYYY-MM-DD>.md` (slashes in branch names are replaced with `-`). Does not post. |
 | `cancel` | No action. The review remains visible in the terminal only. |
 
 No additional orchestrator or dimension subagent is dispatched after your reply — the comment body was computed during the single orchestrator run and persisted to disk.

--- a/docs/specs/review-sdlc.md
+++ b/docs/specs/review-sdlc.md
@@ -28,6 +28,9 @@
 - R7: When verdict is APPROVED, skip the self-fix offer
 - R8: Clean up the manifest temp file after completion
 - R9: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R10: Post-confirmation (`yes` / `save` / `cancel`) is issued by the skill in the main context, not by the orchestrator
+- R11: Orchestrator writes the consolidated comment body to `${manifest.diff_dir}/review-comment.md` and returns its absolute path plus `pr.*` metadata in its summary; the skill acts on the summary without reading the manifest
+- R12: When the user confirms `yes`, the skill posts via `gh api … -F body=@<path>` — no further Agent dispatch is made to complete posting
 
 ## Workflow Phases
 
@@ -36,14 +39,16 @@
    - **Params:** A1-A7 forwarded (`--base <branch>`, `--committed`, `--staged`, `--working`, `--worktree`, `--set-default`, `--dimensions <list>`)
    - **Output:** manifest file path → P1-P8 (base branch, changed files, dimension counts/entries, plan critique); also writes per-dimension `.diff` files to tmpdir. Skill must NOT read manifest into main context
 2. DO — dispatch review-orchestrator agent (or display dry-run plan)
-3. REPORT — display orchestrator summary, clean up manifest
-4. OFFER — conditionally offer self-fix based on review verdict
+3. REPORT — display orchestrator summary
+4. POST — skill handles PR posting decision in main context (`yes` / `save` / `cancel` or no-PR options), then cleans up manifest and diff dir
+5. OFFER — conditionally offer self-fix based on review verdict
 
 ## Quality Gates
 
 - G1: Manifest file produced — `skill/review.js` exits successfully and produces a valid file path
 - G2: Orchestrator dispatched — agent is spawned (not via Skill tool) with manifest path and project root
-- G3: Manifest cleaned up — temp file is deleted after completion or cancellation
+- G3: Manifest file and `diff_dir` cleaned up by the skill after the terminal branch (including failures)
+- G4: Exactly one `review-orchestrator` Agent dispatch per `/review-sdlc` invocation (a retry on failure counts as the same attempt; user confirmation never triggers a new dispatch)
 
 ## Prepare Script Contract
 
@@ -75,6 +80,9 @@
 - C7: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
 - C8: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C9: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
+- C10: Orchestrator MUST NOT call `gh api` or prompt the user for PR-posting confirmation
+- C11: Orchestrator MUST NOT delete `manifest.diff_dir` — the skill owns cleanup of both the manifest file and the diff dir
+- C12: Skill MUST NOT re-dispatch the orchestrator to complete a posting flow already computed — `comment_file` from the orchestrator summary is authoritative
 
 ## Step-Emitter Contract
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.23",
+  "version": "0.17.24",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/review-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/review-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: review-orchestrator
-description: Orchestrates multi-dimension code review. Reads manifest from a temp file, resolves REFERENCE.md, dispatches dimension review subagents in parallel, critiques and deduplicates findings, and posts a consolidated PR comment.
-tools: Read, Glob, Grep, Bash, Agent
+description: Orchestrates multi-dimension code review. Reads manifest from a temp file, resolves REFERENCE.md, dispatches dimension review subagents in parallel, critiques and deduplicates findings, and persists the consolidated comment body to disk for the skill to post.
+tools: Read, Write, Glob, Grep, Bash, Agent
 ---
 
 # Code Review Orchestrator
@@ -135,7 +135,7 @@ Apply fixes from the critique:
   manual review required.`
 - **Re-calibrate** miscalibrated severities.
 
-## Step 5 — Build and Post Consolidated Comment
+## Step 5 — Build and Persist Consolidated Comment
 
 Format the comment using the template from REFERENCE.md section 3.
 
@@ -145,76 +145,40 @@ Format the comment using the template from REFERENCE.md section 3.
 - `APPROVED WITH NOTES` — any `high` finding, OR ≥ 5 `medium` findings
 - `APPROVED` — all other cases
 
-**Present for confirmation:**
+**Display the formatted comment in the terminal** so the user sees the content in your output.
 
-If `manifest.pr.exists`, display the full formatted comment and ask for explicit user
-approval before posting. **Do not execute `gh api` without explicit user approval.**
+**Persist the comment body to disk** using the `Write` tool:
 
-```text
-Review comment ready to post to PR #{manifest.pr.number}:
-─────────────────────────────────────────────
-{consolidated comment}
-─────────────────────────────────────────────
+- Path: `{manifest.diff_dir}/review-comment.md`
+- Content: the consolidated comment body verbatim (no surrounding fences, no shell escaping)
 
-Post this review comment to PR #{manifest.pr.number}? (yes / save / cancel)
-  yes    — post the comment to the PR
-  save   — save review to .claude/reviews/<branch>-<date>.md instead
-  cancel — keep in terminal only (already shown above)
-```
+The skill's main context will read this file when posting or saving.
 
-Wait for the user's response:
+**Do NOT** prompt the user for posting confirmation. **Do NOT** call `gh api`. **Do NOT** implement a `save` branch. **Do NOT** present no-PR menu options. **Do NOT** invoke the `pr-sdlc` skill. The skill owns all of these in the main context after you return — posting is driven from the summary you emit in Step 6.
 
-- `yes` → post via `gh api`:
+## Step 6 — Return Summary
 
-  ```bash
-  gh api repos/{manifest.pr.owner}/{manifest.pr.repo}/issues/{manifest.pr.number}/comments \
-    -f body="{comment}"
-  ```
+Do NOT delete `manifest.diff_dir` — the skill owns cleanup of both the manifest file and the diff dir.
 
-- `save` → write the review to `.claude/reviews/<branch>-<date>.md`
-- `cancel` → skip posting; review is already visible in the terminal
-
-If no PR: present the full review in the terminal, then offer options based on scope:
-
-For `all`, `committed`, or `worktree` scope (branch-based changes):
-
-```text
-No PR found. Options:
-  1. Create a draft PR to attach this review as a comment
-  2. Save review to .claude/reviews/<branch>-<date>.md
-  3. Keep in terminal only (already shown)
-```
-
-For option 1: invoke the `pr-sdlc` skill
-in draft mode, wait for the PR to be created, then post the consolidated review
-comment to the new PR using the `gh api` command above.
-
-For `staged` or `working` scope (local changes not yet committed):
-
-```text
-Reviewing local changes — no PR to post to. Options:
-  1. Save review to .claude/reviews/<branch>-<date>.md
-  2. Keep in terminal only (already shown)
-```
-
-## Step 6 — Cleanup and Return Summary
-
-Clean up the temp diff directory:
-
-```bash
-rm -rf {manifest.diff_dir}
-```
-
-Output this summary for the main context to display:
+Output this structured plain-text summary for the main context to parse:
 
 ```text
 Review complete
   Dimensions run:  {active} ({skipped} skipped — no matching files)
   Total findings:  {total}
     critical: {C} | high: {H} | medium: {M} | low: {L} | info: {I}
-  Verdict: {VERDICT}
-  PR comment: {url or "none"}
+  Verdict:         {VERDICT}
+  Scope:           {scope label}
+  Branch:          {manifest.git.branch}
+  Comment file:    {absolute path to review-comment.md inside diff_dir}
+  PR exists:       {true|false}
+  PR owner:        {manifest.pr.owner or "—"}
+  PR repo:         {manifest.pr.repo or "—"}
+  PR number:       {manifest.pr.number or "—"}
+  Diff dir:        {manifest.diff_dir}
 ```
+
+Every field is required. Use `—` for `PR owner` / `PR repo` / `PR number` when `PR exists` is `false`.
 
 ## Quality Gates
 
@@ -225,9 +189,14 @@ Before returning:
 - Consolidated comment has all 4 sections: header, summary table, verdict, per-dimension details
 - All findings reference a specific `file:line`
 - Verdict computed from actual severity counts (not hardcoded)
-- Temp diff directory (`manifest.diff_dir`) has been cleaned up
+- Comment body written to `{manifest.diff_dir}/review-comment.md`
+- Summary contains all required fields (comment file absolute path, PR metadata, diff_dir)
 
 ## DO NOT
 
-- Post the review comment to a PR via `gh api` without explicit user approval
+- Prompt user for PR-posting confirmation (the skill's main context owns this)
+- Call `gh api` to post a comment (the skill's main context owns this)
+- Implement `yes` / `save` / `cancel` branches or no-PR menu options
+- Invoke the `pr-sdlc` skill
+- Delete `manifest.diff_dir` or the manifest file — the skill cleans both up
 - Dispatch dimension subagents without `model: manifest.subagent_model` — omitting it defaults to opus

--- a/plugins/sdlc-utilities/agents/review-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/review-orchestrator.md
@@ -169,7 +169,7 @@ Review complete
     critical: {C} | high: {H} | medium: {M} | low: {L} | info: {I}
   Verdict:         {VERDICT}
   Scope:           {scope label}
-  Branch:          {manifest.git.branch}
+  Branch:          {manifest.current_branch}
   Comment file:    {absolute path to review-comment.md inside diff_dir}
   PR exists:       {true|false}
   PR owner:        {manifest.pr.owner or "—"}

--- a/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
@@ -72,11 +72,8 @@ Clean up: `rm -f "$MANIFEST_FILE"`. Stop here.
 
 ## Step 2 — Spawn Orchestrator Agent
 
-Locate the orchestrator agent definition using Glob: `path: ~/.claude`, pattern
-`**/agents/review-orchestrator.md`. If not found, retry Glob with the default path (cwd).
-
-Spawn a single Agent (subagent_type: `sdlc:review-orchestrator`) with the orchestrator
-agent's full content as the prompt, plus this context appended:
+Spawn a single Agent using `subagent_type: sdlc:review-orchestrator` with the following
+context as the prompt:
 
 ```
 MANIFEST_FILE: {the temp file path from Step 0}
@@ -142,8 +139,9 @@ Wait for the user's reply.
 - `save` →
 
   ```bash
+  BRANCH_SAFE="${branch//\//-}"
   mkdir -p .claude/reviews
-  cp "{comment_file}" ".claude/reviews/{branch}-$(date +%Y-%m-%d).md"
+  cp "{comment_file}" ".claude/reviews/${BRANCH_SAFE}-$(date +%Y-%m-%d).md"
   ```
 
 - `cancel` → no action. The comment is already visible in the terminal from Step 3.

--- a/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
@@ -84,29 +84,103 @@ PROJECT_ROOT: {current working directory}
 ```
 
 The orchestrator will read the manifest, resolve REFERENCE.md, dispatch dimension
-subagents, critique/deduplicate, format the comment, handle PR posting, and clean up.
+subagents, critique/deduplicate, format the comment, and persist the consolidated
+comment body to `${diff_dir}/review-comment.md`. It does NOT post to a PR and does
+NOT prompt the user — the skill handles posting in Step 4.
 
 Wait for the orchestrator to return its summary.
 
 **On orchestrator failure:** Re-dispatch once with the same inputs. If the second
 attempt also fails, invoke error-report-sdlc with skill=review-sdlc,
-step=Step 2 — orchestrator dispatch, error=agent error output.
+step=Step 2 — orchestrator dispatch, error=agent error output. A failure retry counts
+as the same attempt for quality-gate G4 — user confirmation in Step 4 MUST NOT trigger
+a new orchestrator dispatch.
 
 ---
 
-## Step 3 — Report and Cleanup
+## Step 3 — Parse Orchestrator Summary
 
-Display the orchestrator's summary to the user.
+Display the orchestrator's summary to the user verbatim.
 
-Clean up the manifest temp file:
+Parse the summary to extract:
 
-```bash
-rm -f "$MANIFEST_FILE"
+- `comment_file` — absolute path to `${diff_dir}/review-comment.md`
+- `pr.exists` (boolean), `pr.owner`, `pr.repo`, `pr.number`
+- `verdict` — one of `CHANGES REQUESTED`, `APPROVED WITH NOTES`, `APPROVED`
+- `scope` — scope label from the summary
+- `branch` — current branch name
+- `diff_dir` — absolute path to the orchestrator's working diff dir
+
+Do NOT delete the manifest file here — cleanup happens in Step 6 on every terminal branch.
+
+---
+
+## Step 4 — Handle Posting
+
+This step runs entirely in the main context. It MUST NOT dispatch a new Agent, and
+MUST NOT re-invoke the orchestrator. The comment body at `comment_file` is authoritative.
+
+### PR exists (`pr.exists == true`)
+
+Prompt in the main context:
+
+```text
+Post this review comment to PR #{pr.number}? (yes / save / cancel)
+  yes    — post the comment to the PR
+  save   — save review to .claude/reviews/<branch>-<YYYY-MM-DD>.md instead
+  cancel — keep in terminal only (already shown above)
 ```
 
+Wait for the user's reply.
+
+- `yes` → post via `gh api` using the file body form (safe for large markdown, backticks, quotes):
+
+  ```bash
+  gh api repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments -F body=@{comment_file}
+  ```
+
+- `save` →
+
+  ```bash
+  mkdir -p .claude/reviews
+  cp "{comment_file}" ".claude/reviews/{branch}-$(date +%Y-%m-%d).md"
+  ```
+
+- `cancel` → no action. The comment is already visible in the terminal from Step 3.
+
+### No PR, branch scope (`scope` is `all`, `committed`, or `worktree`)
+
+Prompt:
+
+```text
+No PR found. Options:
+  1. Create a draft PR and attach this review as a comment
+  2. Save review to .claude/reviews/<branch>-<YYYY-MM-DD>.md
+  3. Keep in terminal only
+```
+
+- Option 1 → invoke `pr-sdlc` from the main context in draft mode, wait for PR
+  creation, then post via the `gh api … -F body=@{comment_file}` command above using
+  the newly created PR's owner/repo/number.
+- Option 2 → same `save` command as above.
+- Option 3 → no action.
+
+### No PR, local scope (`scope` is `staged` or `working`)
+
+Prompt:
+
+```text
+Reviewing local changes — no PR to post to. Options:
+  1. Save review to .claude/reviews/<branch>-<YYYY-MM-DD>.md
+  2. Keep in terminal only
+```
+
+- Option 1 → `save` command above.
+- Option 2 → no action.
+
 ---
 
-## Step 4 — Offer Self-Fix
+## Step 5 — Offer Self-Fix
 
 If the verdict is **CHANGES REQUESTED** or **APPROVED WITH NOTES**, offer to fix:
 
@@ -119,12 +193,25 @@ If verdict is **APPROVED**: skip — nothing to fix.
 
 ---
 
+## Step 6 — Cleanup
+
+Runs on every terminal branch of Step 4 — including `cancel`, terminal-only, errors,
+and orchestrator failures. Must not be skipped.
+
+```bash
+rm -f "$MANIFEST_FILE"
+rm -rf "{diff_dir}"
+```
+
+---
+
 ## DO NOT
 
 - Do NOT read the manifest JSON into main context (the orchestrator reads it)
 - Do NOT read REFERENCE.md in main context (the orchestrator resolves it)
 - Do NOT read the orchestrator agent definition into main context — pass the file path or use the sdlc:review-orchestrator subagent_type
 - Do NOT invoke error-report-sdlc for user errors — only for script crashes (exit 2)
+- Do NOT re-dispatch the orchestrator to post the comment — use the `comment_file` from its summary
 
 ## See Also
 

--- a/site/src/data/skills-meta.ts
+++ b/site/src/data/skills-meta.ts
@@ -110,7 +110,8 @@ export const skillsMeta: SkillMeta[] = [
       { id: 'scope-diff', label: 'Resolve diff scope', type: 'script', description: 'Computes the diff based on --committed/--staged/--working/--worktree flags' },
       { id: 'dispatch-reviewers', label: 'Dispatch review agents', type: 'dispatch', description: 'Parallel subagents review each matching dimension independently' },
       { id: 'deduplicate', label: 'Deduplicate findings', type: 'llm', description: 'Merges overlapping findings from multiple dimensions into a unified list' },
-      { id: 'post-comment', label: 'Post PR comment', type: 'script', description: 'Posts consolidated review comment to the GitHub PR via gh CLI' },
+      { id: 'persist-comment', label: 'Persist review comment', type: 'llm', description: 'Orchestrator writes consolidated comment body to disk; skill parses summary and handles posting in main context' },
+      { id: 'post-prompt', label: 'Post or save comment', type: 'user', description: 'Prompts yes / save / cancel; posts via gh api -F body=@ or saves to .claude/reviews/' },
       { id: 'fix-prompt', label: 'Offer self-fix', type: 'user', description: 'Prompts to invoke received-review-sdlc when actionable findings exist' },
     ],
     connections: [

--- a/tests/promptfoo/datasets/review-sdlc.yaml
+++ b/tests/promptfoo/datasets/review-sdlc.yaml
@@ -221,6 +221,93 @@
         dispatch indicates that dimension subagents should use sonnet as their
         model (via manifest.subagent_model or explicit model: sonnet).
 
+- description: "review-sdlc: post-confirmation yes posts via gh api -F body=@ without re-dispatch (issue #167)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
+    project_context: "file://fixtures/review-post-confirm-yes.md"
+    user_request: >
+      Continue the /review-sdlc flow. The orchestrator has already returned the summary shown
+      in the project context and the user replied "yes". Describe exactly what happens next
+      in the main context, including the precise shell command used to post the comment.
+  assert:
+    # Must post via -F body=@ (file form, not -f body="…")
+    - type: regex
+      value: 'gh api[^\n]+-F body=@'
+    # Must reference the orchestrator-provided comment_file path
+    - type: icontains
+      value: "/tmp/review-diff-abc123/review-comment.md"
+    # Must NOT use the fragile -f body="…" inline form
+    - type: not-regex
+      value: '-f body="'
+    # Must NOT re-dispatch any agent to post the comment
+    - type: not-regex
+      value: "(dispatch.*orchestrator|spawn.*Agent|Agent tool|subagent_type)"
+    # Behavioral: one gh api call, zero agent re-dispatch, cleanup happens after
+    - type: llm-rubric
+      value: >
+        The response describes posting the consolidated review comment to PR #42 via exactly
+        one `gh api repos/acme-corp/widgets/issues/42/comments -F body=@/tmp/review-diff-abc123/review-comment.md`
+        call. It does NOT re-invoke the review-orchestrator, does NOT dispatch any new Agent,
+        and does NOT use the fragile `-f body="…"` inline form. After posting, both the
+        manifest file and the diff dir (`/tmp/review-diff-abc123`) are cleaned up.
+
+- description: "review-sdlc: post-confirmation cancel — no gh api, no save, diff_dir cleaned (issue #167)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
+    project_context: "file://fixtures/review-post-confirm-cancel.md"
+    user_request: >
+      Continue the /review-sdlc flow. The orchestrator has already returned the summary shown
+      in the project context and the user replied "cancel". Describe exactly what happens next.
+  assert:
+    # Must NOT invoke gh api
+    - type: not-regex
+      value: "gh api"
+    # Must NOT write anything under .claude/reviews/
+    - type: not-regex
+      value: '\.claude/reviews/[^"\s]*\.md'
+    # Must clean up the diff dir from the summary
+    - type: regex
+      value: "(rm -rf.*review-diff-def456|/tmp/review-diff-def456.*(cleaned|removed|deleted))"
+    # Behavioral
+    - type: llm-rubric
+      value: >
+        The response acknowledges the cancel reply. It does NOT post via `gh api`. It does NOT
+        write any file under `.claude/reviews/`. It still cleans up the manifest file and the
+        diff dir at `/tmp/review-diff-def456` — cleanup runs on every terminal branch, including
+        cancel. It does not re-dispatch the orchestrator.
+
+- description: "review-sdlc: post-confirmation save — copies comment to .claude/reviews, no gh api (issue #167)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
+    project_context: "file://fixtures/review-post-confirm-save.md"
+    user_request: >
+      Continue the /review-sdlc flow. The orchestrator has already returned the summary shown
+      in the project context and the user replied "save". Describe exactly what happens next,
+      including the filename under .claude/reviews/.
+  assert:
+    # Must NOT invoke gh api
+    - type: not-regex
+      value: "gh api"
+    # Must save under .claude/reviews/<branch>-<date>.md
+    - type: regex
+      value: '\.claude/reviews/feat-search-api-\d{4}-\d{2}-\d{2}\.md|\.claude/reviews/[^"\s]*search-api[^"\s]*\.md'
+    # Must reference the orchestrator-provided comment_file as the source
+    - type: icontains
+      value: "/tmp/review-diff-ghi789/review-comment.md"
+    # Must clean up the diff dir after save
+    - type: regex
+      value: "(rm -rf.*review-diff-ghi789|/tmp/review-diff-ghi789.*(cleaned|removed|deleted))"
+    # Behavioral
+    - type: llm-rubric
+      value: >
+        The response describes saving the consolidated comment to a file under
+        `.claude/reviews/` named `<branch>-<YYYY-MM-DD>.md` where branch is `feat/search-api`
+        (slashes replaced or preserved per project convention) and the date is today. The save
+        is performed by copying from the orchestrator-provided `Comment file` path
+        (`/tmp/review-diff-ghi789/review-comment.md`). It does NOT call `gh api`. After saving,
+        both the manifest file and the diff dir (`/tmp/review-diff-ghi789`) are cleaned up.
+        It does not re-dispatch the orchestrator.
+
 - description: "review-sdlc: approved verdict completes cleanly without fix offer"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"

--- a/tests/promptfoo/fixtures/review-post-confirm-cancel.md
+++ b/tests/promptfoo/fixtures/review-post-confirm-cancel.md
@@ -1,0 +1,42 @@
+# Review-sdlc — post-confirmation context (reply: cancel)
+
+The `review-orchestrator` agent has already completed. It persisted the consolidated
+comment body to the path shown below and returned the following summary to the skill's
+main context. No further orchestrator dispatch should happen.
+
+## Orchestrator summary (returned to skill)
+
+```text
+Review complete
+  Dimensions run:  2 (0 skipped — no matching files)
+  Total findings:  1
+    critical: 0 | high: 0 | medium: 0 | low: 1 | info: 0
+  Verdict:         APPROVED
+  Scope:           Committed branch changes only
+  Branch:          feat/search-api
+  Comment file:    /tmp/review-diff-def456/review-comment.md
+  PR exists:       true
+  PR owner:        acme-corp
+  PR repo:         widgets
+  PR number:       42
+  Diff dir:        /tmp/review-diff-def456
+```
+
+## File state
+
+`/tmp/review-diff-def456/review-comment.md` exists with the formatted comment body.
+`.claude/reviews/` does not yet contain any entry for this branch.
+
+## User interaction
+
+The skill displayed the summary and the formatted comment, then showed the prompt:
+
+```text
+Post this review comment to PR #42? (yes / save / cancel)
+```
+
+The user replied: **cancel**
+
+Describe precisely what the skill does. It must NOT call `gh api`, must NOT write any
+file under `.claude/reviews/`, and must still clean up both the manifest file and the
+diff dir at `/tmp/review-diff-def456`.

--- a/tests/promptfoo/fixtures/review-post-confirm-save.md
+++ b/tests/promptfoo/fixtures/review-post-confirm-save.md
@@ -1,0 +1,43 @@
+# Review-sdlc — post-confirmation context (reply: save)
+
+The `review-orchestrator` agent has already completed. It persisted the consolidated
+comment body to the path shown below and returned the following summary to the skill's
+main context. No further orchestrator dispatch should happen.
+
+## Orchestrator summary (returned to skill)
+
+```text
+Review complete
+  Dimensions run:  2 (0 skipped — no matching files)
+  Total findings:  2
+    critical: 0 | high: 0 | medium: 1 | low: 1 | info: 0
+  Verdict:         APPROVED WITH NOTES
+  Scope:           Committed branch changes only
+  Branch:          feat/search-api
+  Comment file:    /tmp/review-diff-ghi789/review-comment.md
+  PR exists:       true
+  PR owner:        acme-corp
+  PR repo:         widgets
+  PR number:       42
+  Diff dir:        /tmp/review-diff-ghi789
+```
+
+## File state
+
+`/tmp/review-diff-ghi789/review-comment.md` exists with the formatted comment body.
+`.claude/reviews/` is currently empty.
+
+## User interaction
+
+The skill displayed the summary and the formatted comment, then showed the prompt:
+
+```text
+Post this review comment to PR #42? (yes / save / cancel)
+```
+
+The user replied: **save**
+
+Describe precisely what the skill does. It must NOT call `gh api`. It MUST save the
+comment to `.claude/reviews/<branch>-<YYYY-MM-DD>.md` by copying the `Comment file`
+path from the summary. After saving, both the manifest file and the diff dir at
+`/tmp/review-diff-ghi789` must be cleaned up.

--- a/tests/promptfoo/fixtures/review-post-confirm-yes.md
+++ b/tests/promptfoo/fixtures/review-post-confirm-yes.md
@@ -1,0 +1,42 @@
+# Review-sdlc — post-confirmation context (reply: yes)
+
+The `review-orchestrator` agent has already completed. It persisted the consolidated
+comment body to the path shown below and returned the following summary to the skill's
+main context. No further orchestrator dispatch should happen.
+
+## Orchestrator summary (returned to skill)
+
+```text
+Review complete
+  Dimensions run:  2 (0 skipped — no matching files)
+  Total findings:  3
+    critical: 0 | high: 1 | medium: 1 | low: 1 | info: 0
+  Verdict:         APPROVED WITH NOTES
+  Scope:           Committed branch changes only
+  Branch:          feat/search-api
+  Comment file:    /tmp/review-diff-abc123/review-comment.md
+  PR exists:       true
+  PR owner:        acme-corp
+  PR repo:         widgets
+  PR number:       42
+  Diff dir:        /tmp/review-diff-abc123
+```
+
+## File state
+
+`/tmp/review-diff-abc123/review-comment.md` exists and contains the formatted
+consolidated review comment (header, summary table, verdict, per-dimension details).
+
+## User interaction
+
+The skill displayed the summary and the formatted comment, then showed the prompt:
+
+```text
+Post this review comment to PR #42? (yes / save / cancel)
+```
+
+The user replied: **yes**
+
+Describe precisely what the skill's main context does next. Include the exact `gh api`
+invocation the skill runs. Do not dispatch any additional Agent calls or re-invoke the
+orchestrator. State how cleanup proceeds.


### PR DESCRIPTION
## Summary

Fixes a bug in `review-sdlc` where the orchestrator re-ran the full review pipeline when the user replied "yes" to post the PR comment. Post-confirmation handling (yes/save/cancel prompt, `gh api` posting, cleanup) is now owned entirely by the skill's main context, while the orchestrator focuses on building and persisting the comment to disk.

## Business Context

Users of the `/review-sdlc` skill experienced the orchestrator being re-dispatched unnecessarily when confirming a PR comment post, causing redundant pipeline execution and potentially duplicate or failed postings. This fix closes the architectural gap introduced when the confirmation flow was split between the orchestrator and skill contexts.

## Business Benefits

- `/review-sdlc` confirm flow works correctly: replying "yes" posts exactly one comment without re-running the full review pipeline.
- `gh api` body escaping bug eliminated — switched from `-f body="..."` (fragile for markdown with backticks/quotes) to `-F body=@<path>` (file form, reliable for any content).
- Branch names with slashes no longer produce broken save paths under `.claude/reviews/`.

## Github Issue

https://github.com/RNagrodzki/sdlc-marketplace/issues/167

## Technical Design

The orchestrator's responsibility is narrowed: it now writes the consolidated comment to `${diff_dir}/review-comment.md` and returns a structured plain-text summary including the file path and PR metadata. The skill's main context reads this summary, presents the yes/save/cancel prompt, calls `gh api repos/.../issues/.../comments -F body=@<path>`, and owns cleanup of both the manifest file and the diff dir on every terminal branch. A new `R10`–`R12` spec requirement and `C10`–`C12` constraints codify the boundary. Three promptfoo test fixtures cover the yes/save/cancel branches.

## Technical Impact

- `review-orchestrator.md` agent: Step 5 no longer posts or prompts; Step 6 no longer deletes `diff_dir`; the `Write` tool is added to the agent's tool list.
- `review-sdlc/SKILL.md`: Steps 3–6 restructured; new Step 4 (posting) and Step 6 (cleanup) added.
- `docs/specs/review-sdlc.md`: Requirements R10–R12 and constraints C10–C12 added; workflow phases and quality gates updated.
- `skills-meta.ts`: Two pipeline step entries updated to reflect the new `llm`/`user` step types.
- No breaking changes to the public skill interface or manifest contract.

## Changes Overview

- Post-confirmation logic (yes/save/cancel prompt, `gh api` call, cleanup) moved from orchestrator to skill's main context
- Orchestrator now persists comment body to `${diff_dir}/review-comment.md` and returns structured summary with PR metadata and file path
- `gh api` posting switched to `-F body=@<path>` file form to fix shell escaping issues with markdown content
- Branch-name slash-to-dash escaping added for `.claude/reviews/` save paths
- `manifest.git.branch` field reference corrected to `manifest.current_branch` in orchestrator
- Spec updated with three new requirements (R10–R12) and three new constraints (C10–C12) formalizing the skill/orchestrator boundary
- Three promptfoo test cases and matching fixtures added for yes/save/cancel post-confirmation branches
- `skills-meta.ts` pipeline step types corrected from stale `script` to `llm`/`user`

## Testing

Three promptfoo test cases added to `tests/promptfoo/datasets/review-sdlc.yaml` covering:
- `yes` reply: verifies `gh api -F body=@<path>` is used, no agent re-dispatch, cleanup runs
- `cancel` reply: verifies no `gh api` call, no `.claude/reviews/` write, cleanup runs
- `save` reply: verifies file copied to `.claude/reviews/<branch>-<date>.md`, no `gh api`, cleanup runs

Fixtures at `tests/promptfoo/fixtures/review-post-confirm-{yes,save,cancel}.md` provide the orchestrator summary context for each scenario.