### PR TITLE
feat(#178): jira-sdlc - write-op guardrails with hook enforcement

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -110,3 +110,7 @@ Branch fix/pipeline-contract-enforcement-and-model-assignment had no upstream. F
 **Trigger:** Review of fix/#167 found orchestrator Step 6 summary template used `{manifest.git.branch}` — this field doesn't exist. The manifest schema has `current_branch` at the top level and `git.{commit_count, commit_log, changed_files}` in a sub-object.
 **Rule:** When adding new fields to an orchestrator summary template, verify field paths against the manifest construction in `scripts/skill/review.js` (lines 535-560). The top-level branch field is `current_branch`, not `git.branch`.
 **Example:** `{manifest.current_branch}` (correct) vs `{manifest.git.branch}` (wrong — this key is undefined).
+
+## 2026-04-27 — version-sdlc: branch with no upstream requires --set-upstream on first push
+**Trigger:** v0.17.25 release on `fix/issue-176-review-sdlc-full-display` — `git push` failed with "no upstream branch". The remoteState in the version context correctly showed `hasUpstream: false`, which was noted as a warning but not acted on pre-push.
+**Rule:** When `remoteState.hasUpstream === false`, use `git push --set-upstream origin <branchName>` for the commit push, then `git push --tags` separately. Don't attempt bare `git push` — it will fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.26] - 2026-04-28
+
+### Added
+- jira-sdlc write-operation guardrails: artifact-based approval gates, placeholder detection, and PreToolUse hook enforcement for all write operations (Create, Edit, Transition, Comment, Link, Worklog) (#178)
+
 ## [0.17.25] - 2026-04-27
 
 ### Fixed

--- a/docs/skills/jira-sdlc.md
+++ b/docs/skills/jira-sdlc.md
@@ -221,12 +221,52 @@ The resulting cache stores `workflows: { "<Type>": { "unsampled": true } }` for 
 
 ---
 
+## Write Operation Safeguards
+
+Every write operation (`create`, `edit`, `transition`, `comment`, `link`, `assign`, `worklog`, `bulk`) passes through a two-step gate before any MCP call is dispatched. Read operations (`search`, `view`) skip this gate entirely.
+
+### Critique pass (R20)
+
+Before presenting a proposal, the skill runs an internal critique against the assembled payload:
+
+- **Template completeness** — every `## ` heading in `description` must come from the resolved template; no invented sections.
+- **Placeholder resolution** — `[bracketed prose]` and `{name}` markers flagged as `low`-confidence must be resolved via `AskUserQuestion` before the payload is shown (R19). High-confidence auto-fills are surfaced as findings but do not block.
+- **Field validity** — required fields for the selected transition are present; field values are within cache-validated enumerations.
+
+The findings are surfaced as a three-line block before the approval prompt:
+
+```
+Initial: <one-line summary of the initial draft>
+Critique: <findings, or "none">
+Final: <one-line summary of the revised payload>
+```
+
+The critique artifact is written to `$TMPDIR/jira-sdlc/critique-<hash>.json`.
+
+### Approval gate (R17)
+
+After the critique block, the full final payload (the exact bytes the MCP call will dispatch) is printed. The user must respond with one of:
+
+- **approve** — proceed to dispatch
+- **change `<what>`** — describe the desired change; the skill loops back through the critique pass with a revised draft and new artifacts
+- **cancel** — abort without dispatching
+
+On `approve`, an approval token is written to `$TMPDIR/jira-sdlc/approval-<hash>.token`. No write MCP call is dispatched without this token.
+
+### Hook enforcement (R21)
+
+A `PreToolUse` hook (`hooks/pre-tool-jira-write-guard.js`) re-derives the payload hash from the tool input at dispatch time, verifies both artifacts exist and are under 10 minutes old, and **blocks dispatch** if either check fails. If dispatch is blocked, the hook's `permissionDecisionReason` is surfaced verbatim — the skill does not retry by guessing what changed.
+
+---
+
 ## What It Creates or Modifies
 
 | File / Artifact | Description |
 |-----------------|-------------|
 | `~/.sdlc-cache/jira/<site>/<KEY>.json` | Project metadata cache (home-keyed, outside the working tree): cloudId, issue types, field schemas, workflows, user mappings |
 | `.claude/jira-templates/<Type>.md` | Project-level issue description templates (created only when `--init-templates` is run, or manually) |
+| `$TMPDIR/jira-sdlc/critique-<hash>.json` | Per-operation critique artifact (write-ops only); contains initial/findings/final summary; verified by the PreToolUse hook |
+| `$TMPDIR/jira-sdlc/approval-<hash>.token` | Per-operation approval token (write-ops only); created on `approve`; verified and deleted by the PreToolUse hook after dispatch |
 | Jira issues | Created or updated via the Atlassian MCP |
 
 ## Related Skills

--- a/docs/specs/jira-sdlc.md
+++ b/docs/specs/jira-sdlc.md
@@ -32,6 +32,15 @@
 - R14: `--skip-workflow-discovery` bypasses Phase 5 entirely. The cache is written with `workflows: { <type>: { unsampled: true } }` for each non-subtask issue type. Transition operations that encounter an `unsampled` marker fall back to a live `getTransitionsForJiraIssue` call per issue (reusing the existing stale-cache auto-refresh path from R9/E10). Cache rows for subtask types and other sections are populated normally.
 - R15: When `--check` resolves against the home-cache layout without `--site`, it scans `~/.sdlc-cache/jira/*/<KEY>.json` for all candidates. Zero matches → `{ exists: false }` (treat as fresh install). Exactly one match → use it. Two or more matches → `{ exists: false, candidateSites: [<host>, …] }`; the user must re-run with `--site <host>` to disambiguate or `--force-refresh` to rebuild against a specific site.
 - R16: SKILL.md frontmatter `description` must include auto-trigger phrases covering the full operation surface: read/view, comment add, create, edit, search, transition, link, assign, worklog, bulk. Required trigger tokens: `read jira`, `view jira`, `show jira`, `get jira`, `fetch jira`, `jira details`, `add comment`, `comment on jira`, `reply to jira`, `jira ticket`, `jira issue`. Purpose: allow the downstream model to activate the skill automatically on common read-and-comment phrasings without an explicit `/jira-sdlc` invocation. Total frontmatter `description` length must stay within 1024 characters.
+- R17 (approval gate): Before `createJiraIssue`, `editJiraIssue`, `transitionJiraIssue`, `addCommentToJiraIssue`, `addWorklogToJiraIssue`, `createIssueLink`, the skill MUST print the full final payload and call `AskUserQuestion` with `approve` / `change <what>` / `cancel`. Loop on `change`. The MCP write tool is dispatched only after `approve`. Read operations (`searchJiraIssuesUsingJql`, `getJiraIssue`, `getTransitionsForJiraIssue`, etc.) are exempt.
+- R18 (template enforcement): Every `createJiraIssue` and every `editJiraIssue` whose payload touches `description` MUST resolve a description template via `.claude/jira-templates/<IssueType>.md` (override) then `plugins/sdlc-utilities/skills/jira-sdlc/templates/<IssueType>.md` (shipped). If no template clearly matches the requested issue type, the skill MUST call `AskUserQuestion` with a closed list of available templates. Free-form descriptions are prohibited. Sections may be removed when not applicable, but new sections MUST NOT be invented.
+- R19 (no-assume placeholder policy): The skill MUST detect placeholder markers in proposed payloads using the C13 regex (both `{name}` and `[bracketed prose]` forms; ADF documents are traversed recursively over `text` nodes). Each detected marker MUST be classified as `high` confidence (explicit user input or definitive cache value) or `low` confidence (inferred or paraphrased). Every `low`-confidence marker MUST be resolved via `AskUserQuestion` before payload finalization. Inapplicable sections require explicit user consent before removal — silent drops are prohibited.
+- R20 (self-critique, surfaced): Before the R17 approval presentation, the skill MUST run a critique pass against (a) template completeness, (b) field correctness (issue type, project key, parent, components, labels), (c) workflow validity (transition target reachable per cached workflow graph), and (d) terminology consistency between summary and description. The skill MUST surface findings to the user as an `Initial:` / `Critique:` / `Final:` block. Critique deltas MUST NOT be applied silently.
+- R21 (script-enforcement layer): R17–R20 MUST be enforced by a PreToolUse hook, not LLM compliance alone. Specifically:
+  - The skill canonicalizes the proposed payload (stable JSON key sort) and computes `payload_hash = sha256(canonical_json)` using shared `lib/payload-hash.js`.
+  - The skill writes `$TMPDIR/jira-sdlc/critique-<payload_hash>.json` before the R20 presentation; structural shape `{initial: string, findings: string[], final: string}`.
+  - The skill writes `$TMPDIR/jira-sdlc/approval-<payload_hash>.token` only after `AskUserQuestion` returns `approve`.
+  - The PreToolUse hook (`hooks/pre-tool-jira-write-guard.js`) re-derives `payload_hash` from `tool_input` and BLOCKS dispatch unless: (a) the C13 regex finds zero unfilled placeholders in payload string fields and ADF text nodes; (b) for `createJiraIssue` / `editJiraIssue` with description: payload `## ` headings are a subset of the resolved template's heading set; (c) `approval-<hash>.token` exists and its mtime is < 10 minutes old; (d) `critique-<hash>.json` exists with valid shape. On success the hook consumes (deletes) both artifact files. Both Atlassian MCP namespaces (`mcp__atlassian__*` and `mcp__claude_ai_Atlassian__*`) MUST be matched by the hook.
 
 ## Assumptions
 
@@ -65,6 +74,11 @@
 - G6: Transition safety — transition `id` from cache or fresh API call, never guessed
 - G7: User disambiguation — `lookupJiraAccountId` results always disambiguated if multiple matches
 - G8: No fabricated values — all field values derived from cache `allowedValues` or user input
+- G9: No write MCP call without an `approve` answer to the R17 approval gate in the same skill turn
+- G10: No `description` field built without a resolved template (R18) — override `.claude/jira-templates/<Type>.md` or shipped `templates/<Type>.md`
+- G11: No `low`-confidence placeholder dispatched without R19 user resolution via `AskUserQuestion`
+- G12: No payload presented to the user without a preceding R20 critique block (`Initial:` / `Critique:` / `Final:`)
+- G13: No write MCP call dispatched without the PreToolUse hook successfully verifying R21 artifacts (approval token + critique JSON, payload-hash bound, < 10 min old). Hook absence or matcher gap is a build failure (caught by `validate-plugin-consistency`).
 
 ## Prepare Script Contract
 
@@ -101,6 +115,7 @@
 - C10: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
 - C11: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data
 - C12: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
+- C13: Placeholder regex — `\{[a-zA-Z_][a-zA-Z0-9_-]*\}|\[[^\]\n]{3,}\]`. Both `{name}` and `[bracketed prose ≥ 3 chars]` forms are treated equally as placeholder markers. ADF `text` nodes are traversed recursively; the regex applies to every string-valued field of the payload.
 
 ## Step-Emitter Contract
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.25",
+  "version": "0.17.26",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/hooks.json
+++ b/plugins/sdlc-utilities/hooks/hooks.json
@@ -69,6 +69,16 @@
             "timeout": 1000
           }
         ]
