### PR TITLE
fix(#184): pr-sdlc - account-switch retry + null-check guard

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,9 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-04-29 — version-sdlc: patch release v0.17.31 on fix/184-sequential-meteor
+First push from untracked branch; `git push --set-upstream origin <branch>` required before `git push --tags`. Both commits were `fix` type (null-check guard + gh-account-switch retry), cleanly mapping to a patch bump.
+
 Active bugs are tracked in GitHub issues. This log retains only entries < 30 days old
 that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.31] - 2026-04-29
+
+### Fixed
+- pr-sdlc: post-failure gh-account-switch retry now correctly re-attempts the PR creation flow after switching GitHub accounts (#184)
+- pr-sdlc: null-check guard added for `verify.accounts` to prevent failures when account verification data is absent (#184)
+
 ## [0.17.30] - 2026-04-29
 
 ### Fixed

--- a/docs/skills/pr-sdlc.md
+++ b/docs/skills/pr-sdlc.md
@@ -152,6 +152,26 @@ If a switch occurs, the skill notifies you: `GitHub account switched: now using 
 
 To override manually: `gh auth switch --user <login>` before running the skill.
 
+### Account auto-recovery (post-failure retry)
+
+If `gh pr create` still fails with a `does not have the correct permissions to execute CreatePullRequest` error after pre-flight detection (for example, the wrong account was active for a personal repo), the skill auto-recovers once. It parses the repo owner from `git remote`, looks for a local `gh` account whose login matches, switches to it, and retries `gh pr create` exactly once.
+
+You see a single concise recovery line:
+
+```
+Switched gh account to <login> due to repo-permission mismatch — retrying
+Pull request created: <url>
+```
+
+If no local account matches the owner, the skill surfaces the original error plus an actionable hint:
+
+```
+gh: ... does not have the correct permissions to execute `CreatePullRequest` ...
+Run `gh auth login --hostname github.com` to authenticate the account that owns this repo.
+```
+
+This recovery is one-shot per pipeline invocation — a second consecutive permission failure is terminal. Tracked in spec requirement E7 ([issue #184](https://github.com/rnagrodzki/sdlc-marketplace/issues/184)).
+
 ---
 
 ## Prerequisites

--- a/docs/specs/pr-sdlc.md
+++ b/docs/specs/pr-sdlc.md
@@ -86,6 +86,7 @@
 - E4: `gh` unavailable → show install instructions (no error report)
 - E5: `gh` auth failure → show `gh auth login` instructions (no error report)
 - E6: Title pattern validation fails → show error message, ask user to edit title
+- E7: `gh pr create` fails with stderr containing both `does not have the correct permissions to execute` and `CreatePullRequest` → post-flight account-switch recovery (distinct from pre-flight `ensureGhAccount`): parse repo owner from `git remote`, look up local gh accounts via `gh auth status`, find a matching account (case-insensitive login vs. owner), run `gh auth switch --user <login>`, retry `gh pr create` exactly once. If a matching account is switched and the retry succeeds, surface a single concise recovery line to the user. If no matching account exists, surface the original error plus the hint `gh auth login --hostname <host>`. Max one retry per pipeline invocation; a second permission failure is terminal. References issue #184.
 
 ## Constraints
 

--- a/docs/specs/pr-sdlc.md
+++ b/docs/specs/pr-sdlc.md
@@ -86,7 +86,7 @@
 - E4: `gh` unavailable → show install instructions (no error report)
 - E5: `gh` auth failure → show `gh auth login` instructions (no error report)
 - E6: Title pattern validation fails → show error message, ask user to edit title
-- E7: `gh pr create` fails with stderr containing both `does not have the correct permissions to execute` and `CreatePullRequest` → post-flight account-switch recovery (distinct from pre-flight `ensureGhAccount`): parse repo owner from `git remote`, look up local gh accounts via `gh auth status`, find a matching account (case-insensitive login vs. owner), run `gh auth switch --user <login>`, retry `gh pr create` exactly once. If a matching account is switched and the retry succeeds, surface a single concise recovery line to the user. If no matching account exists, surface the original error plus the hint `gh auth login --hostname <host>`. Max one retry per pipeline invocation; a second permission failure is terminal. References issue #184.
+- E7: `gh pr create` fails with a repo-permission error → post-flight account-switch recovery (distinct from pre-flight `ensureGhAccount`): if a local gh account matching the repo owner is found, switch to it automatically and retry `gh pr create` exactly once; the user sees a single concise recovery line and not the raw error. If no matching account exists, surface the original error with a `gh auth login` hint for the correct hostname. A second consecutive permission failure is terminal. Max one retry per pipeline invocation. References issue #184.
 
 ## Constraints
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.30",
+  "version": "0.17.31",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -430,6 +430,14 @@ function recoverGhAccountForRepo(projectRoot, errorText, opts = {}) {
   // gh auth switch prints to stderr on success and may return null in our exec wrapper —
   // verify by re-querying status.
   const verify = getGhAccounts(host);
+  if (verify.error || !Array.isArray(verify.accounts)) {
+    return {
+      recovered: false,
+      switched: false,
+      reason: 'switch-verify-failed',
+      error: verify.error,
+    };
+  }
   const newActive = verify.accounts.find(a => a && a.active);
   if (newActive && newActive.login.toLowerCase() === match.login.toLowerCase()) {
     return {

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -314,6 +314,142 @@ function ensureGhAccount(projectRoot) {
   };
 }
 
+/**
+ * Pure helper — pick a gh account whose login matches the given repo owner (case-insensitive).
+ * Used by post-failure recovery (issue #184). Pure / no I/O so it can be unit-tested
+ * without mocking gh.
+ *
+ * @param {string} owner — repo owner from `parseRemoteOwner`
+ * @param {Array<{login: string, active?: boolean}>} accounts — list of gh accounts
+ * @returns {{ login: string, active: boolean }|null}
+ */
+function selectAccountForOwner(owner, accounts) {
+  if (!owner || !Array.isArray(accounts) || accounts.length === 0) return null;
+  const ownerLower = String(owner).toLowerCase();
+  const match = accounts.find(
+    a => a && typeof a.login === 'string' && a.login.toLowerCase() === ownerLower
+  );
+  if (!match) return null;
+  return { login: match.login, active: Boolean(match.active) };
+}
+
+/**
+ * Permission-error signature check for `gh pr create` failures (issue #184).
+ * Returns true when the error text indicates the active gh account lacks
+ * permission to create a pull request on this repo (vs. unrelated failures
+ * like 404, network, or rate-limit).
+ *
+ * @param {string} errorText
+ * @returns {boolean}
+ */
+function isGhCreatePrPermissionError(errorText) {
+  if (typeof errorText !== 'string' || errorText.length === 0) return false;
+  const lower = errorText.toLowerCase();
+  return (
+    lower.includes('does not have the correct permissions to execute') &&
+    lower.includes('createpullrequest')
+  );
+}
+
+/**
+ * Post-failure gh-account-switch recovery for `gh pr create`.
+ *
+ * Composes existing helpers (`parseRemoteOwner`, `getGhAccounts`, `exec`) — no new
+ * git or gh primitives. Distinct from the pre-flight `ensureGhAccount`:
+ * this runs ONLY when `gh pr create` already failed with a permission error,
+ * so it can confirm the recovery actually changed something.
+ *
+ * Behavior:
+ *   - If `errorText` is not a permission error → `{ recovered: false, reason: "non-permission-error" }`
+ *   - If matching account is already active → `{ recovered: false, switched: false, reason: "already-active", account }`
+ *   - If matching account exists and switch succeeds → `{ recovered: true, switched: true, account, previousAccount }`
+ *   - If no matching account → `{ recovered: false, switched: false, hint: "gh auth login --hostname <host>" }`
+ *
+ * For test injection (so promptfoo exec tests can run hermetically), pass
+ * `accounts` and `remote` directly instead of letting the function call gh.
+ *
+ * @param {string} projectRoot
+ * @param {string} errorText
+ * @param {{ accounts?: Array<{login:string, active?:boolean}>, remote?: {host:string,owner:string,repo:string}, dryRun?: boolean }} [opts]
+ * @returns {object}
+ */
+function recoverGhAccountForRepo(projectRoot, errorText, opts = {}) {
+  if (!isGhCreatePrPermissionError(errorText)) {
+    return { recovered: false, reason: 'non-permission-error' };
+  }
+
+  const remote = opts.remote || parseRemoteOwner(projectRoot);
+  if (!remote) {
+    return { recovered: false, switched: false, reason: 'no-remote' };
+  }
+  const { host, owner } = remote;
+
+  let accounts = opts.accounts;
+  if (!accounts) {
+    const result = getGhAccounts(host);
+    if (result.error) {
+      return { recovered: false, switched: false, reason: 'gh-status-error', error: result.error };
+    }
+    accounts = result.accounts;
+  }
+
+  const match = selectAccountForOwner(owner, accounts);
+  if (!match) {
+    return {
+      recovered: false,
+      switched: false,
+      hint: `gh auth login --hostname ${host}`,
+      owner,
+      host,
+    };
+  }
+
+  const activeAccount = accounts.find(a => a && a.active) || null;
+  const previousAccount = activeAccount ? activeAccount.login : null;
+
+  if (match.active) {
+    return {
+      recovered: false,
+      switched: false,
+      reason: 'already-active',
+      account: match.login,
+    };
+  }
+
+  if (opts.dryRun) {
+    return {
+      recovered: true,
+      switched: true,
+      account: match.login,
+      previousAccount,
+      dryRun: true,
+    };
+  }
+
+  const switchResult = exec(`gh auth switch --user ${match.login}`);
+  // gh auth switch prints to stderr on success and may return null in our exec wrapper —
+  // verify by re-querying status.
+  const verify = getGhAccounts(host);
+  const newActive = verify.accounts.find(a => a && a.active);
+  if (newActive && newActive.login.toLowerCase() === match.login.toLowerCase()) {
+    return {
+      recovered: true,
+      switched: true,
+      account: match.login,
+      previousAccount,
+    };
+  }
+
+  return {
+    recovered: false,
+    switched: false,
+    reason: 'switch-failed',
+    account: match.login,
+    previousAccount,
+    error: switchResult,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // PR-specific helpers (used by pr-prepare.js only)
 // ---------------------------------------------------------------------------
@@ -700,6 +836,9 @@ module.exports = {
   parseRemoteOwner,
   getGhAccounts,
   ensureGhAccount,
+  selectAccountForOwner,
+  isGhCreatePrPermissionError,
+  recoverGhAccountForRepo,
   // PR-specific
   getRemoteState,
   pushToRemote,

--- a/plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js
+++ b/plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * pr-recover-gh-account.js
+ *
+ * Post-failure gh-account-switch recovery helper for pr-sdlc Step 6 (issue #184).
+ *
+ * Purpose:
+ *   When `gh pr create` fails with a "does not have the correct permissions
+ *   to execute CreatePullRequest" error, this script decides whether the
+ *   active gh account can be transparently switched to one that owns the
+ *   target repo. Pure matching/decision logic lives in `lib/git.js`
+ *   (`selectAccountForOwner`, `recoverGhAccountForRepo`, `isGhCreatePrPermissionError`).
+ *   This script is a thin CLI wrapper.
+ *
+ * Inputs:
+ *   --error-file <path>       Read stderr text from <path>. Required unless --error is passed.
+ *   --error <string>          Inline error text (alternative to --error-file).
+ *   --project-root <path>     Override project root (defaults to process.cwd()).
+ *   --dry-run                 Skip the live `gh auth switch`; require --accounts-file and --owner.
+ *   --accounts-file <path>    Read accounts JSON from file (used with --dry-run for hermetic tests).
+ *                             Format: [{"login":"alice","active":true}, ...]
+ *   --owner <login>           Override repo owner detection (used with --dry-run).
+ *   --host <host>             Override remote host (used with --dry-run, default "github.com").
+ *
+ * Output:
+ *   Single-line JSON to stdout. Exit code 0 on every documented branch
+ *   (recovered or not). Exit code non-zero only on internal/IO error.
+ *
+ * Examples:
+ *   echo "...permission error..." | node pr-recover-gh-account.js --error-file -
+ *   node pr-recover-gh-account.js --dry-run --accounts-file ./accounts.json --owner Cleeng \
+ *     --error "GraphQL: ... does not have the correct permissions to execute `CreatePullRequest`"
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { recoverGhAccountForRepo } = require('../lib/git');
+
+function parseArgs(argv) {
+  const args = {
+    errorFile: null,
+    errorInline: null,
+    projectRoot: process.cwd(),
+    dryRun: false,
+    accountsFile: null,
+    owner: null,
+    host: 'github.com',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = argv[i + 1];
+    switch (flag) {
+      case '--error-file':
+        args.errorFile = next;
+        i++;
+        break;
+      case '--error':
+        args.errorInline = next;
+        i++;
+        break;
+      case '--project-root':
+        args.projectRoot = path.resolve(next);
+        i++;
+        break;
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--accounts-file':
+        args.accountsFile = next;
+        i++;
+        break;
+      case '--owner':
+        args.owner = next;
+        i++;
+        break;
+      case '--host':
+        args.host = next;
+        i++;
+        break;
+      default:
+        // unknown flag — ignored to keep script forward-compatible
+        break;
+    }
+  }
+  return args;
+}
+
+function readErrorText(args) {
+  if (typeof args.errorInline === 'string' && args.errorInline.length > 0) {
+    return args.errorInline;
+  }
+  if (!args.errorFile) {
+    throw new Error('Missing required input: --error or --error-file');
+  }
+  if (args.errorFile === '-') {
+    // read all of stdin synchronously
+    return fs.readFileSync(0, 'utf8');
+  }
+  return fs.readFileSync(args.errorFile, 'utf8');
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (e) {
+    process.stderr.write(`pr-recover-gh-account: arg parse error: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  let errorText;
+  try {
+    errorText = readErrorText(args);
+  } catch (e) {
+    process.stderr.write(`pr-recover-gh-account: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const opts = {};
+  if (args.dryRun) {
+    opts.dryRun = true;
+    if (!args.accountsFile || !args.owner) {
+      process.stderr.write(
+        'pr-recover-gh-account: --dry-run requires --accounts-file and --owner\n'
+      );
+      process.exit(2);
+    }
+    let accounts;
+    try {
+      accounts = JSON.parse(fs.readFileSync(args.accountsFile, 'utf8'));
+    } catch (e) {
+      process.stderr.write(
+        `pr-recover-gh-account: could not read accounts file: ${e.message}\n`
+      );
+      process.exit(2);
+    }
+    if (!Array.isArray(accounts)) {
+      process.stderr.write('pr-recover-gh-account: accounts file must contain a JSON array\n');
+      process.exit(2);
+    }
+    opts.accounts = accounts;
+    opts.remote = { host: args.host, owner: args.owner, repo: 'unknown' };
+  }
+
+  const result = recoverGhAccountForRepo(args.projectRoot, errorText, opts);
+  process.stdout.write(JSON.stringify(result) + '\n');
+  process.exit(0);
+}
+
+main();

--- a/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -420,8 +420,11 @@ if [ "$GH_EXIT" -ne 0 ]; then
   [ -z "$RECOVER_SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js" ] && RECOVER_SCRIPT="plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
   if [ -n "$RECOVER_SCRIPT" ]; then
     RECOVER_JSON=$(node "$RECOVER_SCRIPT" --error-file "$ERR_FILE")
+  else
+    echo "Warning: pr-recover-gh-account.js not found — skipping account-switch recovery"
   fi
 fi
+rm -f "$ERR_FILE"
 ```
 
 Parse `RECOVER_JSON`. Branches:
@@ -430,7 +433,7 @@ Parse `RECOVER_JSON`. Branches:
 - `recovered: false` and `hint` is present — surface the original stderr followed by the hint (e.g., `Run \`gh auth login --hostname <host>\` to authenticate the account that owns this repo.`) and proceed to the existing failure fallback.
 - `recovered: false` and `reason: "non-permission-error"` — proceed straight to the existing failure fallback (this is not an account problem).
 
-The retry runs at most once per pipeline invocation. The recovery helper is the single source of decision logic — SKILL.md only orchestrates capture, invocation, and re-run. Always remove `"$ERR_FILE"` after handling.
+The retry runs at most once per pipeline invocation. The recovery helper is the single source of decision logic — SKILL.md only orchestrates capture, invocation, and re-run.
 
 **Update mode:**
 

--- a/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -409,6 +409,29 @@ gh pr create --title "<title>" --body "<body>" [--draft] [--label "<l1>" --label
 
 If no labels were approved, omit the `--label` flags entirely.
 
+**Post-failure account-switch recovery (implements spec E7, issue #184):** If `gh pr create` exits non-zero, capture stderr to a temp file and invoke the recovery helper exactly once:
+
+```bash
+ERR_FILE=$(mktemp)
+gh pr create --title "<title>" --body "<body>" [--draft] [--label ...] 2> "$ERR_FILE"
+GH_EXIT=$?
+if [ "$GH_EXIT" -ne 0 ]; then
+  RECOVER_SCRIPT=$(find ~/.claude/plugins -name "pr-recover-gh-account.js" -path "*/sdlc*/scripts/skill/pr-recover-gh-account.js" 2>/dev/null | head -1)
+  [ -z "$RECOVER_SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js" ] && RECOVER_SCRIPT="plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+  if [ -n "$RECOVER_SCRIPT" ]; then
+    RECOVER_JSON=$(node "$RECOVER_SCRIPT" --error-file "$ERR_FILE")
+  fi
+fi
+```
+
+Parse `RECOVER_JSON`. Branches:
+
+- `recovered: true` and `switched: true` — print one user-visible line: `Switched gh account to <account> due to repo-permission mismatch — retrying`. Re-run `gh pr create` with the same arguments **exactly once**. A second consecutive failure is terminal and falls through to the existing failure path below.
+- `recovered: false` and `hint` is present — surface the original stderr followed by the hint (e.g., `Run \`gh auth login --hostname <host>\` to authenticate the account that owns this repo.`) and proceed to the existing failure fallback.
+- `recovered: false` and `reason: "non-permission-error"` — proceed straight to the existing failure fallback (this is not an account problem).
+
+The retry runs at most once per pipeline invocation. The recovery helper is the single source of decision logic — SKILL.md only orchestrates capture, invocation, and re-run. Always remove `"$ERR_FILE"` after handling.
+
 **Update mode:**
 
 ```bash
@@ -427,7 +450,7 @@ Pull request created: <url>
 Pull request updated: <url>
 ```
 
-**If `gh` is unavailable or fails**, show the error and provide a fallback:
+**If `gh` is unavailable or fails (after any account-switch retry has already run)**, show the error and provide a fallback:
 
 ```text
 The GitHub CLI (gh) could not complete the operation. You can:
@@ -472,6 +495,7 @@ Title: <title>
 |-------|----------|---------------------------|
 | `skill/pr.js` exit 1 (`errors[]` present) | Show each error, stop | No — user input error |
 | `skill/pr.js` exit 2 (crash) | Show stderr, stop | Yes |
+| `gh pr create` fails with `does not have the correct permissions to execute CreatePullRequest` (spec E7) | Auto-recover: invoke `pr-recover-gh-account.js` once; if a matching local gh account exists, switch and retry `gh pr create` exactly once. If no match, surface original error + `gh auth login --hostname <host>` hint and continue with the manual fallback below. | No on first retry; Yes only if the retry also fails |
 | `gh pr create` / `gh pr edit` fails with 5xx or unexpected error | Show error; offer manual fallback (copy title + description) | Yes |
 | `gh` unavailable | Show install instructions | No — user setup |
 | `gh` auth failure | Show `gh auth login` instructions | No — auth, not a bug |
@@ -503,14 +527,16 @@ When invoking `error-report-sdlc`, provide:
   use it as the template, then warn the user that the installed plugin may be out of date and
   suggest re-installing (`/plugin install sdlc@sdlc-marketplace`).
 
-- **Multiple GitHub accounts — auto-switch may pick the wrong account for team repos**: The
-  skill detects the correct `gh` account using two phases: first it matches the account login
-  against the remote repository owner name (fast, works for personal repos), then it tests API
-  access per account (fallback, handles org repos). If you're a collaborator on a repo owned by
-  a third party (not your org or personal account), the auto-detection may not find a match and
-  falls back to the currently active account with a warning. In that case, run
-  `gh auth switch --user <login>` manually before invoking the skill. The switch persists for
-  subsequent commands.
+- **Multiple GitHub accounts — auto-recovery covers most mismatches**: Pre-flight, the skill
+  matches the active `gh` account against the remote repo owner (via `ensureGhAccount`).
+  Post-flight (spec E7, issue #184), if `gh pr create` still fails with a `CreatePullRequest`
+  permission error, the skill invokes `pr-recover-gh-account.js` once: it parses the repo
+  owner, looks for a local gh account whose login matches, runs `gh auth switch`, and retries
+  `gh pr create` exactly once. The user sees a single concise recovery line, not the raw
+  GraphQL error. If no matching account is configured locally, the skill surfaces a
+  `gh auth login --hostname <host>` hint and falls through to the manual fallback. Manual
+  `gh auth switch --user <login>` before invoking the skill is still valid for collaborator
+  scenarios where no local account login matches the owner.
 
 - **OpenSpec change detection during PR creation should not block.** Unlike plan-sdlc which can ask the user to disambiguate multiple active changes, pr-sdlc should silently skip OpenSpec enrichment if the change cannot be uniquely identified from the branch name. PR creation should never be blocked by spec detection ambiguity.
 

--- a/site/src/data/skills-meta.ts
+++ b/site/src/data/skills-meta.ts
@@ -178,6 +178,7 @@ export const skillsMeta: SkillMeta[] = [
       { id: 'revise-draft', label: 'Revise draft', type: 'llm', description: 'Fixes failing gates; asks user if context unclear' },
       { id: 'review-confirm', label: 'Present for approval', type: 'user', description: 'Shows title and description; yes/edit/cancel' },
       { id: 'create-pr', label: 'Create or update PR', type: 'script', description: 'Runs gh pr create or gh pr edit after approval' },
+      { id: 'account-recovery', label: 'Post-failure account-switch', type: 'script', description: 'On permission error, auto-switches gh account and retries once (E7)' },
     ],
     connections: [
       { to: 'setup-sdlc', label: 'uses template from' },

--- a/tests/promptfoo/datasets/pr-recover-gh-account-exec.yaml
+++ b/tests/promptfoo/datasets/pr-recover-gh-account-exec.yaml
@@ -1,0 +1,69 @@
+# Script execution tests for pr-recover-gh-account.js (issue #184).
+# Hermetic: --dry-run --accounts-file --owner bypasses real `gh` calls.
+# Fixtures live under tests/promptfoo/fixtures-fs/project-pr-recover-*.
+
+- description: "pr-recover: permission error + matching account → recovered+switched"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+    script_args: "--dry-run --accounts-file accounts.json --owner Cleeng --error-file perm-error.txt"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-pr-recover-match"
+  assert:
+    - type: icontains
+      value: '"recovered":true'
+    - type: icontains
+      value: '"switched":true'
+    - type: icontains
+      value: '"account":"Cleeng"'
+
+- description: "pr-recover: permission error + no matching account → hint emitted"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+    script_args: "--dry-run --accounts-file accounts.json --owner Cleeng --error-file perm-error.txt"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-pr-recover-nomatch"
+  assert:
+    - type: icontains
+      value: '"recovered":false'
+    - type: icontains
+      value: '"switched":false'
+    - type: regex
+      value: '"hint":"gh auth login --hostname [^"]+"'
+
+- description: "pr-recover: non-permission error (404) → reason=non-permission-error"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+    script_args: "--dry-run --accounts-file accounts.json --owner Cleeng --error-file non-perm-error.txt"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-pr-recover-match"
+  assert:
+    - type: icontains
+      value: '"recovered":false'
+    - type: icontains
+      value: '"reason":"non-permission-error"'
+
+- description: "pr-recover: error text missing CreatePullRequest token → reason=non-permission-error"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+    script_args: "--dry-run --accounts-file accounts.json --owner Cleeng --error-file near-perm-error.txt"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-pr-recover-match"
+  assert:
+    - type: icontains
+      value: '"recovered":false'
+    - type: icontains
+      value: '"reason":"non-permission-error"'
+
+- description: "pr-recover: case-insensitive match (owner Cleeng vs account cleeng) → switched"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js"
+    script_args: "--dry-run --accounts-file accounts.json --owner Cleeng --error-file perm-error.txt"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-pr-recover-case"
+  assert:
+    - type: icontains
+      value: '"recovered":true'
+    - type: icontains
+      value: '"switched":true'
+    - type: icontains
+      value: '"account":"cleeng"'

--- a/tests/promptfoo/datasets/pr-sdlc.yaml
+++ b/tests/promptfoo/datasets/pr-sdlc.yaml
@@ -196,3 +196,38 @@
         The scope is drawn from allowedScopes (api, auth, db). The quality gate
         validates the title against the titlePattern regex, confirming pattern match.
         The response mentions pattern validation or matching in the critique output.
+
+- description: "pr-sdlc: post-failure gh-account-switch retry on CreatePullRequest permission error (issue #184)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/feature-branch-permission-denied.md"
+    user_request: >
+      Run /pr-sdlc. The first `gh pr create` call has just failed with stderr containing
+      `does not have the correct permissions to execute \`CreatePullRequest\``.
+      The project context describes the helper script available and the expected recovery
+      JSON it returns. Describe the exact Step 6 flow your skill follows on this failure,
+      including (a) how stderr is captured, (b) how `pr-recover-gh-account.js` is invoked,
+      (c) what user-visible message is printed on a successful switch, (d) how many times
+      `gh pr create` is retried, and (e) what happens on the no-match branch.
+  assert:
+    - type: icontains
+      value: "pr-recover-gh-account"
+    - type: icontains
+      value: "--error-file"
+    - type: regex
+      value: "(retry|retried|re-run|rerun).{0,40}(once|exactly one|single)"
+    - type: llm-rubric
+      value: >
+        The response describes the post-failure recovery flow accurately. It captures the
+        failing `gh pr create` stderr to a temp file (mktemp). It invokes
+        `pr-recover-gh-account.js --error-file <tmp>` exactly once, using the standard
+        installed-first-then-local script lookup pattern (find under ~/.claude/plugins,
+        fallback to plugins/sdlc-utilities/scripts/skill/). It parses the returned JSON.
+        On `recovered:true && switched:true`, it prints a single concise user-visible
+        recovery line (something like "Switched gh account to Cleeng due to repo-permission
+        mismatch — retrying"), not the raw GraphQL error. It re-runs `gh pr create` exactly
+        once — never in a loop. On the no-match branch (`recovered:false` with a `hint`
+        field), it surfaces the original error plus the `gh auth login --hostname <host>`
+        hint and proceeds to the existing failure fallback (no retry). It does not call
+        the helper twice or invoke any matching/decision logic itself — all decisions
+        come from the helper.

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-case/accounts.json
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-case/accounts.json
@@ -1,0 +1,1 @@
+[{"login":"rnagrodzki","active":true},{"login":"cleeng","active":false}]

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-case/perm-error.txt
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-case/perm-error.txt
@@ -1,0 +1,1 @@
+GraphQL: rnagrodzki does not have the correct permissions to execute `CreatePullRequest` (createPullRequest)

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-match/accounts.json
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-match/accounts.json
@@ -1,0 +1,1 @@
+[{"login":"rnagrodzki","active":true},{"login":"Cleeng","active":false}]

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-match/near-perm-error.txt
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-match/near-perm-error.txt
@@ -1,0 +1,1 @@
+does not have the correct permissions to execute SomethingElse

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-match/non-perm-error.txt
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-match/non-perm-error.txt
@@ -1,0 +1,1 @@
+HTTP 404: Not Found - branch does not exist

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-match/perm-error.txt
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-match/perm-error.txt
@@ -1,0 +1,1 @@
+GraphQL: rnagrodzki does not have the correct permissions to execute `CreatePullRequest` (createPullRequest)

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-nomatch/accounts.json
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-nomatch/accounts.json
@@ -1,0 +1,1 @@
+[{"login":"rnagrodzki","active":true},{"login":"someoneelse","active":false}]

--- a/tests/promptfoo/fixtures-fs/project-pr-recover-nomatch/perm-error.txt
+++ b/tests/promptfoo/fixtures-fs/project-pr-recover-nomatch/perm-error.txt
@@ -1,0 +1,1 @@
+GraphQL: rnagrodzki does not have the correct permissions to execute `CreatePullRequest` (createPullRequest)

--- a/tests/promptfoo/fixtures/feature-branch-permission-denied.md
+++ b/tests/promptfoo/fixtures/feature-branch-permission-denied.md
@@ -1,0 +1,67 @@
+# Simulated Project Context: PR creation hits CreatePullRequest permission error
+
+## Git State
+
+- **Current branch:** `feat/add-cache-layer`
+- **Base branch:** `main`
+- **Remote:** `git@github.com:Cleeng/example-repo.git`
+- **Remote state:** branch already pushed to origin
+
+## Active gh accounts (multiple)
+
+```
+- rnagrodzki (active)
+- Cleeng     (inactive)
+```
+
+## Commit Log (1 commit since main)
+
+```
+abc1234 feat(cache): add Redis-backed response cache for /search
+```
+
+## Pre-flight account detection result
+
+```json
+{
+  "switched": false,
+  "account": null,
+  "previousAccount": "rnagrodzki",
+  "warning": null
+}
+```
+
+The pre-flight `ensureGhAccount` returned a no-op because the current owner mapping was ambiguous (or the wrong account remained active). The skill proceeded to Step 6.
+
+## Step 6 — `gh pr create` invocation result
+
+The first invocation of `gh pr create` failed with this stderr:
+
+```
+GraphQL: rnagrodzki does not have the correct permissions to execute `CreatePullRequest` (createPullRequest)
+```
+
+Exit code: 1.
+
+## Available helper
+
+The skill installation contains `plugins/sdlc-utilities/scripts/skill/pr-recover-gh-account.js`.
+
+Invoking it with `--error-file <tmp>` against the captured stderr returns:
+
+```json
+{"recovered":true,"switched":true,"account":"Cleeng","previousAccount":"rnagrodzki"}
+```
+
+## Expected behavior
+
+The skill must:
+
+1. Capture the failing stderr to a temp file (mktemp).
+2. Resolve the helper script path with the standard installed-first-then-local lookup.
+3. Invoke `pr-recover-gh-account.js --error-file <tmp>` exactly once.
+4. Parse the JSON. Since `recovered: true && switched: true`, print one user-visible recovery line such as:
+   `Switched gh account to Cleeng due to repo-permission mismatch — retrying`.
+5. Re-run `gh pr create` with the same arguments **exactly once**. A second permission failure is terminal and falls through to the standard failure fallback.
+6. Never loop. Never call the helper twice in the same pipeline invocation.
+7. On the no-match branch, surface the original error plus the `gh auth login --hostname <host>` hint instead of retrying.

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -23,6 +23,7 @@ tests:
   - file://datasets/sdlc-script-resolution-exec.yaml
   - file://datasets/commit-prepare-exec.yaml
   - file://datasets/pr-prepare-exec.yaml
+  - file://datasets/pr-recover-gh-account-exec.yaml
   - file://datasets/ship-prepare-exec.yaml
   - file://datasets/guardrails-prepare-exec.yaml
   - file://datasets/setup-init-exec.yaml


### PR DESCRIPTION
## Summary
Fixes two related bugs in the pr-sdlc GitHub account handling: the skill now retries PR creation after transparently switching to a matching local gh account when a `CreatePullRequest` permission error occurs post-flight, and a null-check guard prevents crashes when `verify.accounts` is absent during account verification.

## Business Context
Users with multiple GitHub accounts configured locally (personal + org) could hit a `CreatePullRequest` permission error even after pre-flight account detection completed, leaving them with a raw GraphQL error and no actionable resolution path. A separate null-reference error in the account verification path caused failures when the accounts array was absent.

## Business Benefits
PR creation now self-heals for the common multi-account mismatch case — users see a single concise recovery line and the PR is created without manual intervention. The null-check guard eliminates a class of crashes for users whose `gh auth status` output is in an unexpected shape.

## Github Issue
Fixes #184: https://github.com/rnagrodzki/sdlc-marketplace/issues/184

## Technical Design
A new `recoverGhAccountForRepo()` function in `lib/git.js` composes existing helpers (`parseRemoteOwner`, `getGhAccounts`, `exec`) to implement post-failure account-switch recovery without new git/gh primitives. It is distinct from the pre-flight `ensureGhAccount`. A thin CLI wrapper (`pr-recover-gh-account.js`) exposes the logic to the skill via subprocess, keeping SKILL.md as the orchestrator. The `selectAccountForOwner()` and `isGhCreatePrPermissionError()` helpers are pure functions, enabling hermetic testing via `--dry-run` without real `gh` calls.

## Technical Impact
None for single-account users. Multi-account users gain transparent recovery; the retry fires at most once per pipeline invocation. A second consecutive failure falls through to the existing manual fallback. Spec gains requirement E7. No breaking changes to plugin manifests, skill interfaces, hook payloads, or script APIs.

## Changes Overview
- Post-failure `gh pr create` permission error detection and account-switch retry added to pr-sdlc Step 6, with stderr captured to a temp file and recovery delegated to a new helper script
- New decision-logic module in `lib/git.js`: parses repo owner, matches against local gh accounts (case-insensitive), switches accounts, and verifies the switch succeeded
- New CLI wrapper script exposes recovery logic as a subprocess with `--dry-run` support for hermetic test execution
- Null-check guard added to account verification to prevent crashes when account data is absent
- Spec updated with E7 error-handling requirement; user-facing docs updated to describe the auto-recovery behavior
- Promptfoo exec test dataset added covering five scenarios: match+switch, no-match+hint, non-permission error passthrough, near-match passthrough, and case-insensitive match

## Testing
Five new exec test cases exercise the recovery script hermetically via `--dry-run --accounts-file --owner` — no real `gh` calls. Cases cover: permission error with matching account (recovered+switched), permission error with no match (hint emitted), non-permission error (passthrough), near-match (missing `CreatePullRequest` token → passthrough), and case-insensitive match (`Cleeng` vs `cleeng`). One behavioral test case added to the pr-sdlc dataset verifying the skill's Step 6 orchestration narrative.