### PR TITLE
feat(#173): context-advisory - SDLC handoff context advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.28] - 2026-04-28
+
+### Added
+- plan-sdlc, ship-sdlc, execute-plan-sdlc: added context-heaviness advisory to warn users when context window usage is high (#173)
+
 ## [0.17.27] - 2026-04-28
 
 ### Added

--- a/docs/skills/execute-plan-sdlc.md
+++ b/docs/skills/execute-plan-sdlc.md
@@ -264,6 +264,7 @@ Guardrails:       3/3 passed (1 warning, 0 overridden)
 | Source code files | Files created or modified as specified by plan tasks |
 | `.claude/learnings/log.md` | Execution learnings appended after completion (classification accuracy, wave conflicts, recovery outcomes) |
 | `.sdlc/execution/execute-<branch>-<timestamp>.json` | Execution state file written after each wave; enables cross-session resume via --resume. Deleted on success, preserved on failure. |
+| Step 1 context-heaviness advisory | When the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget), Step 1 emits a `/compact` advisory to stderr before guardrail loading. Sidecar is written by the `UserPromptSubmit` hook `hooks/context-stats.js`. Implementation: [`scripts/lib/context-advisory.js`](../../plugins/sdlc-utilities/scripts/lib/context-advisory.js). Distinct from R21 between-wave compaction. Pipeline state survives `/compact` (PreCompact + SessionStart hooks). |
 
 Does not create commits, branches, or push to any remote. The user decides what to do with the changes after execution completes.
 

--- a/docs/skills/plan-sdlc.md
+++ b/docs/skills/plan-sdlc.md
@@ -187,6 +187,7 @@ The plan format is identical regardless of mode, so `/execute-plan-sdlc` loads i
 | `<plansDirectory>/YYYY-MM-DD-<feature-name>.md` | The written plan document (normal mode). Starts as a skeleton header at Step 0 and grows incrementally: header fields and Requirements section added at Step 1, task blocks at Step 2, critique fixes applied at Steps 4 and 6. Path resolved from: user-specified → project `.claude/settings.json` `plansDirectory` → global `~/.claude/settings.json` `plansDirectory` → `~/.claude/plans/` fallback. |
 | Plan mode designated file | When Claude Code plan mode is active, the plan is written to the system-designated file path instead of the above. Same incremental build process applies. The path appears in the plan mode system banner. |
 | `.claude/learnings/log.md` | Planning learnings appended after writing: scope decisions, clarification patterns, decomposition issues. |
+| Step 7 context-heaviness advisory | When the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget), Step 7 prepends a `/compact` advisory above the handoff menu. Sidecar is written by the `UserPromptSubmit` hook `hooks/context-stats.js`. Implementation: [`scripts/lib/context-advisory.js`](../../plugins/sdlc-utilities/scripts/lib/context-advisory.js) consumed via the wrapper [`scripts/skill/plan-handoff-advisory.js`](../../plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js). Pipeline state survives `/compact` (PreCompact + SessionStart hooks). |
 
 ---
 

--- a/docs/skills/ship-sdlc.md
+++ b/docs/skills/ship-sdlc.md
@@ -525,6 +525,7 @@ Then run `/ship-sdlc` without `--resume` to start a new pipeline.
 | Git commits | Feature commit (step 2) and optionally a review fix commit (step 5). |
 | Git tag | Created by version-sdlc if the version step runs. |
 | GitHub PR | Opened or updated by pr-sdlc as the final step. |
+| Step 1 context-heaviness advisory | When the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget), Step 1 emits a `/compact` advisory before the pipeline begins. Sidecar is written by the `UserPromptSubmit` hook `hooks/context-stats.js`. Surfaced through the `contextAdvisory` field of `skill/ship.js` output. Implementation: [`scripts/lib/context-advisory.js`](../../plugins/sdlc-utilities/scripts/lib/context-advisory.js). Pipeline state survives `/compact` (PreCompact + SessionStart hooks). |
 
 ---
 

--- a/docs/specs/execute-plan-sdlc.md
+++ b/docs/specs/execute-plan-sdlc.md
@@ -42,6 +42,7 @@
 - R23: The post-pipeline archive suggestion is never auto-executed — this is the "execute only" entry point; archival is deferred to `/ship-sdlc` or manual invocation
 - R24: If `validateChangeStrict` returns `ok: false`, the suggestion is NOT emitted and the validation output is surfaced instead
 - R25: If the `openspec` CLI is not on PATH (`cliAvailable: false`), the suggestion falls back to the current advisory text (no fabricated validation claim)