+      },
+      {
+        "matcher": "^mcp__(atlassian|claude_ai_Atlassian)__(createJiraIssue|editJiraIssue|transitionJiraIssue|addCommentToJiraIssue|addWorklogToJiraIssue|createIssueLink)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-jira-write-guard.js\"",
+            "timeout": 3000
+          }
+        ]
       }
     ]
   }

--- a/plugins/sdlc-utilities/hooks/pre-tool-jira-write-guard.js
+++ b/plugins/sdlc-utilities/hooks/pre-tool-jira-write-guard.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * PreToolUse hook: Jira write-op guardrail (R21).
+ *
+ * Reads a JSON envelope from stdin (Claude Code hook protocol):
+ *   { tool_name, tool_input, ... }
+ *
+ * For Jira write tools (both `mcp__atlassian__*` and `mcp__claude_ai_Atlassian__*`
+ * namespaces), it independently verifies:
+ *   (a) C13 placeholder regex finds zero markers in payload string fields,
+ *   (b) for createJiraIssue / editJiraIssue with `description`: payload `## `
+ *       headings are a subset of the resolved template's heading set,
+ *   (c) approval token + critique artifact exist for sha256(canonical(payload))
+ *       and are < 10 min old,
+ *   (d) critique artifact has the expected {initial, findings[], final} shape.
+ *
+ * On success the hook consumes (deletes) both artifacts and returns
+ * `{"continue": true}`. On any block, it emits a structured permissionDecision.
+ * On unknown tools or unexpected exceptions it returns `{"continue": true}`
+ * (defense-in-depth: the LLM-side checks are the second line of defense).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Dependency resolution: the hook lives in plugins/.../hooks/, the helpers
+// live in plugins/.../skills/jira-sdlc/lib/. We always look up relative to
+// __dirname so test harnesses can copy or symlink the plugin tree elsewhere.
+const LIB_ROOT = path.resolve(__dirname, '..', 'skills', 'jira-sdlc', 'lib');
+const { payloadHash } = require(path.join(LIB_ROOT, 'payload-hash.js'));
+const { findPlaceholders } = require(path.join(LIB_ROOT, 'placeholder-detect.js'));
+const { loadTemplateHeadings } = require(path.join(LIB_ROOT, 'template-fingerprint.js'));
+const {
+  verifyArtifacts,
+  consumeArtifacts,
+  purgeStale,
+} = require(path.join(LIB_ROOT, 'artifact-store.js'));
+
+const WRITE_TOOLS = new Set([
+  'createJiraIssue',
+  'editJiraIssue',
+  'transitionJiraIssue',
+  'addCommentToJiraIssue',
+  'addWorklogToJiraIssue',
+  'createIssueLink',
+]);
+const NAMESPACE_PREFIXES = ['mcp__atlassian__', 'mcp__claude_ai_Atlassian__'];
+
+const HEADING_RE = /^##\s+(.+?)\s*$/gm;
+
+function isJiraWriteTool(toolName) {
+  if (typeof toolName !== 'string') return false;
+  for (const prefix of NAMESPACE_PREFIXES) {
+    if (toolName.startsWith(prefix)) {
+      const op = toolName.slice(prefix.length);
+      if (WRITE_TOOLS.has(op)) return op;
+    }
+  }
+  return null;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { buf += chunk; });
+    process.stdin.on('end', () => resolve(buf));
+    process.stdin.on('error', reject);
+  });
+}
+
+function emitContinue() {
+  process.stdout.write(JSON.stringify({ continue: true }));
+}
+
+function emitDeny(reason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  }));
+}
+
+/**
+ * Extract the description string from a tool_input payload, or null.
+ * Atlassian MCP accepts description either as a markdown string or as ADF.
+ * For template fingerprinting we only inspect markdown payloads — ADF
+ * descriptions are exempt (no `## ` headings to compare).
+ */
+function extractDescriptionMarkdown(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  // createJiraIssue / editJiraIssue: top-level description (markdown)
+  if (typeof toolInput.description === 'string') return toolInput.description;
+  // Some shapes wrap in fields.description
+  if (toolInput.fields && typeof toolInput.fields.description === 'string') {
+    return toolInput.fields.description;
+  }
+  return null;
+}
+
+function extractIssueType(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  if (typeof toolInput.issueTypeName === 'string') return toolInput.issueTypeName;
+  if (toolInput.issueType && typeof toolInput.issueType.name === 'string') {
+    return toolInput.issueType.name;
+  }
+  if (toolInput.fields && toolInput.fields.issuetype && typeof toolInput.fields.issuetype.name === 'string') {
+    return toolInput.fields.issuetype.name;
+  }
+  return null;
+}
+
+function extractPayloadHeadings(markdown) {
+  const set = new Set();
+  if (!markdown) return set;
+  HEADING_RE.lastIndex = 0;
+  let m;
+  while ((m = HEADING_RE.exec(markdown)) !== null) {
+    set.add(m[1].trim());
+  }
+  return set;
+}
+
+function isSubset(payloadSet, templateSet) {
+  for (const h of payloadSet) {
+    if (!templateSet.has(h)) return { ok: false, missing: h };
+  }
+  return { ok: true };
+}
+
+function projectRoot() {
+  // Hooks run with cwd at the user's repo root in normal use. Allow override
+  // via env for tests.
+  return process.env.JIRA_GUARD_PROJECT_ROOT || process.cwd();
+}
+
+async function main() {
+  let stdin;
+  try {
+    stdin = await readStdin();
+  } catch (e) {
+    process.stderr.write(`pre-tool-jira-write-guard: stdin read error: ${e.message}\n`);
+    return emitContinue();
+  }
+
+  let envelope;
+  try {
+    envelope = JSON.parse(stdin || '{}');
+  } catch (e) {
+    process.stderr.write('pre-tool-jira-write-guard: malformed envelope JSON; allowing through\n');
+    return emitContinue();
+  }
+
+  const toolName = envelope && envelope.tool_name;
+  const op = isJiraWriteTool(toolName);
+  if (!op) {
+    return emitContinue();
+  }
+
+  const toolInput = envelope.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') {
+    process.stderr.write('pre-tool-jira-write-guard: missing tool_input; allowing (defense-in-depth)\n');
+    return emitContinue();
+  }
+
+  // (a) C13 placeholder check
+  let markers;
+  try {
+    markers = findPlaceholders(toolInput);
+  } catch (e) {
+    process.stderr.write(`pre-tool-jira-write-guard: placeholder scan error: ${e.message}\n`);
+    return emitContinue();
+  }
+  if (markers.length > 0) {
+    const sample = markers.slice(0, 3).map((m) => `${m.path}:${m.marker}`).join(', ');
+    return emitDeny(`R19/C13: unfilled placeholder marker(s) in payload — ${sample}`);
+  }
+
+  // (b) R18 template fingerprint (createJiraIssue / editJiraIssue with description only)
+  if (op === 'createJiraIssue' || op === 'editJiraIssue') {
+    const description = extractDescriptionMarkdown(toolInput);
+    if (description !== null && description !== '') {
+      const issueType = extractIssueType(toolInput);
+      if (!issueType) {
+        return emitDeny('R18: cannot enforce template — issue type missing from payload');
+      }
+      const tpl = loadTemplateHeadings(issueType, projectRoot());
+      if (!tpl.source) {
+        return emitDeny(`R18: no template found for issue type "${issueType}" (override or shipped)`);
+      }
+      const payloadHeadings = extractPayloadHeadings(description);
+      const subset = isSubset(payloadHeadings, tpl.headings);
+      if (!subset.ok) {
+        return emitDeny(`R18: template mismatch — heading "${subset.missing}" not in ${tpl.source} template for "${issueType}"`);
+      }
+    } else if (op === 'createJiraIssue') {
+      // Create requires a description-bearing template per R18.
+      return emitDeny('R18: createJiraIssue requires a templated description');
+    }
+  }
+
+  // (c)+(d) artifact verification
+  let hash;
+  try {
+    hash = payloadHash(toolInput);
+  } catch (e) {
+    process.stderr.write(`pre-tool-jira-write-guard: hash error: ${e.message}\n`);
+    return emitContinue();
+  }
+  const v = verifyArtifacts(hash);
+  if (!v.approval || !v.critique) {
+    return emitDeny(`R17/R20/R21: ${v.reason || 'artifact verification failed'} (hash=${hash.slice(0, 12)}…)`);
+  }
+
+  // Success — consume artifacts so they cannot be re-used for a different tool call.
+  try { consumeArtifacts(hash); } catch { /* best-effort */ }
+  // Best-effort housekeeping — runs only on the success path so a "stale" verdict
+  // is reported as such by verifyArtifacts before the file is swept.
+  try { purgeStale(); } catch { /* noop */ }
+  return emitContinue();
+}
+
+main().catch((e) => {
+  process.stderr.write(`pre-tool-jira-write-guard: uncaught error: ${e && e.stack || e}\n`);
+  emitContinue();
+});

--- a/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
@@ -330,7 +330,44 @@ For ambiguous requests, use AskUserQuestion to ask one clarifying question befor
 
 ---
 
