### PR TITLE
fix(#183): version-sdlc - auto-set upstream on first push

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -1,119 +1,12 @@
 # Learnings Log
 
-This is the append-only learnings log for the `ai-setup-automation` marketplace repository.
+Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
-## 2026-04-28 — version-sdlc: branch with no upstream requires --set-upstream on first push
-Feature branch `fix/replace-preset-with-steps-versioned-config` had no remote tracking branch. `git push` failed with exit 128; recovered with `git push --set-upstream origin <branch>` then `git push --tags` separately. Tag pushed successfully.
+Active bugs are tracked in GitHub issues. This log retains only entries < 30 days old
+that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 
-## 2026-04-23 — version-sdlc: branch without upstream requires --set-upstream on first push
-When releasing from a feature branch that has never been pushed, `git push` fails with exit 128. The fix is `git push --set-upstream origin <branch>` followed by `git push --tags`. This is expected behavior when `remoteState.hasUpstream: false` in the version context.
-
-## 2026-04-23 — pr-sdlc: active gh account may be wrong for repo owner
-When the active `gh` account (`rnagrodzkicl`) doesn't have write permission on the target repo, `gh pr create` fails with "does not have the correct permissions to execute CreatePullRequest". Recovery: run `gh auth switch --user <login>` to switch to the account that owns the repo before retrying. The skill's auto-switch only fires if `ghAuth` is non-null in PR_CONTEXT_JSON; if the script doesn't detect a needed switch, the user may need to switch manually.
-
-## 2026-04-23 — version-sdlc: patch bump on feat branch with no upstream
-Branch had no upstream configured. `git push` failed with exit 128. Recovery: used `git push --set-upstream origin <branch>` followed by `git push --tags`. Branch was a new feature branch in the pipeline, so setting upstream was correct and unblocking.
-
-## 2026-04-23 — pr-sdlc auto-switch account detection
-**Trigger:** `gh pr create` failed with permissions error because active gh account was `rnagrodzkicl` (work account) rather than `rnagrodzki` (personal account where the repo lives). The auto-switch logic in `pr.js` did not switch because the branch had already been pushed with the remote set.
-**Rule:** When `gh pr create` fails with a permissions error, check `gh auth status` and switch to the account matching the repo owner before retrying. The skill should detect this and switch automatically; when it doesn't, manual `gh auth switch --user <login>` is the fix.
-**Example:** Repo owner is `rnagrodzki`; active account was `rnagrodzkicl`; fix was `gh auth switch --user rnagrodzki`.
-
-## 2026-04-23 — version-sdlc: patch bump on feature branch without upstream
-Branch feat/131-received-review-auto-step12 had no upstream configured. `git push` failed with exit 128; recovered with `git push --set-upstream origin <branch>` then `git push --tags`. The `remoteState.hasUpstream: false` in the version context was the correct pre-condition warning. No data lost.
-
-## 2026-04-15 — PR #165 (fix/#164 openspec-detection hardening)
-
-The `prConfig.titlePattern` for this repo requires `type(#issue): scope - description` format (e.g. `fix(#164): openspec-detection - harden against contradictory signals`). The dash-separated scope and description is mandatory — titles without the ` - ` separator will fail validation. Conventional commit style alone (without issue number in parens) is not accepted.
-
-## 2026-04-15 — version-sdlc: patch release v0.17.20 via ship pipeline
-Single fix commit for #164 (openspec-detection hardening). Auto mode used; push deferred to ship pipeline's pr step. CI scripts all current. No pre-condition issues.
-
-## 2026-04-15 — plan-sdlc: fix #152 ship-config missing fields
-Planned a fix for `/setup-sdlc` Step 3b dropping `auto`/`skip`/`bump` questions. Root cause was LLM drift when SKILL.md hand-enumerates 8 `AskUserQuestion` calls — the LLM silently shortens the loop. Fix: emit authoritative field list from `setup.js` (new P7 contract) and make SKILL.md iterate mechanically.
-
-Cross-model plan review (sonnet reviewing opus plan) caught two real blockers that self-review missed:
-1. `rebase` field: SKILL.md currently says `yes/no/prompt` but `ship.js` only accepts `auto/skip/prompt` strings (or booleans mapped via legacy logic). Writing `"yes"` would silently fall through to the `'auto'` fallback — user's choice ignored. Lesson: when moving enum field definitions into a new source of truth, verify the runtime consumer's accepted value set, not just the documented-in-SKILL.md set.
-2. Schema path: self-review assumed `plugins/sdlc-utilities/scripts/schemas/` existed (pattern inferred from other plugin layouts) when the actual location is `schemas/` at repo root. Lesson: verify path claims with `ls` even in comments — reviewers flag inaccurate references as noise.
-
-Plan also revealed a pre-existing inconsistency between `ship.js` `VALID_SKIP` (5 items) and SKILL.md Step 3b `skip` options (7 items). Scoped out as follow-up, not fixed.
-
----
-
-## 2026-03-19 — execute-plan-sdlc: 7-improvement upgrade + plan-sdlc new skill
-Executed a 9-task, 2-wave plan upgrading execute-plan-sdlc and creating plan-sdlc. All tasks classified Standard/Complex; no Trivial tasks, so no batching or pre-wave needed. Wave 1 (7 parallel agents) completed cleanly. Spec compliance review found 1 minor issue in plan-reviewer-prompt.md (9-row table vs 8 specified — agent added "Decomposition balance" row not in spec); fixed inline. Wave 2 (2 parallel docs agents) completed cleanly. README update was required post-execution per AGENTS.md — add this check to standard plan-sdlc output for skill additions.
-Key outcome: grouping improvements by target file (not by improvement letter) was the right decomposition strategy — avoided wave conflicts without over-splitting.
-
----
-
-### [DOC_GAP] Documentation not updated after structural feature PRs
-
-- **Date**: 2026-02-24
-- **Session**: post-mortem
-- **Discovery**: After PRs #2, #3, #4 added the `sdlc-utilities` plugin, namespace prefixes, `scripts/`, and CI enforcement, 25 specific documentation issues accumulated across 7 files. Root cause: the PR workflow (`sdlc-creating-pull-requests` skill) has no quality gate checking whether structural docs (README, AGENTS.md, docs/) were updated to match code changes. `aisa-evolve-target` was never triggered post-merge despite being designed for exactly this.
-- **Impact**: HIGH — misleading docs for contributors; wrong naming conventions documented; entire `scripts/` directory undocumented; outdated PR template description in README vs actual 8-section skill.
-- **Action**: (1) Add "Documentation Sync" quality gate to `sdlc-creating-pull-requests` skill. (2) Add Best Practice note in that skill recommending `/aisa-evolve-target` after structural changes. (3) Fix all 25 doc issues in 7 files. (4) Establish `.claude/learnings/` in this repo for future capture.
-- **Status**: PROMOTED:sdlc-creating-pull-requests
-
-### [PATTERN_FAILED] Prescriptive docs written without reading actual code
-
-- **Date**: 2026-02-24
-- **Session**: post-mortem
-- **Discovery**: `docs/adding-skills.md` recommends a gerund naming convention for skill directories (e.g., `writing-unit-tests`). 8 of 9 actual skills in the repo use a non-gerund prefix pattern (`aisa-init`, `aisa-evolve`, `aisa-evolve-*`). The doc was authored as prescriptive ideal without cross-referencing existing code — a violation of Behavioral Rule 2 ("code is ground truth").
-- **Impact**: MEDIUM — contributors following the docs would create skills with inconsistent naming.
-- **Action**: Fix `docs/adding-skills.md` to describe the actual naming pattern used. Document both the `<plugin-prefix>-<noun>` pattern (aisa skills) and the gerund pattern (sdlc skills) as context-specific conventions.
-- **Status**: PROMOTED:docs/adding-skills.md
-
-### [DOC_GAP] scripts/ directory entirely absent from all documentation
-
-- **Date**: 2026-02-24
-- **Session**: post-mortem
-- **Discovery**: `plugins/ai-setup-automation/scripts/` contains `verify-setup.js`, `cache-snapshot.js`, and a `lib/` directory with 6 modules. Not one documentation file mentions this directory. Contributors have no guidance on how to add scripts to a plugin or when to use them vs skills.
-- **Impact**: HIGH — scripts are invoked by health and cache skills; undocumented maintenance risk.
-- **Action**: Add `scripts/` to all structural documentation (AGENTS.md, README.md, docs/architecture.md). Consider adding `docs/adding-scripts.md` if scripts are expected to grow.
-- **Status**: PROMOTED:docs/architecture.md,AGENTS.md
-
-### [GOTCHA] Large script JSON output (>65KB) breaks shell pipes — use temp file pattern
-
-- **Date**: 2026-03-03
-- **Session**: post-mortem
-- **Discovery**: `pr-prepare.js` embeds full `diffContent` in its JSON output, inflating it to ~150KB for a 16-file PR. When an agent runs `node pr-prepare.js | node -e "..."` to parse the output, the pipe silently truncates at ~65KB, producing "Unterminated string in JSON at position 65342". The `pr.md` command says "capture stdout as `PR_CONTEXT_JSON`" with no guidance for large outputs, so the natural interpretation (shell pipe) fails. Workaround: write to a temp file first (`node pr-prepare.js > /tmp/pr-context-$$.json`), then read from it. Same risk applies to `review-prepare.js`.
-- **Impact**: HIGH — `/sdlc:pr` fails silently on repos with large diffs; requires 3+ extra recovery steps.
-- **Action**: (1) Update `pr.md` command to prescribe temp-file write pattern. (2) Add GOTCHA section to `sdlc-creating-pull-requests` SKILL.md. (3) Apply same fix to `review.md` / `sdlc-reviewing-changes` SKILL.md. (4) Consider adding `--output-file` flag to both scripts.
-- **Status**: PROMOTED:sdlc-creating-pull-requests,sdlc-reviewing-changes
-
-### [GOTCHA] Installed plugin script version skew silently suppresses custom PR template
-
-- **Date**: 2026-03-04
-- **Session**: post-mortem
-- **Discovery**: `pr.md` resolved `pr-prepare.js` from the installed plugin first (`~/.claude/plugins`). Installed v0.3.1 predates custom template support; the project's current script has it. The installed version always won, so `PR_CONTEXT_JSON.customTemplate` was `null`, and the skill silently used the default 8-section template (including JIRA Ticket) instead of the project's 7-section `.claude/pr-template.md`. Root cause: lookup order preferred installed over local; no fallback in the skill to cross-check disk.
-- **Impact**: HIGH — project template preferences silently ignored; wrong sections injected into every PR generated against this project.
-- **Action**: (1) Reversed lookup order in `pr.md`: local project script first, installed second. (2) Added Quality Gate Gotcha to `sdlc-creating-pull-requests` skill: if `customTemplate` is null, check disk for `.claude/pr-template.md` and read it directly if present, warn about potential version skew.
-- **Status**: PROMOTED:sdlc-creating-pull-requests
-
-### [GOTCHA] Hardcoded branch names in AGENTS.md become stale immediately
-
-- **Date**: 2026-02-24
-- **Session**: post-mortem
-- **Discovery**: AGENTS.md contained `Current branch: fix/docs` and `Target merge branch: main` as hardcoded text. After merging to main, these lines became factually wrong. Branch metadata in static docs is always stale — it reflects the state at time of writing, not at time of reading.
-- **Impact**: LOW — confusing to contributors and AI agents reading the file.
-- **Action**: Remove hardcoded branch metadata from AGENTS.md. If branch context is needed, use git commands instead of hardcoding in docs.
-- **Status**: STALE
-
-## 2026-04-13 — version-sdlc: branch with no upstream requires --set-upstream on first push
-Branch fix/pipeline-contract-enforcement-and-model-assignment had no upstream. First `git push` failed with exit 128; recovered by running `git push --set-upstream origin <branch>` then `git push --tags` separately. Tag pushed successfully.
-
-## 2026-04-15 — openspec-lib-exec: script_path "inline" silently fails in script-runner.js
-**Trigger:** Review finding that 6 test cases in `openspec-lib-exec.yaml` used `script_path: "inline"` + `script_inline` which the provider doesn't support.
-**Rule:** If a promptfoo exec test calls library functions directly, create a real wrapper script in `tests/promptfoo/scripts/` and use `script_path: "repo://tests/promptfoo/scripts/<name>.js"`. Never use `script_path: "inline"` — script-runner.js passes the path string literally to `execFileSync`, so "inline" becomes a file argument and crashes. The `script_inline` var is never read by any provider.
-**Example:** `script_path: "repo://tests/promptfoo/scripts/openspec-lib-test.js"` with `script_args: "--op isArchived --project-root {{project_root}} --change add-auth"`
-
-## 2026-04-23 — review-orchestrator: manifest field reference `manifest.git.branch` doesn't exist
-**Trigger:** Review of fix/#167 found orchestrator Step 6 summary template used `{manifest.git.branch}` — this field doesn't exist. The manifest schema has `current_branch` at the top level and `git.{commit_count, commit_log, changed_files}` in a sub-object.
-**Rule:** When adding new fields to an orchestrator summary template, verify field paths against the manifest construction in `scripts/skill/review.js` (lines 535-560). The top-level branch field is `current_branch`, not `git.branch`.
-**Example:** `{manifest.current_branch}` (correct) vs `{manifest.git.branch}` (wrong — this key is undefined).
-
-## 2026-04-27 — version-sdlc: branch with no upstream requires --set-upstream on first push
-**Trigger:** v0.17.25 release on `fix/issue-176-review-sdlc-full-display` — `git push` failed with "no upstream branch". The remoteState in the version context correctly showed `hasUpstream: false`, which was noted as a warning but not acted on pre-push.
-**Rule:** When `remoteState.hasUpstream === false`, use `git push --set-upstream origin <branchName>` for the commit push, then `git push --tags` separately. Don't attempt bare `git push` — it will fail.
+## Tracked in GH Issues
+- version-sdlc auto-set-upstream → #183
+- pr-sdlc post-failure gh-switch → #184
+- plan-sdlc README reminder → #185

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -10,3 +10,7 @@ that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 - version-sdlc auto-set-upstream → #183
 - pr-sdlc post-failure gh-switch → #184
 - plan-sdlc README reminder → #185
+
+## 2026-04-29 — received-review-sdlc processing of review findings for fix(#183)
+- `not-icontains` on `--set-upstream` would match the string anywhere in the response (including explanatory text), producing false negatives on regression-guard assertions; `not-regex: 'git push.*--set-upstream'` scopes the check to actual push command lines only.
+- When adding a new behavior to version-sdlc (R15), always verify: (1) CHANGELOG entry covers the fix, (2) P-fields in spec list all script-provided values the skill uses, (3) user-facing docs describe the behavior, (4) regression-guard assertions are precise enough not to false-negative on prose mentions of flagged strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.29] - 2026-04-28
+
+### Changed
+- Internal maintenance: triaged and pruned stale learnings-log entries (#186)
+
 ## [0.17.28] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.30] - 2026-04-29
+
+### Fixed
+- version-sdlc: consolidated upstream auto-set fix — release push now correctly sets the upstream branch on first push from untracked branches (#183)
+
 ## [0.17.29] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.29] - 2026-04-28
 
+### Fixed
+- version-sdlc: auto-set upstream branch on first push when no upstream is configured (#183)
+
 ### Changed
 - Internal maintenance: triaged and pruned stale learnings-log entries (#186)
 

--- a/docs/skills/version-sdlc.md
+++ b/docs/skills/version-sdlc.md
@@ -26,6 +26,8 @@ Manages the full semantic release workflow: detects the version source, bumps th
 | `--hotfix` | Mark this release as a hotfix for DORA metrics tracking. Annotates the commit message with `[hotfix]` and the tag message body with `Type: hotfix`. | off |
 | `--auto` | Skip interactive approval prompts. Release plan is still displayed for visibility; critique gates and pre-condition checks still run. | off |
 
+> **Auto-upstream:** When releasing from a branch with no remote upstream configured, the push step automatically uses `git push --set-upstream origin <branch>` instead of bare `git push`. This avoids first-push failures on fresh feature branches. The subsequent `git push --tags` is unaffected.
+
 ---
 
 ## Examples

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -32,6 +32,7 @@
 - R12: When `--auto` is set, skip AskUserQuestion prompts but display the release plan and run all critique gates
 - R13: Verify pre-conditions before execution: version file exists (file mode), tag does not conflict, no uncommitted changes, git identity configured
 - R14: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
+- R15: When `remoteState.hasUpstream === false`, the push step uses `git push --set-upstream origin <currentBranch>` instead of bare `git push`; the subsequent `git push --tags` is unchanged. This avoids first-push failures on fresh feature branches.
 
 ## Workflow Phases
 

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -39,7 +39,7 @@
 1. CONSUME — read pre-computed context from `skill/version.js` output (current version, commits, config, flags, bump options)
    - **Script:** `skill/version.js`
    - **Params:** A1 positional bump type (`major|minor|patch`), A2-A7 forwarded (`--pre <label>`, `--changelog`, `--hotfix`, `--auto`, `--init`, `--no-push`)
-   - **Output:** JSON → P1-P12 (version source, config mode/changelog/ticket prefix, requested bump, conventional summary with suggested bump and breaking changes, bump options, latest tag, commits, flags, tag conflicts)
+   - **Output:** JSON → P1-P14 (version source, config mode/changelog/ticket prefix, requested bump, conventional summary with suggested bump and breaking changes, bump options, latest tag, commits, flags, tag conflicts, remote state, current branch)
 2. PLAN — determine bump type, compute new version, draft CHANGELOG entry if enabled
 3. CRITIQUE — self-review against all 7 quality gates
 4. IMPROVE — fix failing gates (max 2 iterations per gate)
@@ -70,6 +70,8 @@
 - P10: `commits` (array) — commits since last tag, each with optional `ticketIds`
 - P11: `flags` (object: `{ preLabel, noPush, changelog, hotfix, auto }`) — parsed CLI flags
 - P12: `conflictsWithNext` (object: `{ major, minor, patch }`) — whether each tag already exists
+- P13: `remoteState` (object: `{ hasUpstream, remoteBranch }`) — upstream tracking state for current branch; `hasUpstream` is false when no upstream is configured
+- P14: `currentBranch` (string) — name of the currently checked-out branch
 
 ## Error Handling
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.29",
+  "version": "0.17.30",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.28",
+  "version": "0.17.29",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -184,7 +184,7 @@ Before executing, verify:
 - The version file path exists (for `config.mode === "file"`)
 - The new tag does not conflict with existing tags (`conflictsWithNext[bumpType]` is false)
 - There are no uncommitted changes that would corrupt the release commit (run `git status --porcelain` and warn if non-empty)
-- Remote state is known — warn if no upstream is configured, but do not block the release
+- Remote state is known — note `remoteState.hasUpstream` for use in Step 8 (the push step self-heals a missing upstream by emitting `--set-upstream`; no user action required)
 - Git identity is configured: run `git config user.name` and `git config user.email`. If either is empty, stop and instruct the user to set them:
   ```
   git config user.name "Your Name"
@@ -242,7 +242,9 @@ The release proceeds regardless of the user's answer. This is informational, not
      git tag -a ${newTag} -m "$(printf 'Release %s\n\nType: hotfix' ${newTag})"
      ```
    - Otherwise: `git tag -a ${newTag} -m "Release ${newTag}"`
-6. **Push** (unless `flags.noPush === true`): `git push && git push --tags`
+6. **Push** (unless `flags.noPush === true`):
+   - If `remoteState.hasUpstream === true` (R11): `git push && git push --tags`
+   - If `remoteState.hasUpstream === false` (R15): `git push --set-upstream origin <currentBranch> && git push --tags` — uses `currentBranch` from the prepare-script `version-context` output. This auto-heals first push from a fresh feature branch; no manual `git push -u` is required.
 
 **If any git command fails** (commit, tag, or push) with a non-auth error, show the error.
 
@@ -331,6 +333,7 @@ When invoking `error-report-sdlc`, provide:
 - `bumpOptions.preRelease` is pre-computed in the JSON only when `--pre` was passed at script time. If the user requests a different pre-label during `edit`, re-run the script — the `preRelease` field reflects the label passed at script invocation, not a label added mid-session.
 - For TOML/YAML version files, use the Edit tool with targeted string replacement (old version string → new version string), not full file rewrites, to avoid corrupting file structure.
 - `git push && git push --tags` are two separate pushes. `git push --tags` alone does NOT push the release commit — both commands are required.
+- **Auto-`--set-upstream` on first push (R15):** When `remoteState.hasUpstream === false`, Step 8 emits `git push --set-upstream origin <currentBranch>` instead of bare `git push`. This eliminates the `fatal: The current branch has no upstream` error on releases cut from a fresh feature branch. The branch comes from `currentBranch` in the `version-context` JSON — never hardcode it. The subsequent `git push --tags` is unchanged.
 - If the working tree has uncommitted changes at execution time, the release commit will include only the staged version file and changelog changes. Warn the user so they are not surprised by files missing from the commit.
 - `conventionalSummary.suggestedBump` is derived from commit types. If there are no conventional commits since the last tag, the suggested bump may default to `patch` — confirm with the user if this seems wrong.
 

--- a/tests/promptfoo/datasets/version-sdlc.yaml
+++ b/tests/promptfoo/datasets/version-sdlc.yaml
@@ -197,3 +197,75 @@
         is empty for that commit). The ticket IDs are appended in parentheses at the end of
         each relevant entry line. It presents a release plan and asks for confirmation before
         proceeding.
+
+- description: "version-sdlc: no upstream — release auto-sets upstream on first push"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is on a fresh feature branch feat/foo with no upstream configured. Running
+      version-prepare.js produces this version-context JSON (excerpt):
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "changelog": false}, "versionSource": {"currentVersion": "1.2.3"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.4", "minor": "1.3.0",
+      "major": "2.0.0"}, "tags": {"latest": "v1.2.3"}, "commits": [{"type": "fix",
+      "subject": "correct rate limit header"}], "flags": {"noPush": false, "auto": true,
+      "hotfix": false, "changelog": false}, "conflictsWithNext": {"patch": false,
+      "minor": false, "major": false}, "currentBranch": "feat/foo",
+      "remoteState": {"hasUpstream": false}, "errors": [], "warnings": []}
+    user_request: >
+      Run /version-sdlc patch --auto. The version-prepare.js output is provided in the
+      project context. Show the release plan and the exact push command(s) you would run.
+  assert:
+    # Must auto-set upstream for the current branch
+    - type: regex
+      value: 'git push (--set-upstream|-u) origin feat/foo'
+    # Must still push tags
+    - type: icontains
+      value: "git push --tags"
+    - type: llm-rubric
+      value: >
+        The response reads the version-context output, recognises remoteState.hasUpstream
+        is false and currentBranch is "feat/foo", and emits the push step as
+        `git push --set-upstream origin feat/foo && git push --tags` (or equivalent
+        `git push -u origin feat/foo && git push --tags`). It does NOT emit a bare
+        `git push` for the release commit. It does NOT prompt the user to manually set
+        the upstream — the skill self-heals. The tag push (`git push --tags`) is unchanged.
+
+- description: "version-sdlc: existing upstream — release uses bare push (no --set-upstream)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is on a feature branch feat/bar that already tracks origin/feat/bar.
+      Running version-prepare.js produces this version-context JSON (excerpt):
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "changelog": false}, "versionSource": {"currentVersion": "1.2.3"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.4", "minor": "1.3.0",
+      "major": "2.0.0"}, "tags": {"latest": "v1.2.3"}, "commits": [{"type": "fix",
+      "subject": "correct rate limit header"}], "flags": {"noPush": false, "auto": true,
+      "hotfix": false, "changelog": false}, "conflictsWithNext": {"patch": false,
+      "minor": false, "major": false}, "currentBranch": "feat/bar",
+      "remoteState": {"hasUpstream": true}, "errors": [], "warnings": []}
+    user_request: >
+      Run /version-sdlc patch --auto. The version-prepare.js output is provided in the
+      project context. Show the release plan and the exact push command(s) you would run.
+  assert:
+    # Must use plain `git push` followed by `git push --tags`
+    - type: icontains
+      value: "git push"
+    - type: icontains
+      value: "git push --tags"
+    # Must NOT inject --set-upstream / -u when an upstream already exists (regression guard)
+    - type: not-icontains
+      value: "--set-upstream"
+    - type: not-regex
+      value: 'git push -u '
+    - type: llm-rubric
+      value: >
+        The response reads the version-context output, recognises remoteState.hasUpstream
+        is true, and emits the push step as `git push && git push --tags` — the standard
+        two-command push with no `--set-upstream` flag and no `-u` shorthand. The branch
+        name "feat/bar" does NOT appear in the push command. This is the regression-guard
+        case: ensure auto-upstream behaviour does not leak into branches that already
+        have an upstream.

