### PR TITLE
fix(#176): review-sdlc - display full comment body in Step 3

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,15 @@
 This is the append-only learnings log for the `ai-setup-automation` marketplace repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-04-23 — version-sdlc: branch without upstream requires --set-upstream on first push
+When releasing from a feature branch that has never been pushed, `git push` fails with exit 128. The fix is `git push --set-upstream origin <branch>` followed by `git push --tags`. This is expected behavior when `remoteState.hasUpstream: false` in the version context.
+
+## 2026-04-23 — pr-sdlc: active gh account may be wrong for repo owner
+When the active `gh` account (`rnagrodzkicl`) doesn't have write permission on the target repo, `gh pr create` fails with "does not have the correct permissions to execute CreatePullRequest". Recovery: run `gh auth switch --user <login>` to switch to the account that owns the repo before retrying. The skill's auto-switch only fires if `ghAuth` is non-null in PR_CONTEXT_JSON; if the script doesn't detect a needed switch, the user may need to switch manually.
+
+## 2026-04-23 — version-sdlc: patch bump on feat branch with no upstream
+Branch had no upstream configured. `git push` failed with exit 128. Recovery: used `git push --set-upstream origin <branch>` followed by `git push --tags`. Branch was a new feature branch in the pipeline, so setting upstream was correct and unblocking.
+
 ## 2026-04-23 — pr-sdlc auto-switch account detection
 **Trigger:** `gh pr create` failed with permissions error because active gh account was `rnagrodzkicl` (work account) rather than `rnagrodzki` (personal account where the repo lives). The auto-switch logic in `pr.js` did not switch because the branch had already been pushed with the remote set.
 **Rule:** When `gh pr create` fails with a permissions error, check `gh auth status` and switch to the account matching the repo owner before retrying. The skill should detect this and switch automatically; when it doesn't, manual `gh auth switch --user <login>` is the fix.
@@ -96,3 +105,8 @@ Branch fix/pipeline-contract-enforcement-and-model-assignment had no upstream. F
 **Trigger:** Review finding that 6 test cases in `openspec-lib-exec.yaml` used `script_path: "inline"` + `script_inline` which the provider doesn't support.
 **Rule:** If a promptfoo exec test calls library functions directly, create a real wrapper script in `tests/promptfoo/scripts/` and use `script_path: "repo://tests/promptfoo/scripts/<name>.js"`. Never use `script_path: "inline"` — script-runner.js passes the path string literally to `execFileSync`, so "inline" becomes a file argument and crashes. The `script_inline` var is never read by any provider.
 **Example:** `script_path: "repo://tests/promptfoo/scripts/openspec-lib-test.js"` with `script_args: "--op isArchived --project-root {{project_root}} --change add-auth"`
+
+## 2026-04-23 — review-orchestrator: manifest field reference `manifest.git.branch` doesn't exist
+**Trigger:** Review of fix/#167 found orchestrator Step 6 summary template used `{manifest.git.branch}` — this field doesn't exist. The manifest schema has `current_branch` at the top level and `git.{commit_count, commit_log, changed_files}` in a sub-object.
+**Rule:** When adding new fields to an orchestrator summary template, verify field paths against the manifest construction in `scripts/skill/review.js` (lines 535-560). The top-level branch field is `current_branch`, not `git.branch`.
+**Example:** `{manifest.current_branch}` (correct) vs `{manifest.git.branch}` (wrong — this key is undefined).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.25] - 2026-04-27
+
+### Fixed
+- review-sdlc now displays the full comment body to the user before the posting prompt, ensuring all per-dimension findings and severity levels are visible before confirming (#176)
+
 ## [0.17.24] - 2026-04-23
 
 ### Fixed

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -184,11 +184,13 @@ These suggestions are informational during a review run. To act on them, run `/s
 
 ## PR Posting Flow
 
-After the orchestrator finishes, the skill (not the orchestrator) handles posting in the main context. What you see depends on whether a PR exists for the current branch and the review scope.
+After the orchestrator returns, the full consolidated review (all per-dimension findings, every severity, with `file:line` references and per-dimension `<details>` sections) is printed to the terminal verbatim — read directly from `${diff_dir}/review-comment.md`. The posting prompt then appears below it; replying `cancel` no longer hides any content from view because the body was already shown.
+
+What you see next depends on whether a PR exists for the current branch and the review scope.
 
 ### When a PR exists
 
-The skill prints the full consolidated comment, then prompts:
+After printing the full comment body above, the skill prompts:
 
 ```text
 Post this review comment to PR #{number}? (yes / save / cancel)
@@ -223,7 +225,7 @@ Reviewing local changes — no PR to post to. Options:
 
 ### Comment persistence
 
-During the run, the consolidated comment body is written to `${diff_dir}/review-comment.md` (a temporary location under `$TMPDIR`). The skill reads this path from the orchestrator summary and uses it for `gh api -F body=@…` or `save` copies. The file is discarded along with the diff dir after the terminal branch — including when you reply `cancel` or the command fails.
+During the run, the consolidated comment body is written to `${diff_dir}/review-comment.md` (a temporary location under `$TMPDIR`). The skill reads this path from the orchestrator summary and (a) emits the file's contents verbatim in the terminal before the posting prompt, and (b) uses the same file as the body source for `gh api -F body=@…` or `save` copies. The file is discarded along with the diff dir after the terminal branch — including when you reply `cancel` or the command fails — but its contents remain visible in scrollback.
 
 ---
 

--- a/docs/specs/review-sdlc.md
+++ b/docs/specs/review-sdlc.md
@@ -31,6 +31,7 @@
 - R10: Post-confirmation (`yes` / `save` / `cancel`) is issued by the skill in the main context, not by the orchestrator
 - R11: Orchestrator writes the consolidated comment body to `${manifest.diff_dir}/review-comment.md` and returns its absolute path plus `pr.*` metadata in its summary; the skill acts on the summary without reading the manifest
 - R12: When the user confirms `yes`, the skill posts via `gh api … -F body=@<path>` — no further Agent dispatch is made to complete posting
+- R13: After the orchestrator returns, the skill MUST read `${diff_dir}/review-comment.md` and display its full contents verbatim in the main context before any posting prompt — the orchestrator summary alone is insufficient because it contains only severity counts, not per-finding detail
 
 ## Workflow Phases
 
@@ -39,7 +40,7 @@
    - **Params:** A1-A7 forwarded (`--base <branch>`, `--committed`, `--staged`, `--working`, `--worktree`, `--set-default`, `--dimensions <list>`)
    - **Output:** manifest file path → P1-P8 (base branch, changed files, dimension counts/entries, plan critique); also writes per-dimension `.diff` files to tmpdir. Skill must NOT read manifest into main context
 2. DO — dispatch review-orchestrator agent (or display dry-run plan)
-3. REPORT — display orchestrator summary
+3. REPORT — display orchestrator summary and full consolidated comment body
 4. POST — skill handles PR posting decision in main context (`yes` / `save` / `cancel` or no-PR options), then cleans up manifest and diff dir
 5. OFFER — conditionally offer self-fix based on review verdict
 
@@ -49,6 +50,7 @@
 - G2: Orchestrator dispatched — agent is spawned (not via Skill tool) with manifest path and project root
 - G3: Manifest file and `diff_dir` cleaned up by the skill after the terminal branch (including failures)
 - G4: Exactly one `review-orchestrator` Agent dispatch per `/review-sdlc` invocation (a retry on failure counts as the same attempt; user confirmation never triggers a new dispatch)
+- G5: Full comment body displayed — Step 3 emits the verbatim contents of `${diff_dir}/review-comment.md` in the main context before the posting prompt is shown
 
 ## Prepare Script Contract
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.24",
+  "version": "0.17.25",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/SKILL.md
@@ -95,18 +95,41 @@ a new orchestrator dispatch.
 
 ---
 
-## Step 3 — Parse Orchestrator Summary
+## Step 3 — Parse Orchestrator Summary and Display Full Comment Body
 
-Display the orchestrator's summary to the user verbatim.
+This step implements R13 and quality gate G5: the user MUST see the full
+consolidated review (every per-dimension finding, every severity) in the terminal
+before any posting prompt. The orchestrator summary alone contains only severity
+counts and is insufficient.
 
-Parse the summary to extract:
+1. Display the orchestrator's summary to the user verbatim.
 
-- `comment_file` — absolute path to `${diff_dir}/review-comment.md`
-- `pr.exists` (boolean), `pr.owner`, `pr.repo`, `pr.number`
-- `verdict` — one of `CHANGES REQUESTED`, `APPROVED WITH NOTES`, `APPROVED`
-- `scope` — scope label from the summary
-- `branch` — current branch name
-- `diff_dir` — absolute path to the orchestrator's working diff dir
+2. Parse the summary to extract:
+
+   - `comment_file` — absolute path to `${diff_dir}/review-comment.md`
+   - `pr.exists` (boolean), `pr.owner`, `pr.repo`, `pr.number`
+   - `verdict` — one of `CHANGES REQUESTED`, `APPROVED WITH NOTES`, `APPROVED`
+   - `scope` — scope label from the summary
+   - `branch` — current branch name
+   - `diff_dir` — absolute path to the orchestrator's working diff dir
+
+3. **Display full comment body (implements R13).** Use the Read tool to load the
+   file at `comment_file`, then emit its full contents verbatim to the user inside
+   a fenced markdown block. No summarization, no truncation, no per-severity
+   collapsed table, no "Additional finding (see PR comment for details)"
+   placeholders. The full body must be visible in the terminal before Step 4's
+   posting prompt is shown.
+
+   ### DO NOT (Step 3 display)
+
+   - Do NOT summarize or paraphrase findings — emit the file contents byte-for-byte
+   - Do NOT collapse any finding to a placeholder like
+     "Additional finding (see PR comment for details)"
+   - Do NOT synthesize a severity/count table in place of the persisted body —
+     the orchestrator summary already provides counts; Step 3 must emit the
+     per-finding detail
+   - Do NOT skip the Read step even if the orchestrator summary appears
+     "complete" — the summary is metadata only
 
 Do NOT delete the manifest file here — cleanup happens in Step 6 on every terminal branch.
 

--- a/tests/promptfoo/datasets/review-sdlc.yaml
+++ b/tests/promptfoo/datasets/review-sdlc.yaml
@@ -308,6 +308,61 @@
         both the manifest file and the diff dir (`/tmp/review-diff-ghi789`) are cleaned up.
         It does not re-dispatch the orchestrator.
 
+- description: "review-sdlc: step-3-full-body-display — emits review-comment.md verbatim before posting prompt (issue #176)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"
+    project_context: "file://fixtures/review-step-3-full-body-display.md"
+    user_request: >
+      The review-orchestrator has returned the summary in the project context and the
+      consolidated comment body has been persisted to /tmp/review-diff-issue176/review-comment.md.
+      Resume the skill at Step 3 — display the orchestrator summary, then read and emit
+      the full contents of comment_file verbatim, then show the Step 4 posting prompt.
+  assert:
+    # All four findings (every severity) must appear verbatim — file:line references
+    - type: icontains
+      value: "src/auth/login.ts:42"
+    - type: icontains
+      value: "src/auth/session.ts:88"
+    - type: icontains
+      value: "src/search/query.ts:120"
+    - type: icontains
+      value: "src/api/search.ts:15"
+    # Each finding's message text must appear (not collapsed to a placeholder)
+    - type: icontains
+      value: "Plaintext password comparison"
+    - type: icontains
+      value: "Session token has no expiry"
+    - type: icontains
+      value: "Unbounded recursion in nested filter parser"
+    - type: icontains
+      value: "Inconsistent response envelope"
+    # The truncation placeholder must NOT appear in any form
+    - type: not-regex
+      value: "(Additional finding \\(see PR comment for details\\)|see PR comment for details|see comment for details)"
+    # The model must NOT replace the body with a synthesized severity/count table
+    # standing in for findings — i.e., must not output a table whose only data rows
+    # are bare severity labels with no file:line. The presence of file:line above
+    # is the positive evidence; here we forbid an obvious collapsed-table phrasing.
+    - type: not-regex
+      value: "(\\| critical \\| 1 \\|\\s*\\n\\s*\\| high \\| 1 \\|\\s*\\n\\s*\\| medium \\| 1 \\|\\s*\\n\\s*\\| low \\| 1 \\|\\s*$)"
+    # Posting prompt must appear, and must appear AFTER the findings (login.ts:42 is
+    # the first finding in the body) — regex enforces ordering
+    - type: regex
+      value: "(?s)src/auth/login\\.ts:42.*?yes\\s*/\\s*save\\s*/\\s*cancel"
+    # Behavioral rubric
+    - type: llm-rubric
+      value: >
+        The response performs Step 3 of /review-sdlc. It first displays the orchestrator's
+        structured summary verbatim. It then emits the full contents of
+        /tmp/review-diff-issue176/review-comment.md verbatim — every one of the 4 findings
+        appears with its file:line reference and full message text (CRITICAL plaintext
+        password, HIGH session expiry, MEDIUM unbounded recursion, LOW response envelope).
+        It does NOT summarize, paraphrase, or collapse any finding to a placeholder like
+        "Additional finding (see PR comment for details)". It does NOT replace the body
+        with a synthesized severity/count table. The Step 4 posting prompt
+        (yes / save / cancel) appears AFTER the full comment body, not before. R13 and
+        G5 are satisfied.
+
 - description: "review-sdlc: approved verdict completes cleanly without fix offer"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/review-sdlc/SKILL.md"

--- a/tests/promptfoo/fixtures/review-sdlc/issue-176-multi-finding-comment.md
+++ b/tests/promptfoo/fixtures/review-sdlc/issue-176-multi-finding-comment.md
@@ -1,0 +1,60 @@
+# Code Review — feat/search-api
+
+**Verdict:** CHANGES REQUESTED
+**Scope:** Committed branch changes only
+**Base branch:** main
+**Findings:** 4 (1 critical, 1 high, 1 medium, 1 low)
+
+## Summary
+
+| Dimension | Severity | Findings |
+|---|---|---|
+| security-review | critical | 1 |
+| security-review | high | 1 |
+| code-quality-review | medium | 1 |
+| api-review | low | 1 |
+
+---
+
+<details>
+<summary>security-review (2 findings)</summary>
+
+### CRITICAL — `src/auth/login.ts:42` — Plaintext password comparison
+
+The login handler compares `req.body.password` against the stored hash using `===` instead of a constant-time bcrypt comparison. This leaks timing information and accepts the raw hash if an attacker can read it from the database.
+
+**Fix:** Replace `user.passwordHash === req.body.password` with `await bcrypt.compare(req.body.password, user.passwordHash)`.
+
+### HIGH — `src/auth/session.ts:88` — Session token has no expiry
+
+`createSession()` issues a JWT without an `exp` claim, so tokens are valid forever once issued. Combined with no revocation list, a leaked token is permanent.
+
+**Fix:** Add `expiresIn: '24h'` to the `jwt.sign()` options and document refresh-token rotation.
+
+</details>
+
+<details>
+<summary>code-quality-review (1 finding)</summary>
+
+### MEDIUM — `src/search/query.ts:120` — Unbounded recursion in nested filter parser
+
+`parseFilter()` recurses into `filter.children` without a depth limit. A pathological 10-deep nested query crashes the worker with stack overflow.
+
+**Fix:** Add a `MAX_FILTER_DEPTH = 8` guard and reject deeper queries with a 400 response.
+
+</details>
+
+<details>
+<summary>api-review (1 finding)</summary>
+
+### LOW — `src/api/search.ts:15` — Inconsistent response envelope
+
+`/api/search` returns `{ results: [] }` while every other endpoint returns `{ data: [] }`. This breaks the SDK's response normalizer.
+
+**Fix:** Rename `results` to `data` or add the field as an alias for one release before removing.
+
+</details>
+
+---
+
+_Posted by `/review-sdlc` — 4 findings across 3 dimensions._

--- a/tests/promptfoo/fixtures/review-step-3-full-body-display.md
+++ b/tests/promptfoo/fixtures/review-step-3-full-body-display.md
@@ -1,0 +1,110 @@
+# Review-sdlc — Step 3 full-body display context (issue #176)
+
+The `review-orchestrator` agent has already completed. It persisted the consolidated
+comment body to the path shown below and returned the structured summary that follows.
+You are the skill's main context resuming at **Step 3 — Parse Orchestrator Summary
+and Display Full Comment Body**.
+
+## Orchestrator summary (returned to skill)
+
+```text
+Review complete
+  Dimensions run:  3 (0 skipped)
+  Total findings:  4
+    critical: 1 | high: 1 | medium: 1 | low: 1 | info: 0
+  Verdict:         CHANGES REQUESTED
+  Scope:           Committed branch changes only
+  Branch:          feat/search-api
+  Comment file:    /tmp/review-diff-issue176/review-comment.md
+  PR exists:       true
+  PR owner:        acme-corp
+  PR repo:         widgets
+  PR number:       57
+  Diff dir:        /tmp/review-diff-issue176
+```
+
+## File state
+
+`/tmp/review-diff-issue176/review-comment.md` exists. Its full contents are reproduced
+verbatim below — this is what the Read tool would return when the skill loads
+`comment_file`. Per **R13 / G5** the skill must emit these contents verbatim in the
+main context before any posting prompt.
+
+## Contents of `/tmp/review-diff-issue176/review-comment.md`
+
+```markdown
+# Code Review — feat/search-api
+
+**Verdict:** CHANGES REQUESTED
+**Scope:** Committed branch changes only
+**Base branch:** main
+**Findings:** 4 (1 critical, 1 high, 1 medium, 1 low)
+
+## Summary
+
+| Dimension | Severity | Findings |
+|---|---|---|
+| security-review | critical | 1 |
+| security-review | high | 1 |
+| code-quality-review | medium | 1 |
+| api-review | low | 1 |
+
+---
+
+<details>
+<summary>security-review (2 findings)</summary>
+
+### CRITICAL — `src/auth/login.ts:42` — Plaintext password comparison
+
+The login handler compares `req.body.password` against the stored hash using `===` instead of a constant-time bcrypt comparison. This leaks timing information and accepts the raw hash if an attacker can read it from the database.
+
+**Fix:** Replace `user.passwordHash === req.body.password` with `await bcrypt.compare(req.body.password, user.passwordHash)`.
+
+### HIGH — `src/auth/session.ts:88` — Session token has no expiry
+
+`createSession()` issues a JWT without an `exp` claim, so tokens are valid forever once issued. Combined with no revocation list, a leaked token is permanent.
+
+**Fix:** Add `expiresIn: '24h'` to the `jwt.sign()` options and document refresh-token rotation.
+
+</details>
+
+<details>
+<summary>code-quality-review (1 finding)</summary>
+
+### MEDIUM — `src/search/query.ts:120` — Unbounded recursion in nested filter parser
+
+`parseFilter()` recurses into `filter.children` without a depth limit. A pathological 10-deep nested query crashes the worker with stack overflow.
+
+**Fix:** Add a `MAX_FILTER_DEPTH = 8` guard and reject deeper queries with a 400 response.
+
+</details>
+
+<details>
+<summary>api-review (1 finding)</summary>
+
+### LOW — `src/api/search.ts:15` — Inconsistent response envelope
+
+`/api/search` returns `{ results: [] }` while every other endpoint returns `{ data: [] }`. This breaks the SDK's response normalizer.
+
+**Fix:** Rename `results` to `data` or add the field as an alias for one release before removing.
+
+</details>
+
+---
+
+_Posted by `/review-sdlc` — 4 findings across 3 dimensions._
+```
+
+## What the skill must do next
+
+Per Step 3 (R13, G5):
+
+1. Display the orchestrator's structured summary above verbatim.
+2. Parse summary fields (`comment_file`, `pr.*`, `verdict`, `scope`, `branch`, `diff_dir`).
+3. **Read `comment_file` and emit its full contents verbatim** in a fenced block — every
+   finding (critical, high, medium, low) must appear with its `file:line` reference and
+   message text. Do NOT collapse non-critical findings to placeholders like
+   "Additional finding (see PR comment for details)". Do NOT synthesize a severity/count
+   table in place of the body.
+4. Only after the full body is shown, present the Step 4 posting prompt
+   (`yes / save / cancel`).


### PR DESCRIPTION
## Summary
Fixes a gap in `review-sdlc` where the full consolidated review comment was never displayed to the user before the posting prompt. Step 3 now reads `review-comment.md` verbatim and emits all per-dimension findings to the terminal before asking `yes / save / cancel`.

## Business Context
Users of `/review-sdlc` had no way to read the full review findings before committing to post the comment to GitHub. The orchestrator summary returned only severity counts; the detailed per-finding content (file:line references, descriptions, fix suggestions) was visible only after posting or saving — too late to review before confirming. This left users posting blind.

## Business Benefits
- Users can read every finding (CRITICAL through LOW) with full file:line references and fix guidance before deciding to post
- The `cancel` path no longer hides content — the body is already visible in scrollback when the prompt appears
- Removes the risk of posting an unreviewed comment to a PR

## Github Issue
Fixes #176

## Technical Design
Step 3 of `SKILL.md` was rewritten to explicitly use the Read tool on the `comment_file` path extracted from the orchestrator summary, then emit the file contents verbatim in a fenced block. Two new spec artifacts were added: requirement R13 (mandatory Read + emit before posting prompt) and quality gate G5 (full body must be displayed). The skill explicitly forbids summarization, collapsing findings to placeholders, or substituting a synthesized count table.

## Technical Impact
None. The change is internal to `review-sdlc`'s Step 3 display logic. No skill interfaces, hook payloads, script APIs, or plugin manifest fields changed.

## Changes Overview
- `review-sdlc` Step 3 rewritten to load and emit `review-comment.md` verbatim before any posting prompt — no summarization, no truncation, no placeholder collapsing
- Spec updated with R13 (mandatory full-body display) and G5 (quality gate enforcing it)
- User-facing doc updated to describe the new terminal output behavior and clarify that `cancel` no longer hides content
- Behavioral test case added covering all four severity levels, asserting verbatim content and absence of collapse placeholders
- Test fixture added with a realistic multi-finding review comment (CRITICAL/HIGH/MEDIUM/LOW across three dimensions)

## Testing
Manual: skill was invoked against a branch with findings; Step 3 now emits the complete comment body before the posting prompt appears. Behavioral test added to `review-sdlc.yaml` with nine assertions — four positive (file:line references), two negative (no collapse placeholders, no synthesized count tables), one ordering regex (findings before posting prompt), and one LLM rubric verifying R13/G5 compliance.