+## Step 2.5 — Critique (write-ops only, R20)
+
+Skip this step for read operations (`search`, `view`). For every write operation (`create`, `edit`, `transition`, `comment`, `link`, `assign`, `worklog`, `bulk`), run a critique pass against the proposed payload **before** showing it to the user. Implements R20.
+
+1. Build the initial payload exactly as you would dispatch it (template-resolved per R18, placeholders resolved per R19, fields validated against cache per G5/G6/G8).
+2. Run the critique checklist:
+   - **Template completeness** (create / description-touching edit) — every `## ` heading in the payload description belongs to the resolved template; no invented sections.
+   - **Field correctness** — issue type / project key / parent / components / labels match cached `allowedValues`.
+   - **Workflow validity** — for `transition`, the target status is reachable per the cached workflow graph (R6).
+   - **Terminology consistency** — summary vocabulary matches description vocabulary (no contradictions).
+3. Compute `payload_hash` and write the critique artifact:
+   ```js
+   const { payloadHash } = require('./lib/payload-hash.js');
+   const { writeCritique } = require('./lib/artifact-store.js');
+   const hash = payloadHash(toolInput);
+   writeCritique(hash, { initial: '<one-line summary of initial draft>', findings: [...], final: '<one-line summary of final payload>' });
+   ```
+4. Surface the critique to the user as an `Initial:` / `Critique:` / `Final:` block — do not apply deltas silently.
+
+## Step 2.6 — Approval (write-ops only, R17)
+
+Skip for read operations. Implements R17 + the cooperative half of R21.
+
+1. Print the full final payload (not a summary — the bytes the MCP call will dispatch).
+2. Call `AskUserQuestion` with three options:
+   - **approve** — proceed to Step 3 dispatch
+   - **change <what>** — describe the desired change; loop back to Step 2.5 with the revised draft (new `payload_hash`, fresh artifacts; the previous artifacts are stale and will be auto-purged)
+   - **cancel** — abort the operation, do not dispatch
+3. On `approve` only, write the approval token:
+   ```js
+   const { writeApprovalToken } = require('./lib/artifact-store.js');
+   writeApprovalToken(hash);
+   ```
+4. Proceed to Step 3.
+
 ## Step 3 — Execute Operation
+
+For write operations: precondition — Step 2.6 returned `approve` and both artifacts (`approval-<hash>.token`, `critique-<hash>.json`) are on disk. The PreToolUse hook (`hooks/pre-tool-jira-write-guard.js`) re-derives the hash from `tool_input`, verifies both artifacts, and BLOCKS dispatch otherwise (R21). If dispatch is blocked, surface the hook's `permissionDecisionReason` to the user verbatim — do not retry by guessing what changed.
 
 After Step 2 classifies the operation type, read `./operations-reference.md` and follow the procedure for the matching operation type.
 
@@ -398,8 +435,21 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 | Transition safety | Transition `id` from cache or fresh `getTransitionsForJiraIssue`, never guessed |
 | User disambiguation | `lookupJiraAccountId` results always disambiguated if multiple matches |
 | No fabricated values | All field values derived from cache `allowedValues` or user input |
+| Approval gate (G9) | No write MCP call dispatched without an `approve` from the R17 prompt in this turn |
+| Template enforced (G10) | No `description` field built without a resolved template — `.claude/jira-templates/<Type>.md` (override) or shipped `templates/<Type>.md` (R18) |
+| Placeholders resolved (G11) | No `low`-confidence `{name}` or `[prose]` marker dispatched without explicit user resolution (R19) |
+| Critique surfaced (G12) | No proposal presented to the user without a preceding `Initial:` / `Critique:` / `Final:` block (R20) |
+| Hook verified (G13) | No write MCP call dispatched without the PreToolUse hook successfully verifying R21 artifacts (payload-hash bound, < 10 min old) |
 
 ---
+
+## DO
+
+- Present the full final payload before any write MCP call (R17)
+- Resolve a description template — override or shipped — before building `description` (R18)
+- Escalate every low-confidence placeholder marker via `AskUserQuestion` (R19)
+- Run a critique pass before the approval gate; surface findings to the user (R20)
+- Write critique + approval artifacts via `lib/artifact-store.js` and use `lib/payload-hash.js` for the canonical hash (R21)
 
 ## DO NOT
 
@@ -416,6 +466,11 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 - Leave raw `{placeholder}` syntax in issue descriptions
 - Ignore custom templates at `.claude/jira-templates/<Type>.md` when they exist
 - Generate unstructured descriptions when a template is available
+- Dispatch a write MCP without an `approve` answer to the R17 prompt in this turn (R17)
+- Use a free-form description on `createJiraIssue` or `editJiraIssue` (R18)
+- Fill `[bracketed prose]` or `{name}` placeholders from inference — every `low`-confidence marker requires explicit user resolution (R19)
+- Apply critique deltas silently — always surface the `Initial:` / `Critique:` / `Final:` block (R20)
+- Bypass `lib/artifact-store.js` with direct `fs.writeFile` calls — direct writes break the canonical hash contract the hook verifies (R21)
 
 ---
 

--- a/plugins/sdlc-utilities/skills/jira-sdlc/lib/artifact-store.js
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/lib/artifact-store.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * Filesystem-bound approval / critique artifact store for R21.
+ *
+ * The skill writes:
+ *   - $TMPDIR/jira-sdlc/critique-<hash>.json   (R20 critique block)
+ *   - $TMPDIR/jira-sdlc/approval-<hash>.token  (R17 approval grant)
+ *
+ * The PreToolUse hook re-derives <hash> from `tool_input` and verifies
+ * both files exist with matching mtime < TTL_MS, then consumes (deletes)
+ * them on success. Atomic writes (tmp+rename) so the hook never reads a
+ * partial file.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function storeDir() {
+  return path.join(os.tmpdir(), 'jira-sdlc');
+}
+
+function ensureDir() {
+  const dir = storeDir();
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function critiquePath(hash) {
+  return path.join(storeDir(), `critique-${hash}.json`);
+}
+
+function approvalPath(hash) {
+  return path.join(storeDir(), `approval-${hash}.token`);
+}
+
+function atomicWrite(targetPath, contents) {
+  const dir = path.dirname(targetPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.tmp-${crypto.randomBytes(6).toString('hex')}`);
+  fs.writeFileSync(tmp, contents, 'utf8');
+  fs.renameSync(tmp, targetPath);
+}
+
+/**
+ * Persist a critique artifact. Shape: {initial, findings: string[], final}.
+ * Throws on shape violations to fail loudly during skill development.
+ */
+function writeCritique(hash, payload) {
+  if (!hash || typeof hash !== 'string') throw new TypeError('writeCritique: hash required');
+  if (!payload || typeof payload !== 'object') throw new TypeError('writeCritique: payload object required');
+  if (typeof payload.initial !== 'string' || typeof payload.final !== 'string'
+    || !Array.isArray(payload.findings)) {
+    throw new TypeError('writeCritique: payload must be {initial, findings:[], final}');
+  }
+  ensureDir();
+  atomicWrite(critiquePath(hash), JSON.stringify(payload));
+}
+
+/**
+ * Persist an approval token. Body is the timestamp; mtime drives the TTL.
+ */
+function writeApprovalToken(hash) {
+  if (!hash || typeof hash !== 'string') throw new TypeError('writeApprovalToken: hash required');
+  ensureDir();
+  atomicWrite(approvalPath(hash), String(Date.now()));
+}
+
+/**
+ * Verify both artifacts exist, are readable, well-formed, and not stale.
+ *
+ * @returns {{ approval: boolean, critique: boolean, ageMs: number, reason: string|null }}
+ */
+function verifyArtifacts(hash) {
+  const out = { approval: false, critique: false, ageMs: Infinity, reason: null };
+  const aPath = approvalPath(hash);
+  const cPath = critiquePath(hash);
+
+  let aStat, cStat;
+  try { aStat = fs.statSync(aPath); } catch { /* missing */ }
+  try { cStat = fs.statSync(cPath); } catch { /* missing */ }
+
+  if (!aStat) {
+    out.reason = 'approval token missing';
+    return out;
+  }
+  if (!cStat) {
+    out.reason = 'critique artifact missing';
+    return out;
+  }
+
+  const now = Date.now();
+  const ageMs = Math.min(now - aStat.mtimeMs, now - cStat.mtimeMs);
+  out.ageMs = ageMs;
+  if (now - aStat.mtimeMs > TTL_MS) {
+    out.reason = 'approval token stale (> 10 min)';
+    return out;
+  }
+  if (now - cStat.mtimeMs > TTL_MS) {
+    out.reason = 'critique artifact stale (> 10 min)';
+    return out;
+  }
+
+  // Validate critique JSON shape
+  try {
+    const data = JSON.parse(fs.readFileSync(cPath, 'utf8'));
+    if (typeof data.initial !== 'string' || typeof data.final !== 'string'
+      || !Array.isArray(data.findings)) {
+      out.reason = 'critique artifact malformed';
+      return out;
+    }
+  } catch (e) {
+    out.reason = 'critique artifact unreadable';
+    return out;
+  }
+
+  out.approval = true;
+  out.critique = true;
+  return out;
+}
+
+/**
+ * Delete approval + critique files for the given hash. Best-effort.
+ */
+function consumeArtifacts(hash) {
+  for (const p of [approvalPath(hash), critiquePath(hash)]) {
+    try { fs.unlinkSync(p); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Delete any artifact older than TTL_MS regardless of hash. Used by the hook
+ * to keep the directory bounded even when dispatches never happen.
+ */
+function purgeStale() {
+  const dir = storeDir();
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch { return; }
+  const now = Date.now();
+  for (const name of entries) {
+    const full = path.join(dir, name);
+    try {
+      const st = fs.statSync(full);
+      if (now - st.mtimeMs > TTL_MS) fs.unlinkSync(full);
+    } catch { /* race with another process */ }
+  }
+}
+
+module.exports = {
+  TTL_MS,
+  storeDir,
+  critiquePath,
+  approvalPath,
+  writeCritique,
+  writeApprovalToken,
+  verifyArtifacts,
+  consumeArtifacts,
+  purgeStale,
+};

--- a/plugins/sdlc-utilities/skills/jira-sdlc/lib/payload-hash.js
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/lib/payload-hash.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Stable canonical JSON serialization + sha256 hashing for jira-sdlc payloads.
+ *
+ * Both the skill (when writing approval/critique artifacts) and the PreToolUse
+ * hook (when verifying them) MUST use this module to compute the payload hash
+ * so the two sides agree byte-for-byte regardless of property insertion order.
+ *
+ * Implements R21 of docs/specs/jira-sdlc.md.
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Recursively canonicalize a value into a structure where every plain-object
+ * key set is sorted lexicographically. Arrays preserve their order. Primitives
+ * pass through. Functions and undefined values are dropped (mirroring
+ * JSON.stringify behavior).
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+function canonicalize(value) {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== 'object') return value;
+
+  const sortedKeys = Object.keys(value).sort();
+  const out = {};
+  for (const k of sortedKeys) {
+    const v = canonicalize(value[k]);
+    if (v === undefined) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Compute the canonical sha256 hash of a payload as a lowercase hex string.
+ *
+ * @param {*} payload
+ * @returns {string} 64-char hex digest
+ */
+function payloadHash(payload) {
+  const canonical = canonicalize(payload);
+  const json = JSON.stringify(canonical);
+  return crypto.createHash('sha256').update(json, 'utf8').digest('hex');
+}
+
+module.exports = { canonicalize, payloadHash };

--- a/plugins/sdlc-utilities/skills/jira-sdlc/lib/placeholder-detect.js
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/lib/placeholder-detect.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Detect unfilled placeholder markers in jira-sdlc payloads (R19 / C13).
+ *
+ * Two equally-treated placeholder forms:
+ *   - Brace form: `{snake_or_kebab_name}`
+ *   - Bracket form: `[bracketed prose >= 3 chars]`
+ *
+ * Walks every string-valued field of the payload, including nested ADF
+ * `text` nodes (Atlassian Document Format), so that placeholders inside
+ * description / commentBody / body fields are caught.
+ */
+
+const PLACEHOLDER_REGEX = /\{[a-zA-Z_][a-zA-Z0-9_-]*\}|\[[^\]\n]{3,}\]/g;
+
+/**
+ * @param {*} payload
+ * @returns {Array<{path: string, marker: string}>}
+ */
+function findPlaceholders(payload) {
+  const results = [];
+  walk(payload, '', results);
+  return results;
+}
+
+function walk(node, path, results) {
+  if (node === null || node === undefined) return;
+  if (typeof node === 'string') {
+    PLACEHOLDER_REGEX.lastIndex = 0;
+    let m;
+    while ((m = PLACEHOLDER_REGEX.exec(node)) !== null) {
+      results.push({ path, marker: m[0] });
+    }
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => walk(item, path ? `${path}[${i}]` : `[${i}]`, results));
+    return;
+  }
+  if (typeof node === 'object') {
+    for (const k of Object.keys(node)) {
+      walk(node[k], path ? `${path}.${k}` : k, results);
+    }
+  }
+}
+
+module.exports = { findPlaceholders, PLACEHOLDER_REGEX };

--- a/plugins/sdlc-utilities/skills/jira-sdlc/lib/template-fingerprint.js
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/lib/template-fingerprint.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Resolve and fingerprint description templates for R18 enforcement.
+ *
+ * Resolution order:
+ *   1. Override:  <projectRoot>/.claude/jira-templates/<IssueType>.md
+ *   2. Shipped:   <pluginRoot>/skills/jira-sdlc/templates/<IssueType>.md
+ *
+ * The fingerprint is the set of `## ` heading texts. For the hook to allow
+ * dispatch, every `## ` heading appearing in the payload description must be
+ * a member of the resolved template's heading set (sections may be removed
+ * but never invented).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Extract `## ` headings from a markdown source.
+ * @param {string} markdown
+ * @returns {Set<string>}
+ */
+function extractHeadings(markdown) {
+  const headings = new Set();
+  if (typeof markdown !== 'string' || markdown.length === 0) return headings;
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) headings.add(m[1].trim());
+  }
+  return headings;
+}
+
+/**
+ * Resolve the template for the given issue type and return its heading set.
+ *
+ * @param {string} issueType
+ * @param {string} projectRoot
+ * @param {object} [opts]
+ * @param {string} [opts.shippedTemplatesDir] override for the shipped templates root
+ * @returns {{ headings: Set<string>, source: 'override'|'shipped'|null, file: string|null }}
+ */
+function loadTemplateHeadings(issueType, projectRoot, opts = {}) {
+  if (!issueType || typeof issueType !== 'string') {
+    return { headings: new Set(), source: null, file: null };
+  }
+  const overrideFile = path.join(projectRoot, '.claude', 'jira-templates', `${issueType}.md`);
+  if (fs.existsSync(overrideFile)) {
+    const md = fs.readFileSync(overrideFile, 'utf8');
+    return { headings: extractHeadings(md), source: 'override', file: overrideFile };
+  }
+  const shippedDir = opts.shippedTemplatesDir
+    || path.resolve(__dirname, '..', 'templates');
+  const shippedFile = path.join(shippedDir, `${issueType}.md`);
+  if (fs.existsSync(shippedFile)) {
+    const md = fs.readFileSync(shippedFile, 'utf8');
+    return { headings: extractHeadings(md), source: 'shipped', file: shippedFile };
+  }
+  return { headings: new Set(), source: null, file: null };
+}
+
+module.exports = { extractHeadings, loadTemplateHeadings };