--- a/tests/promptfoo/datasets/version-sdlc.yaml
+++ b/tests/promptfoo/datasets/version-sdlc.yaml
@@ -257,8 +257,8 @@
     - type: icontains
       value: "git push --tags"
     # Must NOT inject --set-upstream / -u when an upstream already exists (regression guard)
-    - type: not-icontains
-      value: "--set-upstream"
+    - type: not-regex
+      value: 'git push.*--set-upstream'
     - type: not-regex
       value: 'git push -u '
     - type: llm-rubric


### PR DESCRIPTION
## Summary
Fixes a first-push failure in version-sdlc: when releasing from a branch with no remote upstream configured, `git push` previously failed with `fatal: The current branch has no upstream branch`. The push step now auto-detects this condition and uses `git push --set-upstream origin <branch>` instead of bare `git push`.

## Business Context
Plugin users cutting releases from fresh feature branches (common in SDLC pipelines) encountered a hard failure on the push step with no automatic recovery path. The error required manual intervention every time a new branch was used for a release, breaking the promise of an automated release workflow.

## Business Benefits
- Release workflow no longer fails on first push from a fresh feature branch
- No manual `git push -u` step required before running `/version-sdlc`
- Behavioral contract is now codified in the spec (R15) and tested, preventing regression

## Github Issue
Fixes #183