+- R26: Step 1 (LOAD) MUST emit a context-heaviness advisory when the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget). The advisory recommends `/compact` and notes that pipeline state survives compaction. When the sidecar is absent or `heavy: false`, no advisory is emitted. This is distinct from R21 (between-wave compaction inside the execution loop) — R26 fires once at handoff before any wave dispatch, R21 governs context management between waves. Implementation lives in `scripts/lib/context-advisory.js`. (Rationale: #173.)
 
 ## Workflow Phases
 

--- a/docs/specs/plan-sdlc.md
+++ b/docs/specs/plan-sdlc.md
@@ -30,6 +30,7 @@
 - R14: Remove the `## Requirements` working section after task decomposition (temporary scaffolding)
 - R15: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R16: When `openspec/config.yaml` exists AND the injected session-start `<system-reminder>` contains a contradictory signal (regex matching `not initialized` together with `openspec`), the skill MUST emit a single audit line naming the authoritative file path and note that the contradictory signal is being ignored. The override line is informational only — skill flow continues. (Rationale: #164 — defensive hardening against co-installed plugins emitting false-negative OpenSpec detection.)
+- R17: Step 7 (handoff) MUST emit a context-heaviness advisory when the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget). The advisory recommends `/compact` and notes that pipeline state survives compaction (preserved by the existing `PreCompact` + `SessionStart` hooks). When the sidecar is absent or `heavy: false`, no advisory is emitted. Implementation lives in `scripts/lib/context-advisory.js` shared with ship-sdlc and execute-plan-sdlc. (Rationale: #173.)
 
 ## Workflow Phases
 

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -62,6 +62,8 @@
   - Acceptance: `SHIP_FIELDS[0].name === 'steps'`; `ship-init.js --steps execute,commit,pr` produces a `.sdlc/local.json` whose top level has `version: 2` and `ship.steps: ["execute","commit","pr"]`, no `preset`/`skip` keys.
 - R34: When no ship config exists and no `--steps`/`--preset` flags are passed, the synthesized preset MUST be `balanced` (excludes the `version` step). `BUILT_IN_DEFAULTS.steps` in `ship-fields.js` MUST equal `PRESET_TO_STEPS.balanced` (`['execute','commit','review','pr','archive-openspec']`). Note: `SHIP_FIELDS[0].default` intentionally diverges (all six canonical steps) — this is the broader questionnaire default so users see all choices; it does not affect runtime behavior.
   - Acceptance: running `skill/ship.js --has-plan` with no `.sdlc/local.json` produces `flags.preset === 'balanced'` and `flags.steps === ['execute','commit','review','pr','archive-openspec']`.
+- R35: Step 1 (pre-flight handoff) MUST emit a context-heaviness advisory when the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget). The advisory recommends `/compact` and notes that pipeline state survives compaction. When the sidecar is absent or `heavy: false`, no advisory is emitted. Implementation lives in `scripts/lib/context-advisory.js` and is appended to `skill/ship.js` PREPARE_OUTPUT_FILE so it surfaces before the pipeline begins. (Rationale: #173.)
+  - Acceptance: with a sidecar containing `heavy: true`, the advisory text appears in `skill/ship.js --dry-run` output; with `heavy: false` or no sidecar, the output contains no advisory.
 
 ## Workflow Phases
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.27",
+  "version": "0.17.28",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/context-stats.js
+++ b/plugins/sdlc-utilities/hooks/context-stats.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * context-stats.js
+ * UserPromptSubmit hook — measures the size of the live transcript file and
+ * writes a sidecar at $TMPDIR/sdlc-context-stats.json so SDLC skills (plan,
+ * ship, execute) can render a context-heaviness advisory at handoff
+ * boundaries.
+ *
+ * Why a hook (not a prepare script): only hooks receive the transcript_path
+ * field on stdin. Bash-tool-invoked scripts do not have access to it.
+ *
+ * Sidecar shape:
+ *   {
+ *     ts:              ISO-8601 string,
+ *     transcriptBytes: number,   // raw file size in bytes
+ *     tokensApprox:    number,   // floor(bytes / 4) — Truffle community heuristic
+ *     modelBudget:     number,   // hardcoded 200000; under-reports on Haiku
+ *     percent:         number,   // 0..100
+ *     heavy:           boolean   // percent >= 60
+ *   }
+ *
+ * Atomic write: temp file + rename, mirroring scripts/lib/state.js.
+ *
+ * Exit codes:
+ *   0 = always (graceful degradation on errors). No stdout. Hook stays silent.
+ */
+
+'use strict';
+
+const fs     = require('node:fs');
+const path   = require('node:path');
+const os     = require('node:os');
+const crypto = require('node:crypto');
+
+const MODEL_BUDGET    = 200000;
+const HEAVY_THRESHOLD = 60; // percent
+const SIDECAR_NAME    = 'sdlc-context-stats.json';
+
+function atomicWriteSync(filePath, content) {
+  const dir    = path.dirname(filePath);
+  const suffix = crypto.randomBytes(4).toString('hex');
+  const tmp    = path.join(dir, path.basename(filePath) + '.' + suffix + '.tmp');
+  fs.writeFileSync(tmp, content, 'utf8');
+  fs.renameSync(tmp, filePath);
+}
+
+function readStdinSync() {
+  try {
+    // Node stdin fd=0 is sync-readable. Use a generous size; hook payloads
+    // are small JSON blobs.
+    return fs.readFileSync(0, 'utf8');
+  } catch (_) {
+    return '';
+  }
+}
+
+(function main() {
+  try {
+    const raw = readStdinSync();
+    if (!raw) process.exit(0);
+
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch (_) {
+      process.exit(0);
+    }
+
+    const transcriptPath = payload && payload.transcript_path;
+    if (!transcriptPath || typeof transcriptPath !== 'string') process.exit(0);
+
+    let stat;
+    try {
+      stat = fs.statSync(transcriptPath);
+    } catch (_) {
+      process.exit(0);
+    }
+
+    const transcriptBytes = stat.size;
+    const tokensApprox    = Math.floor(transcriptBytes / 4);
+    const percent         = Math.min(100, Math.round((tokensApprox / MODEL_BUDGET) * 100));
+    const heavy           = percent >= HEAVY_THRESHOLD;
+
+    const sidecar = {
+      ts: new Date().toISOString(),
+      transcriptBytes,
+      tokensApprox,
+      modelBudget: MODEL_BUDGET,
+      percent,
+      heavy,
+    };
+
+    const tmpDir       = process.env.TMPDIR || os.tmpdir();
+    const sidecarPath  = path.join(tmpDir, SIDECAR_NAME);
+    atomicWriteSync(sidecarPath, JSON.stringify(sidecar, null, 2));
+  } catch (_) {
+    // Graceful degradation — never break the user's prompt flow.
+  }
+
+  process.exit(0);
+})();

--- a/plugins/sdlc-utilities/hooks/hooks.json
+++ b/plugins/sdlc-utilities/hooks/hooks.json
@@ -59,6 +59,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/context-stats.js\"",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/plugins/sdlc-utilities/scripts/lib/context-advisory.js
+++ b/plugins/sdlc-utilities/scripts/lib/context-advisory.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * context-advisory.js
+ * Reads the transcript-stats sidecar written by the UserPromptSubmit hook
+ * (`hooks/context-stats.js`) and returns advisory text for SDLC handoff
+ * boundaries (plan-sdlc Step 7, ship-sdlc Step 1c, execute-plan-sdlc Step 1).
+ *
+ * Sidecar location: `$TMPDIR/sdlc-context-stats.json` (falls back to
+ * `os.tmpdir()` when `TMPDIR` is unset).
+ *
+ * Sidecar shape (written by hooks/context-stats.js):
+ *   {
+ *     ts:              ISO-8601 string,
+ *     transcriptBytes: number,
+ *     tokensApprox:    number,
+ *     modelBudget:     number,
+ *     percent:         number,
+ *     heavy:           boolean
+ *   }
+ *
+ * Returns:
+ *   - null  when the sidecar is missing, unreadable, malformed, or `heavy === false`
+ *   - string advisory text when `heavy === true`
+ *
+ * Zero npm dependencies — Node.js built-ins only.
+ */
+
+const fs   = require('node:fs');
+const path = require('node:path');
+const os   = require('node:os');
+
+const SIDECAR_NAME = 'sdlc-context-stats.json';
+
+function sidecarPath() {
+  const tmpDir = process.env.TMPDIR || os.tmpdir();
+  return path.join(tmpDir, SIDECAR_NAME);
+}
+
+function readSidecar() {
+  try {
+    const raw = fs.readFileSync(sidecarPath(), 'utf8');
+    return JSON.parse(raw);
+  } catch (_) {
+    return null;
+  }
+}
+
+function formatTokens(n) {
+  if (typeof n !== 'number' || !isFinite(n) || n < 0) return '~?k tokens';
+  if (n < 1000) return `~${n} tokens`;
+  const k = Math.round(n / 1000);
+  return `~${k}k tokens`;
+}
+
+/**
+ * Build a context-heaviness advisory for the given skill name.
+ *
+ * @param {object}  opts
+ * @param {string} opts.skill  Skill identifier without leading slash
+ *                             (e.g. `"plan-sdlc"`, `"ship-sdlc"`,
+ *                             `"execute-plan-sdlc"`).
+ * @returns {string|null}      Advisory text when transcript is heavy;
+ *                             null otherwise.
+ */
+function getAdvisory(opts) {
+  const skill = opts && typeof opts.skill === 'string' ? opts.skill : '';
+  const data = readSidecar();
+  if (!data) return null;
+  if (data.heavy !== true) return null;
+
+  const percent = typeof data.percent === 'number' ? data.percent : 0;
+  const tokens  = formatTokens(data.tokensApprox);
+  const slashed = skill ? `/${skill}` : '/<skill>';
+
+  return [
+    '─────────────────────────────────────────────',
+    `Context advisory: transcript at ${percent}% of model budget (${tokens}).`,
+    'Recommendation: run `/compact` before starting this pipeline.',
+    'Pipeline state is preserved across `/compact` (PreCompact + SessionStart hooks),',
+    `so re-invoke \`${slashed}\` afterwards to continue.`,
+    '─────────────────────────────────────────────',
+  ].join('\n');
+}
+
+module.exports = { getAdvisory };

--- a/plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js
+++ b/plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * plan-handoff-advisory.js
+ * Thin wrapper around `lib/context-advisory.getAdvisory()` for plan-sdlc
+ * Step 7. Exists as a dedicated script so the skill can invoke it via Bash
+ * with a stable relative path — invoking via `node -e` would require the
+ * skill to know the absolute lib path at every cwd it might run from.
+ *
+ * Behavior:
+ *   - When the sidecar at $TMPDIR/sdlc-context-stats.json indicates
+ *     `heavy: true`, prints the advisory text to stdout (suitable for
+ *     prepending to the handoff menu).
+ *   - When the sidecar is absent, malformed, or `heavy: false`, prints
+ *     nothing.
+ *   - Always exits 0. Any internal error is swallowed so plan-sdlc Step 7
+ *     never blocks on this advisory.
+ */
+
+'use strict';
+
+try {
+  const { getAdvisory } = require('../lib/context-advisory');
+  const text = getAdvisory({ skill: 'plan-sdlc' });
+  if (text) process.stdout.write(text + '\n');
+} catch (_) {
+  // Graceful degradation — silent failure, never break handoff.
+}
+
+process.exit(0);

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -40,6 +40,7 @@ const { readSection, normalizePreset, PRESET_TO_STEPS } = require(path.join(LIB,
 const { writeOutput } = require(path.join(LIB, 'output'));
 const { VALID_SKIP, VALID_STEPS, BUILT_IN_DEFAULTS, CANONICAL_STEPS } = require(path.join(LIB, 'ship-fields'));
 const { detectActiveChanges, isArchived } = require(path.join(LIB, 'openspec'));
+const { getAdvisory } = require(path.join(LIB, 'context-advisory'));
 
 /**
  * Reverse-map the resolved steps[] back to the nearest canonical preset
@@ -741,6 +742,12 @@ function main() {
   // Detect resume state
   const resume = detectResumeState(projectRoot, gitState.currentBranch);
 
+  // Context-heaviness advisory (implements R35) — sourced from the sidecar
+  // written by hooks/context-stats.js on UserPromptSubmit. Returns null when
+  // the sidecar is missing, malformed, or transcript is below the heavy
+  // threshold. Surfaced verbatim by SKILL.md Step 1c when non-null.
+  const contextAdvisory = getAdvisory({ skill: 'ship-sdlc' });
+
   // Build config values for output
   const configValues = {};
   for (const key of Object.keys(BUILT_IN_DEFAULTS)) {
@@ -780,6 +787,7 @@ function main() {
       warnings: validation.warnings,
     },
     resume,
+    contextAdvisory,
   };
 
   // Exit with 1 if there are fatal errors, 0 otherwise

--- a/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
@@ -58,12 +58,18 @@ SCRIPT_DIR=$(find ~/.claude/plugins -name "config.js" -path "*/sdlc*/lib/config.
 [ -z "$SCRIPT_DIR" ] && { echo "[]"; exit 0; }
 node -e "
 const { readSection } = require('$SCRIPT_DIR/config.js');
+try {
+  const advisory = require('$SCRIPT_DIR/context-advisory.js').getAdvisory({ skill: 'execute-plan-sdlc' });
+  if (advisory) process.stderr.write(advisory + '\n');
+} catch (_) { /* helper missing or sidecar unreadable — silent */ }
 const execute = readSection(process.cwd(), 'execute');
 console.log(JSON.stringify(execute?.guardrails || []));
 "
 ```
 
 Parse the JSON output. If the array is non-empty, store as `activeGuardrails` and print: "Loaded N execution guardrails." If empty or config not found: "No execution guardrails configured." This is backward compatible — no guardrails means no change in behavior.
+
+**Context-heaviness advisory (implements R26):** The inline node block above also prints a context-heaviness advisory to stderr when the sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget). The advisory recommends `/compact` and notes that pipeline state is preserved across compaction (PreCompact + SessionStart hooks). When the sidecar is absent or `heavy: false`, no advisory is emitted. Sidecar is written by the `UserPromptSubmit` hook (`hooks/context-stats.js`); helper at `scripts/lib/context-advisory.js`.
 
 Note: this reads `execute.guardrails` (runtime enforcement), not `plan.guardrails` (planning-time critique). They are independent sets configured separately in `.claude/sdlc.json`.
 

--- a/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
@@ -324,7 +324,17 @@ If this is the 3rd iteration, use AskUserQuestion to surface remaining issues in
 
 ## Step 7: Handoff
 
-**Plan mode:** Announce the plan path and propose execution:
+**Context-heaviness advisory (implements R17):** Before printing either branch below, locate and run the advisory wrapper. If it prints text, prepend that text verbatim to the handoff menu (above the `ship` / `execute` / `done` lines). If it prints nothing, skip the prepend.
+
+```bash
+SCRIPT=$(find ~/.claude/plugins -name "plan-handoff-advisory.js" -path "*/sdlc*/scripts/skill/plan-handoff-advisory.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js"
+[ -n "$SCRIPT" ] && node "$SCRIPT"
+```
+
+The wrapper reads `$TMPDIR/sdlc-context-stats.json` (written by the `UserPromptSubmit` hook `hooks/context-stats.js`) and emits a `/compact` advisory only when transcript ≥60% of model budget. Pipeline state is preserved across `/compact` (PreCompact + SessionStart hooks), so re-invoking after compaction is safe.
+
+**Plan mode:** Announce the plan path and propose execution. Prepend any advisory output from the wrapper above the `ship` / `execute` lines:
 
 > Plan written to `<path>`. On approval:
 >   ship    — run the full pipeline: execute → commit → review → version → PR (/ship-sdlc)
@@ -332,7 +342,7 @@ If this is the 3rd iteration, use AskUserQuestion to surface remaining issues in
 
 Then call ExitPlanMode. Do NOT invoke execute-plan-sdlc or ship-sdlc in this turn — they run after the user accepts in the next turn.
 
-**Normal mode:** Announce the plan path, then present the Workflow Continuation menu (see below).
+**Normal mode:** Announce the plan path, then present the Workflow Continuation menu (see below). Prepend any advisory output from the wrapper above the menu's `ship` / `execute` / `done` lines.
 
 ## Error Recovery
 

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -77,6 +77,8 @@ echo "EXIT_CODE=$EXIT_CODE"
 
 Parse the output JSON from `$PREPARE_OUTPUT_FILE`. If `errors` is non-empty, display them and stop. The parsed output replaces manual computation in subsequent sub-steps (1d–1g).
 
+**Context-heaviness advisory (implements R35):** If the parsed output's top-level `contextAdvisory` field is a non-empty string, print it verbatim before continuing. The advisory recommends `/compact` and notes that pipeline state is preserved across compaction (PreCompact + SessionStart hooks). Sourced from `$TMPDIR/sdlc-context-stats.json`, written by the `UserPromptSubmit` hook (`hooks/context-stats.js`); helper at `scripts/lib/context-advisory.js`. When `contextAdvisory` is `null`, emit nothing.
+
 **Gitignore warning:** If `context.sdlcGitignored` is `false` in the output, print:
 ```
 ⚠ Warning: .sdlc/ is not gitignored. Run --init-config to fix, or manually create .sdlc/.gitignore:

--- a/tests/promptfoo/datasets/context-advisory-exec.yaml
+++ b/tests/promptfoo/datasets/context-advisory-exec.yaml
@@ -1,0 +1,136 @@
+# Script execution tests for the context-heaviness advisory wired into
+# plan-sdlc Step 7 (via plan-handoff-advisory.js), ship-sdlc Step 1
+# (via skill/ship.js), and execute-plan-sdlc Step 1 (via the inline
+# context-advisory require). Implements R17 / R26 / R35.
+#
+# Each test points TMPDIR at the fixture's `tmp/` directory and asserts
+# the heavy / light / missing branches produce the expected output.
+#
+# Fixtures:
+#   project-context-advisory-heavy   → tmp/sdlc-context-stats.json with heavy:true (75%)
+#   project-context-advisory-light   → tmp/sdlc-context-stats.json with heavy:false (10%)
+#   project-context-advisory-missing → tmp/ exists but no sidecar inside
+
+# ---------------------------------------------------------------------------
+# plan-handoff-advisory.js (plan-sdlc Step 7 wrapper)
+# ---------------------------------------------------------------------------
+
+- description: "plan-handoff-advisory: heavy sidecar prints advisory text mentioning /compact and /plan-sdlc"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-heavy"
+  assert:
+    - type: contains
+      value: "Context advisory: transcript at"
+    - type: contains
+      value: "/compact"
+    - type: contains
+      value: "/plan-sdlc"
+
+- description: "plan-handoff-advisory: light sidecar prints nothing"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-light"
+  assert:
+    - type: not-contains
+      value: "Context advisory"
+
+- description: "plan-handoff-advisory: missing sidecar prints nothing"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan-handoff-advisory.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-missing"
+  assert:
+    - type: not-contains
+      value: "Context advisory"
+
+# ---------------------------------------------------------------------------
+# ship.js (ship-sdlc Step 1c — contextAdvisory field in JSON output)
+# ---------------------------------------------------------------------------
+
+- description: "ship-prepare: heavy sidecar populates contextAdvisory in output JSON"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --auto --preset balanced"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-heavy"
+  assert:
+    - type: contains
+      value: '"contextAdvisory":'
+    - type: contains
+      value: "Context advisory: transcript at"
+    - type: contains
+      value: "/ship-sdlc"
+
+- description: "ship-prepare: light sidecar leaves contextAdvisory null"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --auto --preset balanced"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-light"
+  assert:
+    - type: contains
+      value: '"contextAdvisory": null'
+
+- description: "ship-prepare: missing sidecar leaves contextAdvisory null"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --auto --preset balanced"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-missing"
+  assert:
+    - type: contains
+      value: '"contextAdvisory": null'
+
+# ---------------------------------------------------------------------------
+# context-advisory.js helper (direct-call sanity, used by execute-plan-sdlc
+# inline node block in Step 1)
+# ---------------------------------------------------------------------------
+
+- description: "context-advisory helper: heavy sidecar returns advisory mentioning /execute-plan-sdlc"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/run-context-advisory.js"
+    script_args: "execute-plan-sdlc"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-heavy"
+  assert:
+    - type: contains
+      value: "Context advisory: transcript at"
+    - type: contains
+      value: "/execute-plan-sdlc"
+    - type: contains
+      value: "/compact"
+
+- description: "context-advisory helper: light sidecar returns null"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/run-context-advisory.js"
+    script_args: "execute-plan-sdlc"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-light"
+  assert:
+    - type: equals
+      value: "null\n"
+
+- description: "context-advisory helper: missing sidecar returns null"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/run-context-advisory.js"
+    script_args: "execute-plan-sdlc"
+    script_cwd: "{{project_root}}"
+    script_env: '{"TMPDIR": "{{project_root}}/tmp"}'
+    project_root: "file://fixtures-fs/project-context-advisory-missing"
+  assert:
+    - type: equals
+      value: "null\n"

--- a/tests/promptfoo/fixtures-fs/project-context-advisory-heavy/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-context-advisory-heavy/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/project-context-advisory-heavy/tmp/sdlc-context-stats.json
+++ b/tests/promptfoo/fixtures-fs/project-context-advisory-heavy/tmp/sdlc-context-stats.json
@@ -1,0 +1,8 @@
+{
+  "ts": "2026-04-28T22:00:00.000Z",
+  "transcriptBytes": 600000,
+  "tokensApprox": 150000,
+  "modelBudget": 200000,
+  "percent": 75,
+  "heavy": true
+}

--- a/tests/promptfoo/fixtures-fs/project-context-advisory-light/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-context-advisory-light/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/project-context-advisory-light/tmp/sdlc-context-stats.json
+++ b/tests/promptfoo/fixtures-fs/project-context-advisory-light/tmp/sdlc-context-stats.json
@@ -1,0 +1,8 @@
+{
+  "ts": "2026-04-28T22:00:00.000Z",
+  "transcriptBytes": 80000,
+  "tokensApprox": 20000,
+  "modelBudget": 200000,
+  "percent": 10,
+  "heavy": false
+}

--- a/tests/promptfoo/fixtures-fs/project-context-advisory-missing/setup.sh
+++ b/tests/promptfoo/fixtures-fs/project-context-advisory-missing/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Note: the tmp/ subdirectory is intentionally empty — no sdlc-context-stats.json.
+# This fixture exercises the "sidecar missing" branch of context-advisory.js.
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init" || true

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -37,3 +37,4 @@ tests:
   - file://datasets/openspec-enrich-exec.yaml
   - file://datasets/jira-sdlc-exec.yaml
   - file://datasets/jira-sdlc-guardrail-exec.yaml
+  - file://datasets/context-advisory-exec.yaml

--- a/tests/promptfoo/scripts/extract-skill-content.js
+++ b/tests/promptfoo/scripts/extract-skill-content.js
@@ -81,5 +81,23 @@ module.exports = async function transformVars(vars) {
     result.script_cwd = vars.script_cwd.replace(/\{\{project_root\}\}/g, result.project_root);
   }
 
+  // script_env: substitute {{project_root}} in env values so tests can point env
+  // variables (TMPDIR, HOME-style paths, etc.) at fixture-copied directories.
+  // Accepts both string-encoded JSON and object forms.
+  if (vars.script_env && result.project_root) {
+    let envVal = vars.script_env;
+    if (typeof envVal === 'string') {
+      result.script_env = envVal.replace(/\{\{project_root\}\}/g, result.project_root);
+    } else if (envVal && typeof envVal === 'object') {
+      const out = {};
+      for (const [k, v] of Object.entries(envVal)) {
+        out[k] = typeof v === 'string'
+          ? v.replace(/\{\{project_root\}\}/g, result.project_root)
+          : v;
+      }
+      result.script_env = out;
+    }
+  }
+
   return result;
 };

--- a/tests/promptfoo/scripts/run-context-advisory.js
+++ b/tests/promptfoo/scripts/run-context-advisory.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * run-context-advisory.js
+ * Test harness that calls context-advisory.getAdvisory() and prints the result
+ * to stdout (advisory text or the literal "null" line). Used by
+ * datasets/context-advisory-exec.yaml.
+ *
+ * Usage: node run-context-advisory.js <skill-name>
+ */
+
+'use strict';
+
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const helperPath = path.join(REPO_ROOT, 'plugins', 'sdlc-utilities', 'scripts', 'lib', 'context-advisory.js');
+
+const skill = process.argv[2] || 'plan-sdlc';
+
+const { getAdvisory } = require(helperPath);
+const result = getAdvisory({ skill });
+
+if (result === null) {
+  console.log('null');
+} else {
+  console.log(result);
+}


### PR DESCRIPTION
## Summary
Adds a context-heaviness advisory to the plan-sdlc, ship-sdlc, and execute-plan-sdlc skills. When transcript usage reaches 60% or more of the model's context budget, the advisory surfaces a `/compact` recommendation at SDLC handoff boundaries so users know to compact before starting long pipelines.

## Business Context
Long SDLC pipelines (plan → execute → ship) can fail or degrade silently when the model's context window is nearly full at the moment they start. Users had no signal at all — they would invoke `/ship-sdlc` or `/execute-plan-sdlc` without knowing they were already at 75% context usage, leading to truncated outputs or mid-pipeline failures. This feature adds a proactive warning at exactly the right moment: the handoff boundary before a pipeline begins.

## Business Benefits
- Users are warned before launching heavy pipelines into a saturated context, preventing silent mid-run degradation.
- The advisory is zero-friction: it appears only when the threshold is crossed, recommends a concrete action (`/compact`), and confirms that pipeline state is preserved across compaction so no work is lost.
- No false positives below 60%: light sessions see no advisory noise.

## Github Issue
https://github.com/rafal-sdlc/sdlc-marketplace/issues/173

## Technical Design
A `UserPromptSubmit` hook (`hooks/context-stats.js`) fires on every prompt submission. It reads the transcript file path from the hook payload, stat()s the file, approximates token count (bytes ÷ 4), and atomically writes a sidecar JSON at `$TMPDIR/sdlc-context-stats.json`. The sidecar records `percent` and `heavy` (threshold: ≥60%).

A shared helper (`scripts/lib/context-advisory.js`) reads the sidecar and returns advisory text when `heavy: true`, or `null` otherwise. Three SDLC skills consume this helper at their respective handoff points:
- **plan-sdlc Step 7**: via a dedicated wrapper script (`scripts/skill/plan-handoff-advisory.js`) invoked through Bash, output prepended to the handoff menu.
- **ship-sdlc Step 1**: via `skill/ship.js` which calls `getAdvisory()` and populates a `contextAdvisory` field in the prepare output; the skill renders it if non-null.
- **execute-plan-sdlc Step 1**: via an inline `node -e` block that requires the helper and writes to stderr before guardrail loading.

All three paths degrade gracefully: any error in the advisory chain is swallowed and the pipeline continues normally.

## Technical Impact
- New `UserPromptSubmit` hook entry added to `hooks/hooks.json` — fires on every prompt, exits in <2s, no stdout.
- `skill/ship.js` output shape gains one field: `contextAdvisory: string | null` — additive, backward-compatible.
- No changes to plugin manifest schema, skill interfaces, or hook payloads beyond the above.
- Specs updated: R17 (plan-sdlc), R26 (execute-plan-sdlc), R35 (ship-sdlc).

## Changes Overview
- New `UserPromptSubmit` hook measures transcript size on each prompt and writes a lightweight sidecar with context usage stats.
- Shared advisory helper reads the sidecar and emits a formatted `/compact` recommendation when context is heavy.
- plan-sdlc Step 7 prepends the advisory above the handoff menu via a dedicated wrapper script.
- ship-sdlc Step 1 renders the advisory from the `contextAdvisory` field in the ship prepare output.
- execute-plan-sdlc Step 1 emits the advisory to stderr before guardrail loading, via an inline node block.
- Nine promptfoo exec test cases cover the heavy, light, and missing-sidecar branches for all three integration points.
- Test infrastructure gains `{{project_root}}` substitution in `script_env` vars and a new `run-context-advisory.js` harness script.

## Testing
- Nine script execution tests added to `tests/promptfoo/datasets/context-advisory-exec.yaml`, covering plan-handoff-advisory.js, ship.js, and the context-advisory.js helper directly.
- Three fixture directories created (`project-context-advisory-heavy`, `project-context-advisory-light`, `project-context-advisory-missing`) with pre-populated sidecar files for deterministic testing.
- Tests registered in `tests/promptfoo/promptfooconfig-exec.yaml`.
- Manual verification: the advisory text contains the expected `/compact` and skill-name references under the heavy fixture; nothing is emitted under light and missing fixtures.