--- a/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/operations-reference.md
@@ -10,30 +10,45 @@ conditionally after Step 2 classifies the operation type.
 > - Always use `cloudId` from cache — never call `getAccessibleAtlassianResources` again
 > - Never guess field IDs, transition IDs, or user accountIds
 > - Never fabricate field values — use only `allowedValues` from `fieldSchemas`
+>
+> **Write-op canonical procedure (R17–R21):** every write operation below — Create, Edit, Transition, Comment, Worklog, Link — MUST follow the eight-step sequence:
+>
+> 1. Gather inputs from the user request
+> 2. Resolve description template (Create + description-touching Edit only — R18)
+> 3. Detect placeholders via the C13 regex; escalate every `low`-confidence marker via `AskUserQuestion` (R19)
+> 4. Build the proposed payload
+> 5. Critique (R20) — emit the `Initial:` / `Critique:` / `Final:` block, then call `lib/artifact-store.js` `writeCritique(hash, ...)`
+> 6. Approval gate (R17) — `AskUserQuestion` with `approve` / `change <what>` / `cancel`; on `approve` call `lib/artifact-store.js` `writeApprovalToken(hash)`. The PreToolUse hook (`hooks/pre-tool-jira-write-guard.js`) verifies the artifacts written by steps 5–6 and BLOCKS dispatch otherwise (R21)
+> 7. Dispatch the MCP write call
+> 8. Post-op cache update
+>
+> Read operations (Search, View, GetTransitions) and metadata-discovery operations are exempt from steps 5–7.
 
 ---
 
 ## Create Operation
 
 ```
-1. Determine issue type from user request
+1. Gather inputs — determine issue type from user request
    - Map user language ("bug", "feature", "task") to exact type name from cache.issueTypes
    - If ambiguous, ask: "Should I create a Bug, Task, or Story?"
+   - Read cache.fieldSchemas[issueTypeName]; for each required field not provided
+     by the user, ask before proceeding
 
-2. Resolve description template:
-   a. Check .claude/jira-templates/<issueTypeName>.md — if exists, read it (custom)
-   b. Else, find templates/<issueTypeName>.md relative to the resolved $SCRIPT path
-   c. If found: fill all {placeholder} markers from user context
-      - Replace each {placeholder} with actual content from user's request
-      - NEVER leave raw {placeholder} text in the final description
-      - If a section has no applicable content, remove it entirely
-   d. If no template: write a clean, structured description directly
+2. Resolve description template (R18 — required for Create)
+   a. Check .claude/jira-templates/<issueTypeName>.md — if exists, read it (override)
+   b. Else, find templates/<issueTypeName>.md relative to the resolved $SCRIPT path (shipped)
+   c. If found: fill all {placeholder} markers from user context (see step 3)
+   d. If neither exists: AskUserQuestion with the closed list of available templates —
+      free-form descriptions are prohibited
 
-3. Read cache.fieldSchemas[issueTypeName]:
-   - List all required fields
-   - For each required field not provided by user: ask before creating
+3. Detect placeholders via C13 regex (R19) — `\{[a-zA-Z_][a-zA-Z0-9_-]*\}|\[[^\]\n]{3,}\]`
+   - Classify each marker `high` (explicit user input or definitive cache value) or `low`
+   - For every `low` marker: AskUserQuestion to resolve before payload finalization
+   - Inapplicable section removal requires explicit user consent (no silent drops)
+   - NEVER leave raw {placeholder} or [bracketed prose] in the final description
 
-4. Build MCP call using values from cache and user input:
+4. Build the proposed payload using values from cache and user input
    - issueTypeName: exact string from cache.issueTypes (e.g., "Task" NOT "task")
    - priority: { name: "..." } from cache fieldSchemas.priority.allowedValues
    - labels: flat string array
@@ -41,24 +56,60 @@ conditionally after Step 2 classifies the operation type.
    - custom fields: use fieldId key (e.g., customfield_10016) with correct type shape
    - For Sub-task: include parent: "PROJ-123" as top-level parameter
 
-5. Call mcp__atlassian__createJiraIssue with contentFormat: "markdown"
-6. On success: report created issue key and URL
-7. On 400 error: check fieldSchemas for the issue type; verify field shapes from REFERENCE.md Section 2
+5. Critique the payload (R20) — check template completeness, field correctness,
+   workflow validity (n/a for create), terminology consistency
+   - Emit `Initial:` / `Critique:` / `Final:` block to the user
+   - Compute hash and persist:
+       const { payloadHash } = require('./lib/payload-hash.js');
+       const { writeCritique } = require('./lib/artifact-store.js');
+       const hash = payloadHash(payload);
+       writeCritique(hash, { initial, findings, final });
+
+6. Approval gate (R17) — print full final payload, AskUserQuestion approve/change/cancel
+   - On `approve`: writeApprovalToken(hash)
+   - On `change <what>`: revise payload, return to step 5 (new hash, fresh artifacts)
+   - On `cancel`: abort — do not dispatch
+
+7. Dispatch — call mcp__atlassian__createJiraIssue with contentFormat: "markdown"
+   - The PreToolUse hook (R21) re-derives the hash from tool_input and verifies the
+     two artifacts; on hook block, surface permissionDecisionReason verbatim
+   - On 400 error: check fieldSchemas for the issue type; verify field shapes from
+     REFERENCE.md Section 2
+
+8. Post-op cache update — record any newly resolved user mappings or workflow data
 ```
 
 ## Edit Operation
 
 ```
-1. Parse: which issue key, which field(s), what new value(s)
-2. For each field to update, resolve the correct JSON shape from REFERENCE.md Section 2:
+1. Gather inputs — parse: which issue key, which field(s), what new value(s)
+
+2. Resolve description template (R18) — ONLY when description is being touched
+   - Look up the issue's issueTypeName via cache or getJiraIssue
+   - Resolve override `.claude/jira-templates/<Type>.md` then shipped `templates/<Type>.md`
+   - If editing description without a template match, AskUserQuestion with a closed list
+
+3. Detect placeholders via C13 regex (R19) — applies to every string-valued field, not
+   only description; ADF text nodes traversed recursively
+   - Resolve every `low`-confidence marker via AskUserQuestion before payload finalization
+
+4. Build fields object (flat — NOT nested under fields.fields)
    - Priority → { name: "..." }
    - Labels → flat string array (REPLACES existing labels entirely)
    - Components → array of { name: "..." } objects
    - Custom select → { value: "..." }
    - Assignee → { accountId: "..." } from cache.userMappings
-3. Build fields object (flat — NOT nested under fields.fields)
-4. Call mcp__atlassian__editJiraIssue with responseContentFormat: "markdown"
-5. On 400: check field key spelling (customfield_XXXXX), field type, and value shape
+
+5. Critique (R20) — emit Initial/Critique/Final block; writeCritique(hash, ...)
+
+6. Approval gate (R17) — AskUserQuestion approve/change/cancel; on `approve`
+   writeApprovalToken(hash)
+
+7. Dispatch — call mcp__atlassian__editJiraIssue with responseContentFormat: "markdown"
+   - On hook block (R21): surface permissionDecisionReason verbatim
+   - On 400: check field key spelling (customfield_XXXXX), field type, and value shape
+
+8. Post-op cache update — record any newly resolved user mappings
 ```
 
 ## Search Operation