## Technical Design
The version-sdlc SKILL.md push step (Step 8) now branches on `remoteState.hasUpstream`:
- `true`: bare `git push && git push --tags` (unchanged behavior)
- `false`: `git push --set-upstream origin <currentBranch> && git push --tags`

The `currentBranch` value comes from `P14` in the prepare-script JSON output — the branch name is never hardcoded. Spec requirement R15 was added to formally document this contract. The pre-condition check in Step 7 was updated to reflect that a missing upstream no longer blocks — the push step self-heals.

## Technical Impact
None. The change is internal to version-sdlc's push step. No skill interface, hook payload, or script API is modified. The version-context JSON already exposed `remoteState` and `currentBranch` (P13/P14) — these fields are now consumed in the push step.

## Changes Overview
- version-sdlc push step (Step 8) auto-sets upstream when `remoteState.hasUpstream === false`, eliminating the `fatal: no upstream branch` error on first release from a fresh branch
- Spec (docs/specs/version-sdlc.md) gains R15 documenting the upstream auto-set contract, and P-field descriptions updated to include P13/P14
- User docs (docs/skills/version-sdlc.md) gain an Auto-upstream callout under the flags table
- Two behavioral test cases added: one validates upstream auto-set fires when `hasUpstream: false`, one regression-guards that `--set-upstream` is not injected when upstream already exists
- Learnings log pruned of 16 stale entries — retains only recent non-obvious gotchas not yet reflected in code or skills
- CHANGELOG updated with v0.17.29 and v0.17.30 entries; plugin.json version bumped to 0.17.30

## Testing
- Two promptfoo behavioral test cases added to `tests/promptfoo/datasets/version-sdlc.yaml`:
  1. `no upstream`: asserts the push command includes `--set-upstream origin feat/foo` and `git push --tags`
  2. `existing upstream` (regression guard): asserts bare `git push` is used and `--set-upstream`/`-u` do NOT appear in the push command
- Regression-guard assertions use `not-regex` (not `not-icontains`) to scope checks to actual push command lines, avoiding false negatives from explanatory prose