@@ -83,69 +134,91 @@ conditionally after Step 2 classifies the operation type.
 ## Transition Operation
 
 ```
-1. Determine target status from user ("move to Done", "start", "mark in review")
+1. Gather inputs — determine target status from user ("move to Done", "start",
+   "mark in review"); get current status (context or getJiraIssue)
 
-2. Get current status:
-   - If current status is known from context: use it
-   - Else: call mcp__atlassian__getJiraIssue({ cloudId, issueKey, fields: ["status", "issuetype"] })
+   (Steps 2–3 of the canonical procedure are skipped — transitions have no description
+   field and no string fields where placeholder markers can hide.)
 
-3. Look up workflow in cache:
+4. Build payload — look up workflow in cache:
    - transitions = cache.workflows[issueTypeName].transitions[currentStatus]
-   - Find the transition entry matching the target status
-   - If no match: the target transition isn't available from this status;
-     inform user of available transitions and ask which to use
+   - Find transition matching target status; if none, inform user of available
+     transitions and ask which to use
+   - Include requiredFields when non-empty
+     (e.g., { resolution: { name: "Done" } })
+   - Final shape: { cloudId, issueKey, transition: { id }, fields? }
 
-4. Check requiredFields for the chosen transition:
-   - If requiredFields is not empty: include them in the call
-   - Example: { resolution: { name: "Done" } } when requiredFields.resolution.required = true
+5. Critique (R20) — verify transition target reachable per cached workflow graph;
+   emit Initial/Critique/Final; writeCritique(hash, ...)
 
-5. Call mcp__atlassian__transitionJiraIssue({
-     cloudId, issueKey,
-     transition: { id: "<id from cache>" },
-     fields: { <requiredFields> }           // only if requiredFields is non-empty
-   })
+6. Approval gate (R17) — AskUserQuestion approve/change/cancel; on `approve`
+   writeApprovalToken(hash)
 
-6. On success: report new status
-7. On 400 with requiredFields: check that all required fields were included with correct shapes
-8. On "transition not found": call mcp__atlassian__getTransitionsForJiraIssue for fresh list
+7. Dispatch — call mcp__atlassian__transitionJiraIssue
+   - On hook block (R21): surface permissionDecisionReason verbatim
+   - On 400 with requiredFields: verify all required fields were included with correct shapes
+   - On "transition not found": getTransitionsForJiraIssue for fresh list (auto-refresh path)
+
+8. Post-op cache update — record fresh transitions if cache was stale
 ```
 
 ## Comment Operation
 
 ```
-1. Compose comment in markdown (use REFERENCE.md Section 4 safe syntax only)
-2. Convert to ADF — resolve the lib directory and run the conversion script:
+1. Gather inputs — compose comment in markdown (REFERENCE.md Section 4 safe syntax only)
+
+   (Step 2 — template resolution — is skipped; comments have no template.)
+
+3. Detect placeholders via C13 regex (R19) — applies to ADF text nodes recursively
+   - After ADF conversion, walk commentBody.body[] and resolve every `low`-confidence marker
+
+4. Build payload — convert markdown to ADF and assemble:
    SCRIPT=$(find ~/.claude/plugins -name "markdown-to-adf.js" -path "*/sdlc*/scripts/lib/markdown-to-adf.js" 2>/dev/null | head -1)
    [ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/markdown-to-adf.js"
    [ -z "$SCRIPT" ] && { echo "ERROR: markdown-to-adf.js not found"; exit 2; }
    cat <<'COMMENT_MD' | node "$SCRIPT"
    <markdown text>
    COMMENT_MD
-3. Call mcp__atlassian__addCommentToJiraIssue({
-     cloudId, issueIdOrKey,
-     commentBody: <ADF JSON from step 2>,
-     contentFormat: "adf",
-     responseContentFormat: "markdown"
-   })
-4. Never use HTML tags, task lists (- [ ]), or footnotes in source markdown
+   Final shape: { cloudId, issueIdOrKey, commentBody: <ADF JSON>, contentFormat: "adf",
+                 responseContentFormat: "markdown" }
+   Never use HTML tags, task lists (- [ ]), or footnotes in source markdown.
+
+5. Critique (R20) — emit Initial/Critique/Final block; writeCritique(hash, ...)
+
+6. Approval gate (R17) — AskUserQuestion approve/change/cancel; on `approve`
+   writeApprovalToken(hash)
+
+7. Dispatch — call mcp__atlassian__addCommentToJiraIssue
+   - On hook block (R21): surface permissionDecisionReason verbatim
+
+8. Post-op cache update — none typically required for comments
 ```
 
 ## Link Operation
 
 ```
-1. Determine link direction from user intent:
+1. Gather inputs — determine link direction from user intent:
    - "PROJ-A blocks PROJ-B" → outwardIssue = PROJ-A, inwardIssue = PROJ-B
    - "PROJ-A is blocked by PROJ-B" → outwardIssue = PROJ-B, inwardIssue = PROJ-A
    - "PROJ-A relates to PROJ-B" → either direction (symmetric)
    - Cross-reference cache.linkTypes for exact inward/outward label semantics
 
-2. Find link type in cache.linkTypes by name
-3. Call mcp__atlassian__createIssueLink({
-     cloudId,
-     linkType: { name: "Blocks" },
-     inwardIssue: { key: "PROJ-123" },
-     outwardIssue: { key: "PROJ-456" }
-   })
+   (Steps 2–3 of the canonical procedure are skipped — link payloads carry no
+   description and no free-text fields where placeholders can hide.)
+
+4. Build payload — find link type in cache.linkTypes by name; assemble:
+   { cloudId, linkType: { name: "Blocks" },
+     inwardIssue: { key: "PROJ-123" }, outwardIssue: { key: "PROJ-456" } }
+
+5. Critique (R20) — emit Initial/Critique/Final block; writeCritique(hash, ...)
+
+6. Approval gate (R17) — AskUserQuestion approve/change/cancel; on `approve`
+   writeApprovalToken(hash)
+
+7. Dispatch — call mcp__atlassian__createIssueLink
+   - On hook block (R21): surface permissionDecisionReason verbatim
+
+8. Post-op cache update — none typically required for links
 ```
 
 ## Assign Operation
@@ -170,13 +243,26 @@ conditionally after Step 2 classifies the operation type.
 ## Worklog Operation
 
 ```
-1. Parse time from user ("2 hours 30 minutes" → "2h 30m", "half a day" → "4h")
-2. Call mcp__atlassian__addWorklogToJiraIssue({
-     cloudId, issueKey,
-     timeSpent: "<Jira duration string>",
-     comment: "<optional work description>",
-     adjustEstimate: "auto"
-   })
+1. Gather inputs — parse time from user ("2 hours 30 minutes" → "2h 30m",
+   "half a day" → "4h"); collect optional work description
+
+   (Steps 2–3 of the canonical procedure are skipped — worklog has no template
+   and the optional comment is plain text without templated placeholders. The
+   C13 regex still runs over the comment field at hook-verification time.)
+
+4. Build payload:
+   { cloudId, issueKey, timeSpent: "<Jira duration string>",
+     comment: "<optional description>", adjustEstimate: "auto" }
+
+5. Critique (R20) — emit Initial/Critique/Final block; writeCritique(hash, ...)
+
+6. Approval gate (R17) — AskUserQuestion approve/change/cancel; on `approve`
+   writeApprovalToken(hash)
+
+7. Dispatch — call mcp__atlassian__addWorklogToJiraIssue
+   - On hook block (R21): surface permissionDecisionReason verbatim
+
+8. Post-op cache update — none typically required for worklogs
 ```
 
 ## View Operation

--- a/site/src/data/skills-meta.ts
+++ b/site/src/data/skills-meta.ts
@@ -217,6 +217,8 @@ export const skillsMeta: SkillMeta[] = [
       { id: 'resolve-project', label: 'Resolve project key', type: 'script', description: 'Auto-detects from git branch or .sdlc/jira-config.json' },
       { id: 'load-cache', label: 'Initialize or load cache', type: 'script', description: 'Builds cache on first use; reads cached metadata after' },
       { id: 'parse-intent', label: 'Classify operation', type: 'llm', description: 'Interprets request into create/edit/search/transition/etc.' },
+      { id: 'critique-payload', label: 'Critique payload', type: 'llm', description: 'Write-ops only: checks template completeness, placeholder resolution, and field validity before approval' },
+      { id: 'approve-payload', label: 'Approve payload', type: 'user', description: 'Write-ops only: presents final payload for explicit approve / change / cancel before any MCP dispatch' },
       { id: 'execute-op', label: 'Execute Jira operation', type: 'script', description: 'Calls Atlassian MCP with cached field IDs and schemas' },
       { id: 'cache-refresh', label: 'Update cache', type: 'script', description: 'Saves new users, transitions; auto-refreshes on stale data' },
     ],

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/comment-adf-with-placeholder.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/comment-adf-with-placeholder.json
@@ -1,0 +1,15 @@
+{
+  "cloudId": "abc-123",
+  "issueIdOrKey": "PROJ-42",
+  "commentBody": {
+    "type": "doc",
+    "version": 1,
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [{ "type": "text", "text": "Status update: [TBD pending review]" }]
+      }
+    ]
+  },
+  "contentFormat": "adf"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/edit-with-placeholder.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/edit-with-placeholder.json
@@ -1,0 +1,7 @@
+{
+  "cloudId": "abc-123",
+  "issueIdOrKey": "PROJ-42",
+  "issueTypeName": "Bug",
+  "description": "## Objective\nResolve user {user_id} session bug.\n",
+  "contentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/freeform-description-bug.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/freeform-description-bug.json
@@ -1,0 +1,8 @@
+{
+  "cloudId": "abc-123",
+  "projectKey": "PROJ",
+  "issueTypeName": "Bug",
+  "summary": "Free-form description",
+  "description": "## Made-up Heading\nThis heading does not exist in the Bug template.\n",
+  "contentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/no-description-bug.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/no-description-bug.json
@@ -1,0 +1,7 @@
+{
+  "cloudId": "abc-123",
+  "projectKey": "PROJ",
+  "issueTypeName": "Bug",
+  "summary": "No description provided",
+  "contentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/override-bug-create.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/override-bug-create.json
@@ -1,0 +1,8 @@
+{
+  "cloudId": "abc-123",
+  "projectKey": "PROJ",
+  "issueTypeName": "Bug",
+  "summary": "Custom override path",
+  "description": "## Steps to reproduce\nReal repro.\n\n## Expected\nA.\n\n## Actual\nB.\n",
+  "contentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/placeholder-laden-bug.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/placeholder-laden-bug.json
@@ -1,0 +1,8 @@
+{
+  "cloudId": "abc-123",
+  "projectKey": "PROJ",
+  "issueTypeName": "Bug",
+  "summary": "Login button broken",
+  "description": "## Objective\n[describe the broken behavior here]\n\n## Details\nReal content.\n",
+  "contentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json
@@ -1,0 +1,9 @@
+{
+  "cloudId": "abc-123",
+  "projectKey": "PROJ",
+  "issueTypeName": "Bug",
+  "summary": "Login button broken on mobile Safari",
+  "description": "## Objective\nButton fails to submit on iOS Safari 17.\n\n## Details\nReproduced 100% on iPhone 14, blocks login flow.\n\n## How to Test\nTap the login button on iPhone 14 Safari; expect form submit.\n",
+  "contentFormat": "markdown",
+  "responseContentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/valid-comment-adf.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/valid-comment-adf.json
@@ -1,0 +1,16 @@
+{
+  "cloudId": "abc-123",
+  "issueIdOrKey": "PROJ-42",
+  "commentBody": {
+    "type": "doc",
+    "version": 1,
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [{ "type": "text", "text": "Looks good to me." }]
+      }
+    ]
+  },
+  "contentFormat": "adf",
+  "responseContentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/valid-edit.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/valid-edit.json
@@ -1,0 +1,9 @@
+{
+  "cloudId": "abc-123",
+  "issueIdOrKey": "PROJ-42",
+  "issueTypeName": "Bug",
+  "fields": {
+    "summary": "Updated summary"
+  },
+  "responseContentFormat": "markdown"
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/valid-link.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/valid-link.json
@@ -1,0 +1,6 @@
+{
+  "cloudId": "abc-123",
+  "linkType": { "name": "Blocks" },
+  "inwardIssue": { "key": "PROJ-100" },
+  "outwardIssue": { "key": "PROJ-200" }
+}

--- a/tests/promptfoo/datasets/fixtures/jira-payloads/valid-transition.json
+++ b/tests/promptfoo/datasets/fixtures/jira-payloads/valid-transition.json
@@ -1,0 +1,5 @@
+{
+  "cloudId": "abc-123",
+  "issueIdOrKey": "PROJ-42",
+  "transition": { "id": "31" }
+}

--- a/tests/promptfoo/datasets/jira-sdlc-guardrail-exec.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc-guardrail-exec.yaml
@@ -1,0 +1,207 @@
+# jira-sdlc write-op guardrail (R17–R21) hook + helper exec tests.
+#
+# Coverage matrix:
+#   helper-payload-hash      → R21 (canonical hash)
+#   helper-placeholder       → R19 / C13
+#   helper-template          → R18
+#   helper-artifact-store    → R17 / R20 / R21
+#   hook-allow (×3)          → R17/R18/R19/R20/R21 happy paths
+#   hook-deny (×9)           → R17/R18/R19/R20/R21 violation paths
+#   hook-continue (×2)       → defense-in-depth
+#
+# All cases use the local script-runner; assertions check the RESULT line
+# emitted by tests/promptfoo/scripts/jira-write-guard-test.js.
+
+# ---------- Helper module tests ----------
+
+- description: "guardrail helper: payload-hash key-order independence + determinism"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op helper-payload-hash"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+- description: "guardrail helper: placeholder-detect ADF traversal + short-bracket exclusion"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op helper-placeholder"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+- description: "guardrail helper: template-fingerprint override beats shipped, missing returns null"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op helper-template"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+- description: "guardrail helper: artifact-store roundtrip + stale-detection"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op helper-artifact-store"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+# ---------- Hook integration: allow paths ----------
+
+- description: "jira-write-guardrail #1: createJiraIssue valid Bug, fresh artifacts → allow"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op hook-allow --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json --artifacts fresh"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "allow"
+
+- description: "jira-write-guardrail #10: transitionJiraIssue valid → allow"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op hook-allow --tool mcp__atlassian__transitionJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-transition.json --artifacts fresh"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+- description: "jira-write-guardrail #13: createJiraIssue with override template → allow"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op hook-allow --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/override-bug-create.json --artifacts fresh --template-mode override"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+
+# ---------- Hook integration: deny paths ----------
+
+- description: "jira-write-guardrail #2: createJiraIssue with [bracketed] placeholder → deny (R19)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/placeholder-laden-bug.json --artifacts fresh --reason-substring placeholder'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "placeholder"
+
+- description: "jira-write-guardrail #3: createJiraIssue with no description → deny (R18)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/no-description-bug.json --artifacts fresh --reason-substring template'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "template"
+
+- description: "jira-write-guardrail #4: createJiraIssue with invented heading → deny (R18 template mismatch)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/freeform-description-bug.json --artifacts fresh --reason-substring template'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "template"
+
+- description: "jira-write-guardrail #5: createJiraIssue with critique present, approval missing → deny (R17)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json --artifacts missing-approval --reason-substring approval'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "approval"
+
+- description: "jira-write-guardrail #6: createJiraIssue with approval present, critique missing → deny (R20)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json --artifacts missing-critique --reason-substring critique'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "critique"
+
+- description: "jira-write-guardrail #7: createJiraIssue with stale artifacts (> 10 min) → deny (R21 TTL)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-bug-create.json --artifacts stale --reason-substring stale'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "stale"
+
+- description: "jira-write-guardrail #8: editJiraIssue with {placeholder} in description → deny (R19)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__editJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/edit-with-placeholder.json --artifacts fresh --reason-substring placeholder'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "placeholder"
+
+- description: "jira-write-guardrail #9: addCommentToJiraIssue ADF [TBD] in text node → deny (R19 ADF traversal)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__addCommentToJiraIssue --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/comment-adf-with-placeholder.json --artifacts fresh --reason-substring placeholder'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "placeholder"
+
+- description: "jira-write-guardrail #11: createIssueLink with no artifacts → deny (R17/R20)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: '--op hook-deny --tool mcp__atlassian__createIssueLink --payload-fixture tests/promptfoo/datasets/fixtures/jira-payloads/valid-link.json --artifacts none --reason-substring approval'
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "approval"
+
+# ---------- Hook integration: continue paths (defense-in-depth) ----------
+
+- description: "jira-write-guardrail #12: non-matching tool (Read) → continue:true (no parsing)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op hook-continue --tool Read --payload-fixture __no_input__"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "continue"
+
+- description: "jira-write-guardrail #14: malformed tool_input → continue:true (defense-in-depth)"
+  provider: file://providers/script-runner.js
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/jira-write-guard-test.js"
+    script_args: "--op hook-continue --tool mcp__atlassian__createJiraIssue --payload-fixture __malformed__"
+  assert:
+    - type: icontains
+      value: "RESULT: PASS"
+    - type: icontains
+      value: "continue"

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -169,3 +169,111 @@
         incomplete, and does NOT guess a transition id. The response treats unsampled
         identically to a transition ID not being cached — the existing auto-refresh
         fallback from REFERENCE handles both cases.
+
+- description: "jira-sdlc R17: write-op approval gate prompts before createJiraIssue dispatch"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-task.md"
+    user_request: >
+      Run /jira-sdlc. Create a bug in PROJ: "login button broken on mobile Safari".
+      The cache is loaded. Walk through how you would handle the request — show the
+      payload you would dispatch and the user interaction you would have before
+      calling the MCP tool.
+  assert:
+    # Must NOT dispatch createJiraIssue in the planned/described flow before approval
+    - type: not-regex
+      value: "Dispatching mcp__atlassian__createJiraIssue|Dispatched mcp__atlassian__createJiraIssue|Successfully called mcp__atlassian__createJiraIssue"
+    # Must surface the approval prompt with the three required options
+    - type: icontains
+      value: "approve"
+    - type: icontains
+      value: "cancel"
+    # Behavioral: approval gate is presented and dispatch is conditional on approve
+    - type: llm-rubric
+      value: >
+        The response presents the full final payload to the user via AskUserQuestion
+        with three options: approve, change <what>, and cancel. The skill explicitly
+        states it will NOT call mcp__atlassian__createJiraIssue until the user answers
+        "approve". On "change" it loops back; on "cancel" it aborts the operation.
+        The skill describes the approval gate (R17) as a precondition for dispatch,
+        not as an optional courtesy.
+
+- description: "jira-sdlc R18: createJiraIssue requires a resolved description template"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-task.md"
+    user_request: >
+      Run /jira-sdlc. Create a Subtask in PROJ: "refactor cache layer". Note that
+      this skill ships templates only for Bug, Story, Task, Spike, and Epic — there
+      is no Subtask.md template, and no override is configured at
+      .claude/jira-templates/Subtask.md. Walk through how the skill resolves the
+      description template.
+  assert:
+    # Must ask which template to use rather than fabricating a description
+    - type: regex
+      value: "(which template|pick a template|choose.*template|select.*template|AskUserQuestion)"
+    # Must not promise a free-form description
+    - type: not-regex
+      value: "free.?form|free.?text|unstructured description"
+    # Behavioral: closed-list template prompt
+    - type: llm-rubric
+      value: >
+        The response recognizes that no Subtask template ships and no override
+        exists, then prompts the user via AskUserQuestion with a closed list of
+        available templates (Bug, Story, Task, Spike, Epic) — never inventing a
+        description and never proceeding with a free-form description. The skill
+        treats the absence of a template as a user-resolution event (R18), not a
+        silent fallback.
+
+- description: "jira-sdlc R19: low-confidence placeholders escalate to AskUserQuestion"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-task.md"
+    user_request: >
+      Run /jira-sdlc. Create a Story for the new dashboard. The user has given
+      no other detail — the request is intentionally vague. Walk through how the
+      skill builds the description and what it asks the user before dispatching.
+  assert:
+    # Must surface AskUserQuestion for missing context
+    - type: icontains
+      value: "AskUserQuestion"
+    # Must not leave unfilled bracketed placeholder prose in the proposed payload
+    - type: not-regex
+      value: "\\[[^\\]\\n]{15,}\\]"
+    # Behavioral: per-section escalation
+    - type: llm-rubric
+      value: >
+        The response detects that the request is too vague to fill the Story
+        template's sections (acceptance criteria, scope, etc.), classifies each
+        templated marker as low-confidence, and explicitly escalates each one via
+        AskUserQuestion to the user before assembling the final payload. The
+        proposed final payload contains no unfilled `{name}` or `[bracketed prose]`
+        markers. Inapplicable sections are removed only with explicit user consent
+        (no silent drops).
+
+- description: "jira-sdlc R20: critique block (Initial/Critique/Final) surfaces before approval"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-task.md"
+    user_request: >
+      Run /jira-sdlc. Edit BUG-42 in PROJ to add a Steps to Reproduce section in
+      the description. The cache is loaded. Walk through the full flow including
+      the self-critique step before you ask for approval.
+  assert:
+    # Must emit Initial:/Critique:/Final: labels
+    - type: icontains
+      value: "Initial:"
+    - type: icontains
+      value: "Critique:"
+    - type: icontains
+      value: "Final:"
+    # Behavioral: critique deltas surfaced, not silent
+    - type: llm-rubric
+      value: >
+        The response emits an explicit Initial: / Critique: / Final: block before
+        the approval gate, surfacing every critique delta to the user. The Initial
+        section shows the first-pass payload, Critique lists the issues found
+        (template completeness, field correctness, workflow validity, terminology
+        consistency per R20), and Final shows the corrected payload. The skill
+        does NOT apply critique deltas silently — every change between Initial and
+        Final is enumerated in Critique.

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -36,3 +36,4 @@ tests:
   - file://datasets/openspec-lib-exec.yaml
   - file://datasets/openspec-enrich-exec.yaml
   - file://datasets/jira-sdlc-exec.yaml
+  - file://datasets/jira-sdlc-guardrail-exec.yaml

--- a/tests/promptfoo/scripts/jira-write-guard-test.js
+++ b/tests/promptfoo/scripts/jira-write-guard-test.js
@@ -1,0 +1,280 @@
+/**
+ * jira-write-guard-test.js — drives the PreToolUse hook and its helper modules.
+ *
+ * Used by datasets/jira-sdlc-guardrail-exec.yaml via script-runner.js. Each
+ * --op invocation runs one isolated scenario, prints a single
+ * "RESULT: <PASS|FAIL> <details>" line on stdout, and exits 0 when the
+ * scenario matches expectations. We never throw on assertion failure — we
+ * print and exit non-zero so the eval tooling can surface reasons.
+ *
+ * Operations:
+ *   helper-payload-hash      — key-order independence + determinism
+ *   helper-placeholder       — detects markers in nested ADF; ignores < 3 chars
+ *   helper-template          — override beats shipped; missing returns null
+ *   helper-artifact-store    — round-trip + stale-detection
+ *
+ *   hook-allow               — feeds a valid envelope (with artifacts present),
+ *                               asserts {"continue":true}
+ *   hook-deny                — feeds an envelope expected to be denied,
+ *                               asserts permissionDecision == "deny" and reason
+ *                               substring match
+ *   hook-continue            — non-matching tool / malformed input, asserts
+ *                               {"continue":true}
+ *
+ * Args (per scenario):
+ *   --op <name>
+ *   --tool <tool_name>            (hook-* ops)
+ *   --payload-fixture <path>      (hook-* ops; relative to repo root)
+ *   --reason-substring <text>     (hook-deny only)
+ *   --artifacts <state>           one of: fresh | missing-approval | missing-critique | stale | none
+ *   --template-mode <mode>        one of: shipped | override | none (default shipped)
+ *   --tmp-prefix <name>           name suffix for the per-test tmpdir (avoids collisions)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const crypto = require('crypto');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const LIB = path.join(REPO_ROOT, 'plugins/sdlc-utilities/skills/jira-sdlc/lib');
+const HOOK = path.join(REPO_ROOT, 'plugins/sdlc-utilities/hooks/pre-tool-jira-write-guard.js');
+
+const { payloadHash } = require(path.join(LIB, 'payload-hash.js'));
+const { findPlaceholders, PLACEHOLDER_REGEX } = require(path.join(LIB, 'placeholder-detect.js'));
+const { extractHeadings, loadTemplateHeadings } = require(path.join(LIB, 'template-fingerprint.js'));
+const store = require(path.join(LIB, 'artifact-store.js'));
+
+function arg(name, def = null) {
+  const i = process.argv.indexOf(name);
+  if (i === -1 || i + 1 >= process.argv.length) return def;
+  return process.argv[i + 1];
+}
+
+function emit(ok, details) {
+  console.log(`RESULT: ${ok ? 'PASS' : 'FAIL'} ${details}`);
+  process.exitCode = ok ? 0 : 1;
+  // Do NOT call process.exit() — it bypasses `finally` blocks, leaving artifact
+  // files behind and polluting subsequent test runs that share os.tmpdir().
+  return ok;
+}
+
+// ---- Helper-module tests ----
+
+function helperPayloadHash() {
+  const h1 = payloadHash({ a: 1, b: 2, c: { x: 1, y: 2 } });
+  const h2 = payloadHash({ c: { y: 2, x: 1 }, b: 2, a: 1 });
+  const h3 = payloadHash({ a: 1, b: 2, c: { x: 1, y: 2 } });
+  if (h1 !== h2) return emit(false, `key-order: ${h1} != ${h2}`);
+  if (h1 !== h3) return emit(false, `determinism: ${h1} != ${h3}`);
+  if (!/^[0-9a-f]{64}$/.test(h1)) return emit(false, `format: ${h1}`);
+  emit(true, `hash=${h1.slice(0, 12)}…`);
+}
+
+function helperPlaceholder() {
+  const adf = {
+    type: 'doc',
+    content: [
+      { type: 'paragraph', content: [{ type: 'text', text: 'See {issue_id}' }] },
+      { type: 'paragraph', content: [{ type: 'text', text: 'Owner: [name of owner]' }] },
+    ],
+  };
+  const m = findPlaceholders({ description: 'No marker here', adf });
+  if (m.length !== 2) return emit(false, `expected 2 markers, got ${m.length}: ${JSON.stringify(m)}`);
+  const shortBracket = findPlaceholders({ s: '[ab]' });
+  if (shortBracket.length !== 0) return emit(false, `short bracket should be ignored: ${JSON.stringify(shortBracket)}`);
+  // Sanity: regex global flag works
+  if (!PLACEHOLDER_REGEX.global) return emit(false, 'regex missing /g flag');
+  emit(true, `markers=${m.length}`);
+}
+
+function helperTemplate() {
+  // Shipped Bug.md must exist
+  const tplShipped = loadTemplateHeadings('Bug', REPO_ROOT);
+  if (tplShipped.source !== 'shipped' || tplShipped.headings.size === 0) {
+    return emit(false, `shipped resolution failed: ${JSON.stringify({ source: tplShipped.source, n: tplShipped.headings.size })}`);
+  }
+  // Build a temp project root with override
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'jira-tpl-test-'));
+  fs.mkdirSync(path.join(tmpRoot, '.claude/jira-templates'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpRoot, '.claude/jira-templates/Bug.md'),
+    '# Override\n## Custom Section\n## Another\n',
+    'utf8'
+  );
+  const tplOverride = loadTemplateHeadings('Bug', tmpRoot);
+  if (tplOverride.source !== 'override') {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    return emit(false, `override not preferred: ${tplOverride.source}`);
+  }
+  if (!tplOverride.headings.has('Custom Section') || !tplOverride.headings.has('Another')) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    return emit(false, `override headings missing: ${[...tplOverride.headings].join(',')}`);
+  }
+  // Missing template
+  const tplMiss = loadTemplateHeadings('NoSuchType', REPO_ROOT);
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (tplMiss.source !== null) return emit(false, `missing should be null, got ${tplMiss.source}`);
+  emit(true, `shipped=${tplShipped.headings.size} override=ok missing=null`);
+}
+
+function helperArtifactStore() {
+  const hash = crypto.randomBytes(16).toString('hex');
+  store.writeCritique(hash, { initial: 'I', findings: ['F'], final: 'F' });
+  store.writeApprovalToken(hash);
+  let v = store.verifyArtifacts(hash);
+  if (!v.approval || !v.critique) return emit(false, `verify fresh: ${v.reason}`);
+  store.consumeArtifacts(hash);
+  v = store.verifyArtifacts(hash);
+  if (v.approval || v.critique) return emit(false, 'verify after consume should fail');
+  // Stale detection — write then backdate mtime
+  const hash2 = crypto.randomBytes(16).toString('hex');
+  store.writeCritique(hash2, { initial: 'I', findings: [], final: 'F' });
+  store.writeApprovalToken(hash2);
+  const oldTime = Date.now() - (store.TTL_MS + 60_000);
+  fs.utimesSync(store.approvalPath(hash2), oldTime / 1000, oldTime / 1000);
+  fs.utimesSync(store.critiquePath(hash2), oldTime / 1000, oldTime / 1000);
+  v = store.verifyArtifacts(hash2);
+  if (v.approval || v.critique || !/stale/.test(v.reason || '')) {
+    store.consumeArtifacts(hash2);
+    return emit(false, `stale detection failed: reason=${v.reason}`);
+  }
+  store.consumeArtifacts(hash2);
+  emit(true, 'roundtrip+stale ok');
+}
+
+// ---- Hook integration tests ----
+
+function setupTmpProjectRoot(templateMode) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jira-guard-fix-'));
+  if (templateMode === 'override') {
+    fs.mkdirSync(path.join(root, '.claude/jira-templates'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.claude/jira-templates/Bug.md'),
+      '# Bug Override\n## Steps to reproduce\n## Expected\n## Actual\n',
+      'utf8'
+    );
+  }
+  return root;
+}
+
+function setupArtifacts(toolInput, mode) {
+  if (mode === 'none') return null;
+  const hash = payloadHash(toolInput);
+  if (mode === 'fresh') {
+    store.writeCritique(hash, { initial: 'I', findings: [], final: 'F' });
+    store.writeApprovalToken(hash);
+  } else if (mode === 'missing-approval') {
+    store.writeCritique(hash, { initial: 'I', findings: [], final: 'F' });
+  } else if (mode === 'missing-critique') {
+    store.writeApprovalToken(hash);
+  } else if (mode === 'stale') {
+    store.writeCritique(hash, { initial: 'I', findings: [], final: 'F' });
+    store.writeApprovalToken(hash);
+    const old = Date.now() - (store.TTL_MS + 60_000);
+    fs.utimesSync(store.approvalPath(hash), old / 1000, old / 1000);
+    fs.utimesSync(store.critiquePath(hash), old / 1000, old / 1000);
+  }
+  return hash;
+}
+
+function loadFixture(rel) {
+  const full = path.join(REPO_ROOT, rel);
+  if (!fs.existsSync(full)) throw new Error(`fixture missing: ${rel}`);
+  return JSON.parse(fs.readFileSync(full, 'utf8'));
+}
+
+function runHook(envelope, projectRoot) {
+  const r = spawnSync('node', [HOOK], {
+    input: JSON.stringify(envelope),
+    encoding: 'utf8',
+    cwd: projectRoot || REPO_ROOT,
+    timeout: 5000,
+  });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', exitCode: r.status ?? -1 };
+}
+
+function parseHookOutput(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) return {};
+  try { return JSON.parse(trimmed); } catch { return { _parseError: trimmed.slice(0, 200) }; }
+}
+
+function hookCommon(expectedKind, reasonSubstring) {
+  const op = arg('--op');
+  const tool = arg('--tool');
+  const fixture = arg('--payload-fixture');
+  const artifactsMode = arg('--artifacts', 'fresh');
+  const templateMode = arg('--template-mode', 'shipped');
+
+  let toolInput = null;
+  let envelope = null;
+  let projectRoot = templateMode === 'override' ? setupTmpProjectRoot('override') : null;
+
+  try {
+    if (fixture === '__malformed__') {
+      const r = spawnSync('node', [HOOK], { input: 'not json', encoding: 'utf8', cwd: REPO_ROOT, timeout: 5000 });
+      const parsed = parseHookOutput(r.stdout);
+      if (parsed.continue !== true) return emit(false, `malformed: expected continue, got ${r.stdout}`);
+      return emit(true, 'malformed-input → continue:true');
+    }
+    if (fixture === '__no_input__') {
+      envelope = { tool_name: tool };
+      const r = runHook(envelope, projectRoot);
+      const parsed = parseHookOutput(r.stdout);
+      if (parsed.continue !== true) return emit(false, `no tool_input: expected continue, got ${r.stdout}`);
+      return emit(true, 'missing-tool-input → continue:true');
+    }
+
+    toolInput = loadFixture(fixture);
+    if (artifactsMode !== 'skip') setupArtifacts(toolInput, artifactsMode);
+    envelope = { tool_name: tool, tool_input: toolInput };
+    const r = runHook(envelope, projectRoot);
+    const parsed = parseHookOutput(r.stdout);
+
+    if (expectedKind === 'allow') {
+      if (parsed.continue !== true) return emit(false, `expected allow, got: ${r.stdout}`);
+      return emit(true, 'allow');
+    }
+    if (expectedKind === 'continue') {
+      if (parsed.continue !== true) return emit(false, `expected continue, got: ${r.stdout}`);
+      return emit(true, 'continue');
+    }
+    if (expectedKind === 'deny') {
+      const decision = parsed.hookSpecificOutput && parsed.hookSpecificOutput.permissionDecision;
+      const reason = parsed.hookSpecificOutput && parsed.hookSpecificOutput.permissionDecisionReason;
+      if (decision !== 'deny') return emit(false, `expected deny, got decision=${decision} stdout=${r.stdout}`);
+      if (reasonSubstring && !(reason || '').toLowerCase().includes(reasonSubstring.toLowerCase())) {
+        return emit(false, `reason missing "${reasonSubstring}": ${reason}`);
+      }
+      return emit(true, `deny reason="${reason}"`);
+    }
+    return emit(false, `unknown expectedKind ${expectedKind}`);
+  } finally {
+    // Best-effort cleanup
+    try { if (toolInput) store.consumeArtifacts(payloadHash(toolInput)); } catch { /* noop */ }
+    try { if (projectRoot) fs.rmSync(projectRoot, { recursive: true, force: true }); } catch { /* noop */ }
+  }
+}
+
+const op = arg('--op');
+try {
+  switch (op) {
+    case 'helper-payload-hash':   helperPayloadHash(); break;
+    case 'helper-placeholder':    helperPlaceholder(); break;
+    case 'helper-template':       helperTemplate(); break;
+    case 'helper-artifact-store': helperArtifactStore(); break;
+    case 'hook-allow':            hookCommon('allow'); break;
+    case 'hook-continue':         hookCommon('continue'); break;
+    case 'hook-deny':             hookCommon('deny', arg('--reason-substring')); break;
+    default:
+      console.log(`RESULT: FAIL unknown op "${op}"`);
+      process.exitCode = 2;
+  }
+} catch (e) {
+  console.log(`RESULT: FAIL ${op}: ${e && e.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Adds write-operation guardrails to jira-sdlc, enforcing a mandatory critique-then-approve gate before any Jira write (Create Issue, Edit Issue, Transition, Comment, Link, Worklog) is dispatched. A PreToolUse hook provides deterministic enforcement — blocking uncritiqued or unapproved payloads even if the skill is bypassed. Fixes #178

## Business Context

The jira-sdlc skill could previously dispatch write operations (creating issues, posting comments, transitioning tickets) without any validation or explicit user consent. This created a risk of malformed payloads, placeholder-laden content, or unintended mutations reaching Jira. Issue #178 identified the need for approval gates and placeholder detection before any write operation executes.

## Business Benefits

- Users cannot accidentally push placeholder text or template artifacts into Jira
- Every write operation now requires explicit user approval, preventing silent misuse
- The PreToolUse hook provides a deterministic safety net independent of skill behavior, so protection holds even if the skill is invoked non-interactively
- Comprehensive test coverage (18 exec + 4 behavioral cases) gives confidence in guardrail correctness

## Github Issue

https://github.com/rafalNagrodzki/sdlc-marketplace/issues/178

## Technical Design

Three-tier enforcement strategy:

- **Tier 1 (deterministic):** The PreToolUse hook (`pre-tool-jira-write-guard.js`) intercepts all `mcp__atlassian__*` and `mcp__claude_ai_Atlassian__*` write tool calls and validates: (a) placeholder regex — rejects payloads containing `{{...}}`, `[PLACEHOLDER]`, etc.; (b) template fingerprint — rejects payloads that still match known template boilerplate; (c) sha256-bound approval token — requires a matching approval artifact generated during the critique/approve flow.
- **Tier 2 (cooperative):** SKILL.md gains Step 2.5 (LLM critique of assembled payload) and Step 2.6 (user approval gate) before Step 3 execution. Approval generates a sha256-signed artifact stored by `artifact-store.js` and verified by the hook.
- **Tier 3 (behavioral):** promptfoo tests validate R17–R20 requirements end-to-end.

Four new lib helpers support the hook: `artifact-store.js` (read/write approval artifacts), `payload-hash.js` (sha256 signing), `placeholder-detect.js` (regex + ADF tree traversal), `template-fingerprint.js` (known template pattern detection). `operations-reference.md` is restructured as a canonical 8-step procedure shared by all 6 write operations.

## Technical Impact

- **hooks.json updated:** Two new PreToolUse hook registrations added (one per MCP provider namespace). Existing hook configurations are preserved.
- **Skill interface change:** jira-sdlc write flows now require Step 2.5 critique + Step 2.6 approval before execution — existing automations that skip these steps will be blocked by the hook.
- **No breaking changes to public APIs or manifests** beyond the added hook enforcement.
- Plugin version bumped to v0.17.26.

## Changes Overview

- Write-operation guardrails added to jira-sdlc: critique step (R20), approval gate (R17), and hook enforcement (R21) now gate all 6 write operations before dispatch
- PreToolUse hook added with three-tier validation: placeholder detection, template fingerprint matching, and sha256 approval token verification
- Four lib helpers introduced to support the hook: artifact store, payload hashing, placeholder detection, and template fingerprinting
- operations-reference.md restructured as a canonical 8-step procedure for all write operations, replacing ad-hoc per-operation instructions
- Jira payload fixtures added for both valid and invalid cases (placeholders, overrides, freeform) to support exec tests
- Behavioral test coverage added for R17–R20 requirements in jira-sdlc dataset
- Exec test suite added (18 scenarios: 14 hook scenarios + 4 helper unit tests) in dedicated guardrail dataset
- Skill documentation updated with Write Operation Safeguards section describing the three-tier enforcement model
- Site skills-meta.ts pipeline updated to include critique-payload and approve-payload steps for jira-sdlc

## Testing

Behavioral tests (promptfoo): 4 new cases covering R17 (approval gate), R18 (placeholder rejection), R19 (template fingerprint rejection), R20 (critique pass before approval).

Exec tests (promptfoo-exec): 18 cases — 14 hook scenarios exercising valid payloads, placeholder-laden payloads, template-fingerprinted payloads, missing token, and token mismatch; 4 helper unit tests for artifact-store, payload-hash, placeholder-detect, and template-fingerprint.

Fixtures: 10 JSON fixture payloads added covering valid and invalid variants for create, edit, comment (ADF), transition, link, and worklog operations. Tests run without LLM via `promptfooconfig-exec.yaml`.