### PR TITLE
fix(#190): execute-plan-sdlc / ship-sdlc - hard-remove legacy flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.33] - 2026-05-03
+
+### Fixed
+- ship-sdlc: removed legacy `--preset` and `--skip` flags; `--preset` is renamed to `--quality`; users are now directed to `--steps` and `--quality` with clear error messages (#190)
+
 ## [0.17.32] - 2026-04-29
 
 ### Changed

--- a/docs/skills/execute-plan-sdlc.md
+++ b/docs/skills/execute-plan-sdlc.md
@@ -10,7 +10,7 @@ Orchestrates implementation plan execution with adaptive task classification, wa
 
 ```text
 /execute-plan-sdlc
-/execute-plan-sdlc --preset balanced
+/execute-plan-sdlc --quality balanced
 /execute-plan-sdlc --resume
 ```
 
@@ -28,7 +28,8 @@ The plan must contain at least 2 tasks with clear deliverables (files to create 
 
 | Flag | Description | Default |
 |---|---|---|
-| `--preset <full\|balanced\|minimal>` | Auto-select a model preset, skipping the interactive selection prompt. `full` = Speed, `balanced` = Balanced, `minimal` = Quality. Legacy A/B/C accepted. Invalid values fall back to interactive selection. | Interactive prompt |
+| `--quality <full\|balanced\|minimal>` | Auto-select the model quality tier, skipping the interactive selection prompt. `full` = Speed, `balanced` = Balanced, `minimal` = Quality. Invalid values fall back to interactive selection. (Renamed from `--preset` in #190 to disambiguate from ship-sdlc's `--steps` step-selection flag.) When invoked from ship-sdlc, `--quality` is forwarded only when the user explicitly passed `--quality` to ship. | Interactive prompt |
+| `--auto` | Suppress interactive prompts: auto-resume if state exists, auto-approve high-risk gates, use `--quality` value (required when `--auto` is set). | Off |
 | `--resume` | Resume from the most recent execution state file for the current branch. Completed waves are skipped; in-progress waves are retried. If the plan has changed since execution started, you are prompted to resume or restart. | Off |
 | `--workspace <branch\|worktree\|prompt>` | Workspace isolation mode when on the default branch. `branch` creates a feature branch, `worktree` creates a git worktree, `prompt` asks interactively. | `prompt` |
 | `--rebase <auto\|skip\|prompt>` | Rebase onto the default branch before execution. `auto` rebases silently (aborts on conflict), `skip` skips, `prompt` asks. | Skip |
@@ -190,13 +191,13 @@ Select preset (full/balanced/minimal), "custom" to edit individual tasks, or "ca
 
 Claude loads the plan from the specified file, validates it, classifies tasks, and presents the wave structure for confirmation.
 
-### Skip preset selection
+### Skip quality-tier selection
 
 ```text
-/execute-plan-sdlc --preset balanced
+/execute-plan-sdlc --quality balanced
 ```
 
-Claude applies the Balanced preset automatically and proceeds to execution after showing the wave structure — no interactive prompt.
+Claude applies the Balanced quality tier automatically and proceeds to execution after showing the wave structure — no interactive prompt.
 
 ### Resume after interruption
 

--- a/docs/skills/ship-sdlc.md
+++ b/docs/skills/ship-sdlc.md
@@ -29,7 +29,7 @@ This skill is for **expert users working on projects with established quality gu
 ## Usage
 
 ```text
-/ship-sdlc [--auto] [--skip <steps>] [--preset full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]
+/ship-sdlc [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]
 ```
 
 ---
@@ -39,8 +39,8 @@ This skill is for **expert users working on projects with established quality gu
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--auto` | Non-interactive mode. Forwards `--auto` to sub-skills that support it (commit-sdlc, version-sdlc, pr-sdlc). Pipeline still pauses at received-review-sdlc (intentionally interactive). | Off |
-| `--skip <steps>` | **Legacy CLI sugar.** Comma-separated list of steps to subtract from the resolved `steps[]`: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`. The persistent config field is `ship.steps[]` — `--skip` is parse-time sugar only. | None |
-| `--preset full\|balanced\|minimal` | **Legacy CLI sugar.** Expands to a canonical `steps[]` set: `full` = all six, `balanced` = all except `version`, `minimal` = `[execute, commit, pr]`. Legacy `A`/`B`/`C` aliases accepted. The persistent config field is `ship.steps[]`; ship synthesizes `--preset` for execute-plan-sdlc at the boundary. | `balanced` |
+| `--steps <csv>` | Comma-separated list of steps to run, fully replacing the resolved step list. Valid values: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`. The single source of truth for pipeline composition is `ship.steps[]` in `.sdlc/local.json`; CLI `--steps` is a one-shot override. | From config or built-in defaults |
+| `--quality <full\|balanced\|minimal>` | Forwarded to execute-plan-sdlc as `--quality` (model tier). Only forwarded when the user explicitly passes `--quality` to ship; otherwise execute-plan-sdlc applies its own selection. (Renamed from `--preset` in #190 to disambiguate from `--steps`.) | Not forwarded |
 | `--bump patch\|minor\|major` | Version bump type forwarded to version-sdlc. | `patch` |
 | `--draft` | Create the PR as a draft. | Off |
 | `--dry-run` | Display the full pipeline plan and stop. No steps are executed. | Off |
@@ -48,7 +48,11 @@ This skill is for **expert users working on projects with established quality gu
 | `--init-config` | Launch interactive config creation for `.sdlc/local.json`, then stop. No pipeline execution. | Off |
 | `--workspace branch\|worktree\|prompt` | Workspace isolation mode forwarded to execute-plan-sdlc. `branch` creates a feature branch, `worktree` creates a git worktree, `prompt` asks interactively. In worktree mode, the version step is auto-skipped (tags are repo-global) and `--label skip-version-check` is added to the PR step to bypass the CI version check. | `prompt` |
 | `--openspec-change <name>` | Explicitly select the OpenSpec change to archive, overriding branch-name matching. Used when the branch name does not match the change directory name. | — |
-| `--skip archive-openspec` | Skip the conditional archive-openspec step even when trigger conditions are met. | — |
+
+
+**Removed (#190 hard-remove):** `--preset` and `--skip` are no longer accepted. Passing either produces an error pointing at `--steps <csv>` (for step composition) and `--quality <full|balanced|minimal>` (for the execute-plan-sdlc model tier). Legacy on-disk v1 configs (`ship.preset`/`ship.skip`) are still auto-migrated to v2 by `lib/config.js`.
+
+To omit the `archive-openspec` step from a single run: `--steps <csv>` listing the desired steps without `archive-openspec`. Or omit it from `ship.steps[]` in `.sdlc/local.json` for a persistent change.
 
 ---
 
@@ -81,7 +85,8 @@ The pipeline runs 7 steps sequentially. Two steps are conditional on the review 
 Step 5a:       Step 5b:       Step 5c:
 execute-       commit-sdlc    review-sdlc
 plan-sdlc      (--auto if     (--committed)
-(--preset X)    auto mode)          |
+(--quality X    auto mode)          |
+ if forwarded)                      |
    |                |              |
    | git add -A     |    +---------+---------+
    +------->--------+    |                   |
@@ -132,14 +137,14 @@ plan-sdlc      (--auto if     (--committed)
 - **Staging gap**: execute-plan-sdlc creates files but does not stage them. The pipeline runs `git add -A -- ':!.sdlc/'` between execute and commit, excluding the `.sdlc/` runtime directory.
 - **Pipeline plan is binding**: Steps marked "will run" in the pipeline table must execute. Step statuses are computed by `ship-prepare.js` — the LLM follows them mechanically and cannot unilaterally skip planned steps.
 - **Agent-based dispatch**: Sub-skills are dispatched as Agents, not invoked via the Skill tool. Each Agent loads its sub-skill's SKILL.md in its own context and returns only a structured result (status, summary, artifacts). This keeps the ship pipeline's context clean — sub-skill definitions stay in the agent, not the orchestrator.
-- **Skip provenance (`skipSource`)**: Each step in the `ship-prepare.js` output includes a `skipSource` field tracking why it was skipped: `"none"` (not skipped), `"cli"` (user `--skip`), `"config"` (from `.sdlc/local.json`), `"auto"` (workspace rule), `"condition"` (precondition unmet), or `"default"` (unexpected — may indicate fabricated flags).
+- **Skip provenance (`skipSource`)**: Each step in the `ship-prepare.js` output includes a `skipSource` field tracking why it was skipped: `"none"` (not skipped), `"cli"` (omitted from CLI `--steps`), `"config"` (omitted from `ship.steps[]` in `.sdlc/local.json`), `"auto"` (workspace rule), `"condition"` (precondition unmet), or `"default"` (excluded by built-in defaults).
 - **Review threshold**: The severity that triggers the fix loop is configurable via `reviewThreshold` in config (default: `high`). At `high`, critical and high findings trigger fixes; medium and below are deferred to the summary.
 
 ---
 
 ## What Gets Printed
 
-The pipeline prints every decision and state change. Here is a realistic full output for a run with `--auto --preset balanced`:
+The pipeline prints every decision and state change. Here is a realistic full output for a run with `--auto --quality balanced`:
 
 ```
 I'm using the ship-sdlc skill.
@@ -181,7 +186,7 @@ Ship Pipeline
 --------------------------------------------------------------------
 Step  Skill                 Status       Args           Pause?
 --------------------------------------------------------------------
-1     execute-plan-sdlc     will run     --preset balanced  no
+1     execute-plan-sdlc     will run     --quality balanced no
 2     commit-sdlc           will run     --auto         no
 3     review-sdlc           will run     --committed    no
 4     received-review-sdlc  conditional  (if crit/high) YES
@@ -195,7 +200,7 @@ Interactive pauses: received-review (if triggered)
 Auto mode — proceeding without confirmation.
 
 ━━━ Ship Pipeline — Step 1/7: Execute ━━━
-  Invoking: /execute-plan-sdlc --preset balanced
+  Invoking: /execute-plan-sdlc --quality balanced
   Reason: plan detected in context, preset balanced from config
   Expectation: execute all plan tasks in waves
 
@@ -263,7 +268,7 @@ Step  Skill                 Result
 ================================================================
 
 Decisions log:
-  - Steps resolved: [execute, commit, review, pr, archive-openspec] (from config; synthesized --preset balanced for execute-plan-sdlc)
+  - Steps resolved: [execute, commit, review, pr, archive-openspec] (from config; --quality balanced forwarded to execute-plan-sdlc because user passed --quality)
   - Version step skipped (from config default, bump type: patch)
   - Review found 2 medium, 1 low issues — below threshold, deferred
   - PR created (from --auto flag)
@@ -292,7 +297,7 @@ Loads config (if present), detects context, presents the pipeline plan, and asks
 ### Full auto mode with preset
 
 ```text
-/ship-sdlc --auto --preset minimal
+/ship-sdlc --auto --quality minimal
 ```
 
 Runs the quality preset with no confirmation prompts except at received-review-sdlc (if triggered) and version-sdlc.
@@ -300,7 +305,7 @@ Runs the quality preset with no confirmation prompts except at received-review-s
 ### Dry run to preview the pipeline
 
 ```text
-/ship-sdlc --dry-run --skip version
+/ship-sdlc --dry-run --steps execute,commit,review,pr,archive-openspec
 ```
 
 Displays the full pipeline table showing which steps will run, which are skipped, and which flags are forwarded. No steps are executed.
@@ -308,7 +313,7 @@ Displays the full pipeline table showing which steps will run, which are skipped
 ### Skip execute and version
 
 ```text
-/ship-sdlc --skip execute,version
+/ship-sdlc --steps commit,review,pr,archive-openspec
 ```
 
 Useful when you've already implemented the changes manually and want to commit, review, and open a PR.
@@ -380,7 +385,9 @@ Any legacy `skip[]` entries are subtracted from the expanded set. To trigger the
 ### Merge precedence
 
 ```
-CLI flag (incl. --preset/--skip sugar)  >  .sdlc/local.json (ship.steps)  >  built-in defaults
+CLI --steps  >  .sdlc/local.json (ship.steps)  >  built-in defaults
+
+(Legacy CLI sugar `--preset` and `--skip` are hard-removed in #190; passing them produces an error.)
 ```
 
 ### Team-specific examples
@@ -510,7 +517,7 @@ Then run `/ship-sdlc` without `--resume` to start a new pipeline.
 
 | Field | Value |
 |---|---|
-| `argument-hint` | `[--auto] [--skip <steps>] [--preset full\|balanced\|minimal] [--draft] [--dry-run]` |
+| `argument-hint` | `[--auto] [--steps <csv>] [--quality full\|balanced\|minimal] [--draft] [--dry-run]` |
 | Plan mode | Graceful refusal (Step 0) |
 
 ---

--- a/docs/specs/execute-plan-sdlc.md
+++ b/docs/specs/execute-plan-sdlc.md
@@ -1,6 +1,6 @@
 # execute-plan-sdlc Specification
 
-> Orchestrate plan execution with adaptive task classification, wave-based parallel dispatch, preset-driven model assignment, PCIDCI critique loops, inter-wave context propagation, and automatic error recovery with state persistence for resume.
+> Orchestrate plan execution with adaptive task classification, wave-based parallel dispatch, quality-tier-driven model assignment, PCIDCI critique loops, inter-wave context propagation, and automatic error recovery with state persistence for resume.
 
 **User-invocable:** yes
 **Model:** opus
@@ -9,16 +9,16 @@
 ## Arguments
 
 - A1: plan file path — path to the plan file (positional; optional if plan is already in conversation context)
-- A2: `--preset full|balanced|minimal` — model assignment preset; skips interactive preset selection (default: interactive prompt)
+- A2: `--quality full|balanced|minimal` — model tier (quality preset); selects the model assignment mapping for dispatched agents and skips the interactive selection prompt (default: interactive prompt). Independent of ship-sdlc step selection (see `ship-sdlc.md` A2). When invoked from ship-sdlc, `--quality` is forwarded only when the user explicitly passed `--quality` to ship; otherwise execute-plan-sdlc applies its own selection logic.
 - A3: `--resume` — resume execution from a saved state file (default: false)
 - A4: `--workspace branch|worktree|prompt` — workspace isolation mode when on default branch (default: prompt)
 - A5: `--rebase auto|prompt|skip` — rebase onto default branch before execution (default: skip)
-- A6: `--auto` — suppress interactive prompts; auto-resume, auto-approve high-risk gates, use `--preset` value (default: false)
+- A6: `--auto` — suppress interactive prompts; auto-resume, auto-approve high-risk gates, use `--quality` value (default: false). When `--auto` is set, `--quality` is required.
 
 ## Core Requirements
 
 - R1: Classify each task by complexity (Trivial/Standard/Complex), risk (Low/Medium/High), and dependencies
-- R2: Model assignment per preset — Speed: haiku/haiku/sonnet; Balanced: haiku/sonnet/opus; Quality: sonnet/opus/opus
+- R2: Model assignment per quality tier — `full` (Speed): haiku/haiku/sonnet; `balanced` (Balanced): haiku/sonnet/opus; `minimal` (Quality): sonnet/opus/opus
 - R3: Build waves via topological sort of dependency DAG with same-file constraint (no two tasks modifying same file in one wave)
 - R4: Adaptive wave size cap: 1-3 tasks→no cap, 4-8→4, 9-15→5, 16+→6; complex tasks count as 2
 - R5: Small-plan direct execution for total tasks ≤3 AND all Trivial/Standard AND no high-risk — no wave orchestration, no state file
@@ -27,11 +27,11 @@
 - R8: Every agent prompt includes full task text (never a reference to the plan file), exact file list, expected deliverable, and prior-wave context
 - R9: Filesystem verification mandatory after each wave: `git diff --stat` confirms claimed changes; canary check greps for verification token
 - R10: Completion checklist parsing: cross-check `files_created`/`files_modified` against `git diff --stat`, verify STATUS field, handle NEEDS_CONTEXT and BLOCKED statuses
-- R11: Spec compliance review after each wave for non-trivial tasks (skip for Speed preset)
+- R11: Spec compliance review after each wave for non-trivial tasks (skip for Speed quality tier — `--quality full`)
 - R12: Inter-wave critique: detect when actual output differs from what downstream tasks assumed
 - R13: Maximum 2 retries per task; model escalation on failure (haiku→sonnet, sonnet→opus, opus→user)
 - R14: State persistence after every wave via `state/execute.js`; cleanup on success, preserve on failure for `--resume`
-- R15: Resume verifies plan hash; mismatch offers resume-with-existing or restart
+- R15: Resume verifies plan hash; mismatch offers resume-with-existing or restart. Persisted state file uses field name `quality` (not `preset`) for the model tier.
 - R16: Workspace isolation when on default branch: derive branch name or create worktree
 - R17: Pre-execution rebase when `--rebase auto`: fetch, check ancestor, attempt rebase, abort on conflict
 - R18: Execution guardrails: pre-wave (error-severity only) and post-wave (all severities); error violations block, warning violations report only
@@ -56,10 +56,10 @@
 2. CLASSIFY — classify each task (complexity, risk, model); build dependency DAG and wave structure
 3. ROUTE — small-plan direct execution (≤3 tasks) or standard wave execution
 4. CRITIQUE — critique wave structure (file conflicts, dependencies, risk clustering, trivial aggregation)
-5. IMPROVE — fix critique issues; present final wave structure with preset (auto-selected or interactive)
+5. IMPROVE — fix critique issues; present final wave structure with quality tier (auto-selected via `--quality` or interactive)
 6. DO — execute waves sequentially: pre-wave guardrail check → high-risk gate → dispatch agents → collect and verify → spec compliance review → post-wave guardrails → progress report → inter-wave critique → state persistence
    - **Script:** `state/execute.js` (per-wave lifecycle)
-   - **Params:** subcommands: `init --branch --preset --total-tasks` (first wave), `wave-start --wave N`, `task-done/task-fail --wave --task --name --complexity --risk --files-changed`, `wave-done/wave-fail --wave N`, `context --data '<json>'`
+   - **Params:** subcommands: `init --branch --quality --total-tasks` (first wave), `wave-start --wave N`, `task-done/task-fail --wave --task --name --complexity --risk --files-changed`, `wave-done/wave-fail --wave N`, `context --data '<json>'`
    - **Output:** JSON state object persisted to `.sdlc/execution/execute-<branch>-<timestamp>.json` after each wave
 7. RECOVER — error recovery per failure type (model escalation, conflict resolution, inline fix, user escalation)
 8. VERIFY — final verification: full test suite, build, lint, `git diff --stat`
@@ -73,13 +73,13 @@
 
 - G1: Plan validated — no blocking validation issues (≥2 tasks, no cycles, clear deliverables)
 - G2: Wave structure critiqued — all file conflicts and dependency issues resolved
-- G3: User approved — preset selected or custom editing completed
+- G3: User approved — quality tier selected (`--quality` or interactive) or custom editing completed
 - G4: All tasks completed — no tasks skipped without user consent
 - G5: Per-wave verification — `git diff --stat` confirms changes, tests/build/lint pass
 - G6: Final verification — full suite green
 - G7: No drift — tasks match their specifications
 - G8: No orphans — all created files are referenced/used
-- G9: Spec compliance reviewed — non-trivial waves pass spec review (unless Speed preset)
+- G9: Spec compliance reviewed — non-trivial waves pass spec review (unless Speed quality tier `--quality full`)
 - G10: Pre-wave guardrail check — error-severity guardrails pass or user overrides
 - G11: Post-wave guardrail check — error-severity pass/fixed/overridden; warnings reported
 - G12: Completion checklists valid — each agent's COMPLETE/VERIFY/STATUS block present and cross-checked

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -9,8 +9,8 @@
 ## Arguments
 
 - A1: `--auto` — run pipeline non-interactively; forwarded to sub-skills that support it (default: false)
-- A2: `--skip <steps>` — comma-separated steps to skip; valid: execute, commit, review, received-review, commit-fixes, version, pr (default: from config or none)
-- A3: `--preset full|balanced|minimal` — execution preset forwarded to execute-plan-sdlc (default: from config or balanced)
+- A2: `--steps <csv>` — comma-separated steps to run; valid: execute, commit, review, received-review, commit-fixes, version, pr, archive-openspec. When passed, fully replaces the resolved step list (config `ship.steps[]` and built-in defaults are ignored). The single source of truth for pipeline composition is config `ship.steps[]`; CLI `--steps` is a one-shot override.
+- A3: `--quality full|balanced|minimal` — execution quality (model tier) forwarded to execute-plan-sdlc; only forwarded when explicitly passed via CLI (default: not forwarded; execute-plan-sdlc applies its own selection)
 - A4: `--bump patch|minor|major` — version bump type forwarded to version-sdlc (default: from config or patch)
 - A5: `--draft` — create PR as draft (default: from config or false)
 - A6: `--dry-run` — display pipeline plan without executing (default: false)
@@ -47,21 +47,21 @@
 - R23: Trigger conditions for `archive-openspec` (all must hold): `openspec/config.yaml` exists; an active non-archived change matches the current branch (`openspec.branchMatch`) OR `--openspec-change <name>` is passed; prior steps completed without halting.
 - R24: The `archive-openspec` step calls `openspec validate <name> --strict` via `lib/openspec.js::validateChangeStrict`; on failure, halts the pipeline and surfaces validation output.
 - R25: On validation success: prompts the user (non-interactive in `--auto`); on approval (or `--auto`), runs `openspec archive <name> --yes` via `lib/openspec.js::runArchive`, then creates a commit `chore(openspec): archive <name>`.
-- R26: `--skip archive-openspec` disables the step. The value is added to `VALID_SKIP` in `ship-fields.js`.
+- R26: To disable the `archive-openspec` step, omit it from `ship.steps[]` in config or from CLI `--steps`. The value `archive-openspec` is recognized in `VALID_STEPS` (`lib/ship-fields.js`).
 - R27: The step is idempotent — if `lib/openspec.js::isArchived(projectRoot, changeName)` returns true, the step is skipped with reason "already archived".
 - R28: `--openspec-change <name>` flag explicitly selects the change to archive, overriding branch matching.
-- R29: The ship config schema MUST NOT contain a `preset` field. The decorative `preset` (`full|balanced|minimal`) is replaced by an explicit `steps[]` list in `.sdlc/local.json`. CLI flag `--preset <X>` is preserved as legacy sugar that expands to `steps[]` at parse time; it is never persisted as `preset` in the config file.
-  - Acceptance: `schemas/sdlc-local.schema.json` `shipSection` contains no `preset` property; `lib/ship-fields.js` `SHIP_FIELDS` contains no `preset` field; `BUILT_IN_DEFAULTS` contains no `preset` key.
-- R30: The ship config schema MUST NOT contain a `skip` field. The single source of truth for which steps run is `steps[]`; CLI flag `--skip <step,…>` is preserved as legacy sugar that subtracts from the resolved `steps[]` at parse time. It is never persisted in the config file.
-  - Acceptance: `schemas/sdlc-local.schema.json` `shipSection` contains no `skip` property; `lib/ship-fields.js` `SHIP_FIELDS` contains no `skip` field; `BUILT_IN_DEFAULTS` contains no `skip` key.
+- R29: The ship config schema MUST NOT contain a `preset` field. The decorative `preset` (`full|balanced|minimal`) is replaced by an explicit `steps[]` list in `.sdlc/local.json`. CLI flag `--preset` is hard-removed: passing `--preset` to ship-sdlc produces a clear error pointing the user at `--steps <csv>`. Migration of legacy on-disk v1 configs (with `ship.preset`) continues to be handled by `lib/config.js` v1→v2 migration (R32).
+  - Acceptance: `schemas/sdlc-local.schema.json` `shipSection` contains no `preset` property; `lib/ship-fields.js` `SHIP_FIELDS` contains no `preset` field; `BUILT_IN_DEFAULTS` contains no `preset` key; `skill/ship.js parseArgs` rejects `--preset` with an error written to `errors[]`.
+- R30: The ship config schema MUST NOT contain a `skip` field. The single source of truth for which steps run is `steps[]`. CLI flag `--skip` is hard-removed: passing `--skip` to ship-sdlc produces a clear error pointing the user at `--steps <csv>`. Migration of legacy on-disk v1 configs (with `ship.skip`) continues to be handled by `lib/config.js` v1→v2 migration (R32).
+  - Acceptance: `schemas/sdlc-local.schema.json` `shipSection` contains no `skip` property; `lib/ship-fields.js` `SHIP_FIELDS` contains no `skip` field; `BUILT_IN_DEFAULTS` contains no `skip` key; `skill/ship.js parseArgs` rejects `--skip` with an error written to `errors[]`.
 - R31: Top-level local config files (`.sdlc/local.json`) MUST carry an integer `version` field. Current schema version is `2`. The schema declares `"version": {"type": "integer", "const": 2}` at the top level. Files lacking `version` are treated as v1 and auto-migrated on read.
   - Acceptance: `schemas/sdlc-local.schema.json` declares top-level `version` with `const: 2`; new configs written via `writeLocalConfig`/`util/ship-init.js` include `version: 2` at the top level (not nested in `ship`).
 - R32: `lib/config.js::readLocalConfig` MUST auto-migrate v1 → v2 on read. Migration steps: (a) expand legacy `ship.preset` to `steps[]` via `PRESET_TO_STEPS` (full/balanced/minimal and legacy A/B/C aliases); (b) subtract any legacy `ship.skip[]` members from the expanded steps; (c) delete `ship.preset` and `ship.skip` from the in-memory object; (d) set `ship.steps = <result>` and top-level `version: 2`; (e) persist the migrated config back atomically; (f) emit a single stderr deprecation notice on first migration. Migration MUST be idempotent — reading a v2 config does not rewrite or re-emit. The `migrateConfig` (--migrate) flow also triggers the v1→v2 ship migration.
   - Acceptance: passing `{$schema, ship:{preset:"balanced", skip:[]}}` (no version) to `readLocalConfig` returns `{version:2, ship:{steps:[execute,commit,review,pr,archive-openspec], …}}` and rewrites disk; passing the migrated result back to `readLocalConfig` returns identical content with no disk write and no second notice.
 - R33: The setup-sdlc questionnaire (`shipFields` from `lib/ship-fields.js`) MUST emit a `steps` field (multi-select; options enumerate the six canonical steps `execute, commit, review, version, pr, archive-openspec`; default = all six). It MUST NOT emit `preset` or `skip` fields. `util/ship-init.js` MUST consume `--steps <csv>` (validated against `VALID_STEPS`) and write a config whose top level carries `version: 2`. The `--preset` flag MUST be removed from `ship-init.js` and rejected with a clear migration-pointer error if passed.
   - Acceptance: `SHIP_FIELDS[0].name === 'steps'`; `ship-init.js --steps execute,commit,pr` produces a `.sdlc/local.json` whose top level has `version: 2` and `ship.steps: ["execute","commit","pr"]`, no `preset`/`skip` keys.
-- R34: When no ship config exists and no `--steps`/`--preset` flags are passed, the synthesized preset MUST be `balanced` (excludes the `version` step). `BUILT_IN_DEFAULTS.steps` in `ship-fields.js` MUST equal `PRESET_TO_STEPS.balanced` (`['execute','commit','review','pr','archive-openspec']`). Note: `SHIP_FIELDS[0].default` intentionally diverges (all six canonical steps) — this is the broader questionnaire default so users see all choices; it does not affect runtime behavior.
-  - Acceptance: running `skill/ship.js --has-plan` with no `.sdlc/local.json` produces `flags.preset === 'balanced'` and `flags.steps === ['execute','commit','review','pr','archive-openspec']`.
+- R34: When no ship config exists and no `--steps` flag is passed, `BUILT_IN_DEFAULTS.steps` in `ship-fields.js` MUST equal `['execute','commit','review','pr','archive-openspec']` (excludes the `version` step). The resolved `flags.steps` mirrors that array. Note: `SHIP_FIELDS[0].default` intentionally diverges (all six canonical steps) — this is the broader questionnaire default so users see all choices; it does not affect runtime behavior.
+  - Acceptance: running `skill/ship.js --has-plan` with no `.sdlc/local.json` produces `flags.steps === ['execute','commit','review','pr','archive-openspec']` and contains no `flags.preset` field at the top level.
 - R35: Step 1 (pre-flight handoff) MUST emit a context-heaviness advisory when the latest transcript stats sidecar at `$TMPDIR/sdlc-context-stats.json` indicates `heavy: true` (transcript ≥60% of model budget). The advisory recommends `/compact` and notes that pipeline state survives compaction. When the sidecar is absent or `heavy: false`, no advisory is emitted. Implementation lives in `scripts/lib/context-advisory.js` and is appended to `skill/ship.js` PREPARE_OUTPUT_FILE so it surfaces before the pipeline begins. (Rationale: #173.)
   - Acceptance: with a sidecar containing `heavy: true`, the advisory text appears in `skill/ship.js --dry-run` output; with `heavy: false` or no sidecar, the output contains no advisory.
 
@@ -69,7 +69,7 @@
 
 1. CONSUME — load config, parse flags, run `skill/ship.js` for context detection and step computation
    - **Script:** `skill/ship.js`
-   - **Params:** A1-A8 forwarded (`--auto`, `--skip <csv>`, `--preset`, `--bump`, `--draft`, `--resume`, `--workspace`); internal: `--has-plan` (from plan context detection)
+   - **Params:** A1-A8 forwarded (`--auto`, `--steps <csv>`, `--quality`, `--bump`, `--draft`, `--resume`, `--workspace`); internal: `--has-plan` (from plan context detection). `--quality` is forwarded to execute-plan-sdlc only when explicitly passed; cross-reference: see `execute-plan-sdlc.md` A2.
    - **Output:** JSON → P1-P6 (flags with per-flag provenance sources, resume detection, context with branch/auth/openspec/worktree, pipeline steps with status/reason/skipSource/invocation, config)
 2. PLAN — build pipeline table from `skill/ship.js` steps array; display flag resolution and auto-skip decisions
 3. CRITIQUE — validate pipeline: gh auth, branch safety, skip values, flag coherence
@@ -86,7 +86,7 @@
 
 - G1: `gh` CLI authenticated — `gh auth status` succeeds
 - G2: Not on default branch — warn if on main/master (do not block)
-- G3: Skip values valid — all `--skip` values are recognized step names
+- G3: Step values valid — all CLI `--steps` values are recognized step names (`VALID_STEPS` from `lib/ship-fields.js`)
 - G4: At least one step will run — pipeline is not entirely skipped
 - G5: Flag coherence — `--bump` without version step produces error (exit code 1, blocking)
 - G6: Pipeline contract — every `will_run` step was dispatched as Agent
@@ -127,7 +127,7 @@
 - C7: Must not proceed past a failed sub-skill — stop, save state, inform user
 - C8: Must not skip steps marked `will_run` in the pipeline plan — the plan is a binding contract
 - C9: Must not copy example args from SKILL.md — use `step.invocation` from skill/ship.js
-- C10: Must not add `--skip` flags not present in user invocation or ship config
+- C10: Must not add `--steps` flags not present in user invocation; pipeline composition derives from CLI `--steps` > config `ship.steps[]` > `BUILT_IN_DEFAULTS.steps`
 - C11: Must not skip, bypass, or defer prepare script execution — the script must run and exit successfully before any skill phase begins
 - C12: Must not override, reinterpret, or discard prepare script output — for every P-field, the script return value is authoritative and final; the skill must not substitute LLM-generated alternatives
 - C13: Must not independently compute, infer, or fabricate values for any field the prepare script is contracted to provide — if the script fails or a field is absent, the skill must stop rather than fill in data

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.32",
+  "version": "0.17.33",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -12,13 +12,17 @@
  * Options:
  *   --has-plan              Plan is present in conversation context
  *   --auto                  Skip interactive approval prompts
- *   --skip <csv>            Comma-separated steps to skip
- *   --preset full|balanced|minimal  Pipeline preset (legacy A|B|C accepted)
+ *   --steps <csv>           Comma-separated steps to run (overrides config)
+ *   --quality full|balanced|minimal  Forwarded to execute-plan-sdlc as --quality (only when explicitly passed)
  *   --bump patch|minor|major  Version bump type
  *   --draft                 Mark PR as draft
  *   --dry-run               Print plan without executing
  *   --resume                Resume from last checkpoint
  *   --workspace branch|worktree|prompt  Workspace isolation mode
+ *
+ * Removed (legacy CLI sugar — passing these now produces a hard error):
+ *   --preset                Use --steps <csv> instead.
+ *   --skip                  Use --steps <csv> with the desired steps listed instead.
  *
  * Exit codes:
  *   0 = success, JSON on stdout
@@ -36,40 +40,13 @@ const LIB = path.join(__dirname, '..', 'lib');
 
 const { exec, checkGitState, detectBaseBranch } = require(path.join(LIB, 'git'));
 const { resolveMainWorktree } = require(path.join(LIB, 'state'));
-const { readSection, normalizePreset, PRESET_TO_STEPS } = require(path.join(LIB, 'config'));
+const { readSection } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
-const { VALID_SKIP, VALID_STEPS, BUILT_IN_DEFAULTS, CANONICAL_STEPS } = require(path.join(LIB, 'ship-fields'));
+const { VALID_STEPS, BUILT_IN_DEFAULTS, CANONICAL_STEPS } = require(path.join(LIB, 'ship-fields'));
 const { detectActiveChanges, isArchived } = require(path.join(LIB, 'openspec'));
 const { getAdvisory } = require(path.join(LIB, 'context-advisory'));
 
-/**
- * Reverse-map the resolved steps[] back to the nearest canonical preset
- * (`full`, `balanced`, or `minimal`). Used solely to synthesize a `--preset`
- * argument for execute-plan-sdlc, which still requires one for state init.
- *
- * Exact set match wins. Non-canonical step combinations fall back to `full`
- * — execute-plan-sdlc's preset is decorative for state seeding only; the
- * actual pipeline shape is controlled by ship's resolved steps[].
- *
- * Compatibility seam tied to issue #180: decoupling execute-plan-sdlc from
- * --preset is explicitly out of scope.
- *
- * @param {string[]} steps  Resolved step list
- * @returns {'full'|'balanced'|'minimal'}
- */
-function stepsToPreset(steps) {
-  if (!Array.isArray(steps)) return 'full';
-  const set = new Set(steps);
-  const eq = (canonical) => {
-    if (set.size !== canonical.length) return false;
-    for (const s of canonical) if (!set.has(s)) return false;
-    return true;
-  };
-  if (eq(PRESET_TO_STEPS.full))     return 'full';
-  if (eq(PRESET_TO_STEPS.balanced)) return 'balanced';
-  if (eq(PRESET_TO_STEPS.minimal))  return 'minimal';
-  return 'full';
-}
+const VALID_QUALITY = ['full', 'balanced', 'minimal'];
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -79,8 +56,8 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   let hasPlan   = false;
   let auto      = false;
-  let skip      = null;
-  let preset    = null;
+  let steps     = null;
+  let quality   = null;
   let bump      = null;
   let draft     = false;
   let dryRun    = false;
@@ -88,6 +65,7 @@ function parseArgs(argv) {
   let workspace       = null;
   let rebase          = null;
   let openspecChange  = null;
+  const errors = [];
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -95,10 +73,18 @@ function parseArgs(argv) {
       hasPlan = true;
     } else if (a === '--auto') {
       auto = true;
-    } else if (a === '--skip' && args[i + 1]) {
-      skip = args[++i].split(',').map(s => s.trim()).filter(Boolean);
-    } else if (a === '--preset' && args[i + 1]) {
-      preset = args[++i];
+    } else if (a === '--steps' && args[i + 1]) {
+      steps = args[++i].split(',').map(s => s.trim()).filter(Boolean);
+    } else if (a === '--quality' && args[i + 1]) {
+      quality = args[++i];
+    } else if (a === '--preset') {
+      // Hard-removed: --preset is no longer accepted (#190). Consume the
+      // following value (if any) so it doesn't get parsed as a positional.
+      if (args[i + 1] && !args[i + 1].startsWith('--')) i++;
+      errors.push('--preset is no longer accepted by ship-sdlc. Use --steps <csv> to control which steps run, or --quality <full|balanced|minimal> to set the model tier forwarded to execute-plan-sdlc.');
+    } else if (a === '--skip') {
+      if (args[i + 1] && !args[i + 1].startsWith('--')) i++;
+      errors.push('--skip is no longer accepted by ship-sdlc. Use --steps <csv> with the desired steps listed instead.');
     } else if (a === '--bump' && args[i + 1]) {
       bump = args[++i];
     } else if (a === '--draft') {
@@ -116,7 +102,7 @@ function parseArgs(argv) {
     }
   }
 
-  return { hasPlan, auto, skip, preset, bump, draft, dryRun, resume, workspace, rebase, openspecChange };
+  return { hasPlan, auto, steps, quality, bump, draft, dryRun, resume, workspace, rebase, openspecChange, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -164,8 +150,7 @@ function mergeFlags(cli, config) {
     }
   }
 
-  // Value flags (no preset here — preset is legacy CLI sugar that expands to
-  // steps[]; synthesized from steps[] later for execute-plan-sdlc forwarding).
+  // Value flags
   for (const key of ['bump', 'workspace']) {
     if (cli[key] !== null && cli[key] !== undefined) {
       merged[key]  = cli[key];
@@ -179,23 +164,20 @@ function mergeFlags(cli, config) {
     }
   }
 
-  // -- Step resolution (replaces preset/skip as the canonical source) --
+  // -- Step resolution --
   //
-  // Resolution order:
-  //   1. config.steps (from .sdlc/local.json — already migrated to v2 by lib/config.js)
-  //   2. BUILT_IN_DEFAULTS.steps (all six canonical steps)
+  // Single source of truth: `ship.steps[]`. Resolution order:
+  //   1. CLI --steps (one-shot override; fully replaces resolved list)
+  //   2. config.steps from .sdlc/local.json
+  //   3. BUILT_IN_DEFAULTS.steps
   //
-  // CLI overrides applied in order:
-  //   3. --preset <X>: legacy sugar — expands to canonical PRESET_TO_STEPS[X]
-  //      and OVERRIDES the resolved steps[] entirely.
-  //   4. --skip <a,b>: legacy sugar — subtracts the named steps from the
-  //      currently resolved steps[].
-  //
-  // The persistent config field is `ship.steps[]`. CLI `--preset` and
-  // `--skip` are not persisted — they're parse-time sugar only.
+  // No --preset/--skip override paths exist (#190 — hard-removed).
   let stepsList;
   let stepsSource;
-  if (Array.isArray(cfg.steps)) {
+  if (Array.isArray(cli.steps) && cli.steps.length > 0) {
+    stepsList   = cli.steps.slice();
+    stepsSource = 'cli';
+  } else if (Array.isArray(cfg.steps)) {
     stepsList   = cfg.steps.slice();
     stepsSource = 'config';
   } else {
@@ -203,43 +185,19 @@ function mergeFlags(cli, config) {
     stepsSource = 'default';
   }
 
-  // CLI --preset (legacy sugar) — full override
-  let cliPreset = null;
-  if (cli.preset !== null && cli.preset !== undefined) {
-    cliPreset = normalizePreset(cli.preset);
-    if (PRESET_TO_STEPS[cliPreset]) {
-      stepsList   = PRESET_TO_STEPS[cliPreset].slice();
-      stepsSource = 'cli (preset)';
-    }
+  merged.steps  = stepsList;
+  sources.steps = stepsSource;
+
+  // -- Quality (model tier forwarded to execute-plan-sdlc) --
+  //
+  // Only emitted when CLI explicitly passed --quality. When absent, ship does
+  // not forward the flag and execute-plan-sdlc applies its own selection
+  // logic (interactive prompt or its own config default).
+  if (cli.quality !== null && cli.quality !== undefined) {
+    merged.quality  = cli.quality;
+    sources.quality = 'cli';
   }
-
-  // CLI --skip (legacy sugar) — subtraction
-  if (Array.isArray(cli.skip) && cli.skip.length > 0) {
-    const skipSet = new Set(cli.skip);
-    stepsList = stepsList.filter(s => !skipSet.has(s));
-    stepsSource = stepsSource + ' (cli --skip)';
-  }
-
-  merged.steps    = stepsList;
-  sources.steps   = stepsSource;
-
-  // skip stays in the merged object purely as the subtraction list users
-  // supplied on the CLI — surfaced for validation (unrecognized values) and
-  // diagnostic output. It is NOT a source of truth for which steps run.
-  merged.skip   = Array.isArray(cli.skip) ? cli.skip : [];
-  sources.skip  = Array.isArray(cli.skip) && cli.skip.length > 0 ? 'cli' : 'none';
-
-  // Synthesize preset from resolved steps[] for execute-plan-sdlc forwarding.
-  // CLI --preset (if passed) takes precedence as the synthesized value, since
-  // the user's explicit choice is more informative than a reverse-mapped
-  // approximation. Otherwise reverse-map from steps[].
-  if (cliPreset && ['full', 'balanced', 'minimal'].includes(cliPreset)) {
-    merged.preset = cliPreset;
-    sources.preset = 'cli';
-  } else {
-    merged.preset = stepsToPreset(stepsList);
-    sources.preset = 'synthesized';
-  }
+  // Otherwise: no merged.quality / no sources.quality — intentionally absent.
 
   // reviewThreshold: not a CLI flag, comes from config or default.
   if (cfg.reviewThreshold !== undefined) {
@@ -286,25 +244,18 @@ function mergeFlags(cli, config) {
 
 function computeSteps(flags, flagSources, { openspecContext } = {}) {
   // Steps[] is the canonical source of truth for which top-level steps run.
-  // A step IS skipped when it is NOT in flags.steps. The legacy `skip[]`
-  // semantics are now derived: a step is "skipped" iff it's missing from
-  // flags.steps; the original skip provenance is whatever determined the
-  // resolved steps[] (config / cli --preset / cli --skip).
+  // A step IS skipped when it is NOT in flags.steps. The provenance for an
+  // exclusion is whatever determined the resolved steps[] (cli --steps /
+  // config / built-in default).
   const stepsSet = new Set(Array.isArray(flags.steps) ? flags.steps : []);
-  const skipSetCli = new Set(Array.isArray(flags.skip) ? flags.skip : []);
 
   // Derive the skipSource for a given step name. Convention preserved for
   // downstream consumers (state files, hooks, learnings).
   function skipSource(name) {
     if (stepsSet.has(name)) return 'none';
-    // CLI --skip explicitly excluded this step
-    if (skipSetCli.has(name)) return 'cli';
-    // The resolved steps[] came from config (or default) and doesn't include
-    // this step. Treat as 'config' if config provided a steps[]; otherwise
-    // 'default' (built-in default — would only happen for an unknown step).
     const src = flagSources && flagSources.steps;
-    if (src && src.startsWith('config')) return 'config';
-    if (src && src.startsWith('cli'))    return 'cli';
+    if (src === 'cli')    return 'cli';
+    if (src === 'config') return 'config';
     return 'default';
   }
 
@@ -322,10 +273,10 @@ function computeSteps(flags, flagSources, { openspecContext } = {}) {
           ? 'condition'
           : skipSource('execute'),
       args: [
-        // Forward synthesized preset to execute-plan-sdlc (compatibility seam
-        // — execute-plan-sdlc still requires --preset for state init; see
-        // stepsToPreset() comment above).
-        flags.preset ? `--preset ${flags.preset}` : '',
+        // Forward --quality to execute-plan-sdlc only when the user
+        // explicitly passed --quality to ship. Otherwise execute-plan-sdlc
+        // applies its own selection logic (interactive or its own default).
+        flags.quality ? `--quality ${flags.quality}` : '',
         flags.workspace !== 'prompt' ? `--workspace ${flags.workspace}` : '',
         flags.rebase !== 'prompt' ? `--rebase ${flags.rebase}` : '',
       ].filter(Boolean).join(' '),
@@ -521,29 +472,26 @@ function runValidation(flags, flagSources, steps, context) {
     warnings.push(`You are on the default branch "${context.defaultBranch}". Ship pipelines should run on feature branches.`);
   }
 
-  // All --skip values must be recognized (legacy CLI sugar; subtraction list)
-  let skipValuesRecognized = true;
-  for (const s of flags.skip) {
-    if (!VALID_STEPS.includes(s)) {
-      warnings.push(`Unrecognized skip value "${s}". Valid values: ${VALID_STEPS.join(', ')}`);
-      skipValuesRecognized = false;
-    }
-  }
-
-  // All steps[] values must be recognized
+  // All steps[] values must be recognized; CLI --steps unrecognized values
+  // are errors (the user passed something invalid). Config-sourced unknowns
+  // remain warnings to avoid breaking pre-existing configs that drift.
+  let stepValuesRecognized = true;
   if (Array.isArray(flags.steps)) {
     for (const s of flags.steps) {
       if (!VALID_STEPS.includes(s)) {
-        warnings.push(`Unrecognized step "${s}" in steps[]. Valid values: ${VALID_STEPS.join(', ')}`);
+        if (flagSources.steps === 'cli') {
+          errors.push(`Unrecognized step "${s}" in --steps. Valid values: ${VALID_STEPS.join(', ')}`);
+          stepValuesRecognized = false;
+        } else {
+          warnings.push(`Unrecognized step "${s}" in steps[]. Valid values: ${VALID_STEPS.join(', ')}`);
+        }
       }
     }
   }
 
-  // Fabrication guard: --skip values present but source is 'none' would
-  // indicate the LLM hallucinated --skip arguments that were never actually
-  // passed. (skip source is 'cli' when --skip was passed, 'none' otherwise.)
-  if (flags.skip.length > 0 && flagSources.skip === 'none') {
-    errors.push("Skip flags present but source is 'none' — likely fabricated. Remove --skip or pass explicitly via CLI.");
+  // Validate --quality value when forwarded
+  if (flags.quality !== undefined && !VALID_QUALITY.includes(flags.quality)) {
+    errors.push(`Invalid --quality "${flags.quality}". Valid values: ${VALID_QUALITY.join(', ')}`);
   }
 
   // At least one non-conditional step must run (conditional steps only
@@ -569,7 +517,7 @@ function runValidation(flags, flagSources, steps, context) {
   return {
     ghAuth: context.ghAuthenticated,
     notOnDefault,
-    skipValuesRecognized,
+    stepValuesRecognized,
     atLeastOneStepRuns,
     coherentFlags,
     warnings,
@@ -634,6 +582,11 @@ function main() {
 
   const errors   = [];
   const warnings = [];
+
+  // Surface argument-parsing errors first (legacy --preset/--skip rejection).
+  if (Array.isArray(cli.errors) && cli.errors.length > 0) {
+    errors.push(...cli.errors);
+  }
 
   // Load config
   const { config: fileConfig, source: configSource } = loadConfig(projectRoot);
@@ -764,8 +717,11 @@ function main() {
     flags: {
       auto: flags.auto,
       steps: flags.steps,
-      preset: flags.preset, // synthesized for execute-plan-sdlc forwarding
-      skip: flags.skip,     // legacy CLI subtraction list (diagnostic only)
+      // quality is included only when explicitly passed via CLI (forwarded to
+      // execute-plan-sdlc as --quality); absent otherwise so downstream
+      // consumers can rely on `flags.quality === undefined` to detect "user
+      // did not specify".
+      ...(flags.quality !== undefined ? { quality: flags.quality } : {}),
       bump: flags.bump,
       draft: flags.draft,
       dryRun: flags.dryRun,
@@ -781,7 +737,7 @@ function main() {
     validation: {
       ghAuth: validation.ghAuth,
       notOnDefault: validation.notOnDefault,
-      skipValuesRecognized: validation.skipValuesRecognized,
+      stepValuesRecognized: validation.stepValuesRecognized,
       atLeastOneStepRuns: validation.atLeastOneStepRuns,
       coherentFlags: validation.coherentFlags,
       warnings: validation.warnings,

--- a/plugins/sdlc-utilities/scripts/state/execute.js
+++ b/plugins/sdlc-utilities/scripts/state/execute.js
@@ -5,7 +5,7 @@
  * Delegates all I/O to lib/state.js; zero npm dependencies.
  *
  * Usage:
- *   node execute-state.js init        --branch <b> --preset <X> --total-tasks <n> [--plan-path <p>] [--plan-hash <h>]
+ *   node execute-state.js init        --branch <b> --quality <X> --total-tasks <n> [--plan-path <p>] [--plan-hash <h>]
  *   node execute-state.js wave-start  --wave <n>
  *   node execute-state.js wave-done   --wave <n>
  *   node execute-state.js wave-fail   --wave <n>
@@ -40,8 +40,15 @@ function parseArgs(argv) {
     const a = args[i];
     if (a === '--branch' && args[i + 1]) {
       result.branch = args[++i];
-    } else if (a === '--preset' && args[i + 1]) {
-      result.preset = args[++i];
+    } else if (a === '--quality' && args[i + 1]) {
+      result.quality = args[++i];
+    } else if (a === '--preset') {
+      // Hard-removed (#190): --preset renamed to --quality. Consume the
+      // following value (if any) and surface a clear error so callers update
+      // their invocations. The error is written to stderr and exits non-zero;
+      // the orchestrator surfaces it in the agent prompt.
+      if (args[i + 1] && !args[i + 1].startsWith('--')) i++;
+      result._presetRejected = true;
     } else if (a === '--total-tasks' && args[i + 1]) {
       const val = parseInt(args[++i], 10);
       if (isNaN(val)) { process.stderr.write(`Error: --total-tasks requires a number, got "${args[i]}"\n`); process.exit(2); }
@@ -136,12 +143,16 @@ function deepMerge(target, source) {
 // ---------------------------------------------------------------------------
 
 function cmdInit(opts) {
+  if (opts._presetRejected) {
+    process.stderr.write('Error: --preset is no longer accepted by execute-plan-sdlc state init. Use --quality <full|balanced|minimal> instead (#190).\n');
+    process.exit(2);
+  }
   if (!opts.branch) {
     process.stderr.write('Error: --branch is required for init\n');
     process.exit(2);
   }
-  if (!opts.preset) {
-    process.stderr.write('Error: --preset is required for init\n');
+  if (!opts.quality) {
+    process.stderr.write('Error: --quality is required for init (--preset was renamed to --quality, #190)\n');
     process.exit(2);
   }
   if (opts.totalTasks == null || isNaN(opts.totalTasks)) {
@@ -156,7 +167,7 @@ function cmdInit(opts) {
     branch: opts.branch,
     planPath: opts.planPath || null,
     planHash: opts.planHash || null,
-    preset: opts.preset,
+    quality: opts.quality,
     totalTasks: opts.totalTasks,
     waves: [],
     context: {},

--- a/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
@@ -2,7 +2,7 @@
 name: execute-plan-sdlc
 description: "Use when the user wants to execute an implementation plan with adaptive intelligence — classifies tasks by complexity and risk, builds optimized dependency waves, critiques wave structure before dispatch, verifies results after each wave, and recovers from failures without stopping. Self-contained: no external sub-skills required. Triggers on: execute plan, run plan, implement plan, autonomous execution, execute this plan. Also auto-triggered when the user accepts a plan from plan-sdlc (plan content is already in conversation context)."
 user-invocable: true
-argument-hint: "[plan-file-path] [--preset full|balanced|minimal] [--resume] [--workspace branch|worktree|prompt] [--rebase auto|skip|prompt] [--auto]"
+argument-hint: "[plan-file-path] [--quality full|balanced|minimal] [--resume] [--workspace branch|worktree|prompt] [--rebase auto|skip|prompt] [--auto]"
 ---
 
 # Execute Plan (SDLC)
@@ -84,7 +84,7 @@ Note: this reads `execute.guardrails` (runtime enforcement), not `plan.guardrail
      Options: **resume** | **restart**
      If "restart", delete the state file and proceed to plan loading below.
   5. Load the `context` object: use `completedTaskIds` to identify remaining tasks, `filesAdded`/`filesModified` for filesystem awareness, `interfacesCreated` and `decisionsFromPriorWaves` for agent prompt context.
-  6. Load the `preset` from the state file (CLI `--preset` overrides if provided).
+  6. Load the `quality` from the state file (CLI `--quality` overrides if provided).
   7. Skip to Step 5, resuming from the first wave with status `in_progress` or `pending`. Use the context object to construct inter-wave context for the next wave's agent prompts.
 
 - If `--resume` was NOT passed but a state file exists for the current branch:
@@ -94,7 +94,7 @@ Note: this reads `execute.guardrails` (runtime enforcement), not `plan.guardrail
     Options: **yes** — resume | **restart** — discard state file and start fresh
     If "yes", follow the resume flow above (steps 2-7). If "restart", delete the state file and proceed normally.
 
-**Parse `--auto`:** If `--auto` was passed, store the flag. Auto mode suppresses interactive prompts: resume detection auto-resumes if state exists, high-risk gates auto-approve, and preset selection uses the value from `--preset` (required when `--auto` is set).
+**Parse `--auto`:** If `--auto` was passed, store the flag. Auto mode suppresses interactive prompts: resume detection auto-resumes if state exists, high-risk gates auto-approve, and quality-tier selection uses the value from `--quality` (required when `--auto` is set).
 
 **Parse `--workspace`:** If `--workspace branch|worktree|prompt` was passed as an argument, store the mode. If absent, default to `prompt`. When `--workspace` is explicitly set to `branch` or `worktree`, the corresponding action is taken automatically without prompting (steps 3a-3c below).
 
@@ -178,7 +178,7 @@ For each task, determine three things:
 - **Standard** → `sonnet` — capable, cost-efficient
 - **Complex** → `opus` — most capable, required for architectural and cross-cutting work
 
-The user selects a preset in Step 4 that applies these mappings (or overrides them).
+The user selects a quality tier (preset) in Step 4 that applies these mappings (or overrides them).
 
 After classification, Read `./classifying-and-waving-tasks.md` for wave-building algorithm and adaptive sizing.
 
@@ -218,7 +218,7 @@ Note every issue found.
 
 Fix each issue from the critique. Then present the final wave structure showing per-task model assignments:
 
-**Preset auto-selection:** If the user invoked the skill with `--preset <full|balanced|minimal>` (e.g., `/execute-plan-sdlc --preset balanced`), apply the specified preset without presenting the selection prompt. Show the wave structure with the applied preset and proceed directly to Step 5.
+**Quality auto-selection:** If the user invoked the skill with `--quality <full|balanced|minimal>` (e.g., `/execute-plan-sdlc --quality balanced`), apply the specified quality tier (preset) without presenting the selection prompt. Show the wave structure with the applied tier and proceed directly to Step 5. (When invoked from ship-sdlc, `--quality` is forwarded only when the user explicitly passed `--quality` to ship.)
 
 Valid values: `full` (Speed), `balanced` (Balanced), `minimal` (Quality). Legacy `A`/`B`/`C` are accepted and normalized. Invalid values → fall back to interactive selection.
 
@@ -241,19 +241,19 @@ Wave 3 (N tasks — HIGH RISK, will pause):
 ────────────────────────────────────────────
 Total: N tasks across N waves + pre-wave
 
-Model Presets:
+Quality Tiers (Model Presets):
   full) Speed:       N × haiku, N × sonnet              — fast, low cost (skips spec compliance review)
   balanced) Balanced:  N × haiku, N × sonnet, N × opus  — default ✓
   minimal) Quality:    N × sonnet, N × opus              — max correctness
 
-Use AskUserQuestion to select a preset:
-> Select execution preset
+Use AskUserQuestion to select a quality tier:
+> Select execution quality tier
 
 Options: **full** (Speed) | **balanced** (Balanced, default) | **minimal** (Quality) | **custom** | **cancel**
-Tip: Use --preset balanced to skip this prompt next time.
+Tip: Use --quality balanced to skip this prompt next time.
 ```
 
-Always present all 3 presets. Default is Balanced. When the user selects a preset (full/balanced/minimal), update the per-task model assignments and proceed to execution immediately. "custom" opens per-task editing before execution. "cancel" aborts. No additional confirmation needed — preset selection is the approval.
+Always present all 3 tiers. Default is Balanced. When the user selects a tier (full/balanced/minimal), update the per-task model assignments and proceed to execution immediately. "custom" opens per-task editing before execution. "cancel" aborts. No additional confirmation needed — tier selection is the approval.
 
 ## Step 5 (DO): Execute
 
@@ -301,8 +301,8 @@ Options:
 - Exact list of files the agent may touch
 - Expected deliverable: what changed + how to verify
 - For complex tasks: brief summary of relevant changes from prior waves
-- **Model**: pass `model: "<assigned-model>"` to the Agent tool (haiku, sonnet, or opus per the selected preset)
-  **This is REQUIRED on every dispatch — no exceptions.** Omitting `model:` causes the agent to inherit the parent model (opus), defeating the preset system. Before sending any Agent dispatch message, verify: does every Agent call in this message include `model:`? If not, add it.
+- **Model**: pass `model: "<assigned-model>"` to the Agent tool (haiku, sonnet, or opus per the selected quality tier)
+  **This is REQUIRED on every dispatch — no exceptions.** Omitting `model:` causes the agent to inherit the parent model (opus), defeating the quality-tier system. Before sending any Agent dispatch message, verify: does every Agent call in this message include `model:`? If not, add it.
 - **Mode**: pass `mode: "bypassPermissions"` to the Agent tool on every dispatch.
 
 **5c. Collect and verify** — After all agents return:
@@ -335,7 +335,7 @@ Options:
 
 **5c-bis. Spec compliance review (Standard and Complex tasks only):**
 
-Skip for waves containing only Trivial tasks. Skip if the Speed preset was selected.
+Skip for waves containing only Trivial tasks. Skip if the Speed quality tier (`--quality full`) was selected.
 
 After mechanical verification passes (Steps 5c.1–4), dispatch a single spec compliance reviewer (sonnet). At dispatch time, Read `./spec-compliance-reviewer.md` and use it as the prompt template. Provide:
 - Each non-trivial task's full specification text
@@ -392,7 +392,7 @@ SCRIPT=$(find ~/.claude/plugins -name "execute.js" -path "*/sdlc*/scripts/state/
 
 On the very first wave dispatch, initialize the state file:
 ```bash
-node "$SCRIPT" init --branch <branch> --preset <X> --total-tasks <N>
+node "$SCRIPT" init --branch <branch> --quality <X> --total-tasks <N>
 ```
 
 Before each wave: `node "$SCRIPT" wave-start --wave <N>`
@@ -454,7 +454,7 @@ Fix inline if possible; report to user otherwise.
 
 **8-bis. Final spec completeness check (when OpenSpec context available):**
 
-Skip this sub-step if `openspecSpecs` is empty (no OpenSpec context was loaded in Step 1) or if the Speed preset was selected.
+Skip this sub-step if `openspecSpecs` is empty (no OpenSpec context was loaded in Step 1) or if the Speed quality tier (`--quality full`) was selected.
 
 Also skip if ALL per-wave spec compliance reviews (Step 5c-bis) passed without issues AND the plan has 3 or fewer waves — the per-wave reviews already provided sufficient coverage in that case.
 
@@ -507,13 +507,13 @@ On failure or interruption (not all tasks completed), preserve the state file. P
 |---|---|
 | Plan validated | No blocking validation issues |
 | Wave structure critiqued | All file conflicts and dependency issues resolved |
-| User approved | Preset selected (A/B/C) or custom editing completed in Step 4 |
+| User approved | Quality tier selected (`--quality full|balanced|minimal`) or custom editing completed in Step 4 |
 | All tasks completed | No tasks skipped without user consent |
 | Per-wave verification | Tests/build/lint pass after each wave |
 | Final verification | Full suite green |
 | No drift | Tasks match their specifications |
 | No orphans | All created files are referenced/used |
-| Spec compliance reviewed | Non-trivial waves pass spec review (unless Speed preset selected) |
+| Spec compliance reviewed | Non-trivial waves pass spec review (unless Speed quality tier `--quality full` selected) |
 | Final spec completeness | All delta spec requirements covered across all waves (when openspecSpecs available) |
 | Pre-wave guardrail check | Error-severity guardrails pass or user overrides (Step 5a-pre) |
 | Post-wave guardrail check | Error-severity guardrails pass, fixed, or user overrides; warnings reported (Step 5c-ter) |
@@ -548,7 +548,7 @@ On failure or interruption (not all tasks completed), preserve the state file. P
 - Write state files for small-plan direct execution (≤3 tasks) — they execute without waves and are fast enough to re-run
 - Auto-override error-severity guardrail violations in `--auto` mode — guardrails exist to prevent drift; always block
 - Evaluate warning-severity guardrails pre-wave — warnings are assessed post-wave against actual changes, not intent
-- Dispatch agents without the `model:` parameter — every agent dispatch must include `model: "<X>"` per the preset table. Omitting it defaults to opus, defeating the cost optimization of the preset system.
+- Dispatch agents without the `model:` parameter — every agent dispatch must include `model: "<X>"` per the quality-tier table. Omitting it defaults to opus, defeating the cost optimization of the quality-tier system.
 
 ## Gotchas
 

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ship-sdlc
-description: "Use this skill when shipping a feature end-to-end after plan acceptance: executing, committing, reviewing, fixing critical issues, versioning, and opening a PR in one flow. Chains execute-plan-sdlc, commit-sdlc, review-sdlc, received-review-sdlc, version-sdlc, and pr-sdlc with conditional review-fix loop. Arguments: [--auto] [--skip <steps>] [--preset full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]. Triggers on: ship it, ship this, full pipeline, execute to PR, ship feature, run the whole thing."
+description: "Use this skill when shipping a feature end-to-end after plan acceptance: executing, committing, reviewing, fixing critical issues, versioning, and opening a PR in one flow. Chains execute-plan-sdlc, commit-sdlc, review-sdlc, received-review-sdlc, version-sdlc, and pr-sdlc with conditional review-fix loop. Arguments: [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]. Triggers on: ship it, ship this, full pipeline, execute to PR, ship feature, run the whole thing."
 user-invocable: true
-argument-hint: "[--auto] [--skip <steps>] [--preset full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--workspace branch|worktree|prompt] [--openspec-change <name>] [--init-config]"
+argument-hint: "[--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--workspace branch|worktree|prompt] [--openspec-change <name>] [--init-config]"
 ---
 
 # Ship Pipeline
@@ -67,8 +67,12 @@ SCRIPT=$(find ~/.claude/plugins -name "ship.js" -path "*/sdlc*/scripts/skill/shi
 [ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/skill/ship.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/skill/ship.js"
 [ -z "$SCRIPT" ] && { echo "ERROR: Could not locate skill/ship.js. Is the sdlc plugin installed?" >&2; exit 2; }
 
-PREPARE_OUTPUT_FILE=$(node "$SCRIPT" --output-file --has-plan --auto --skip version --preset balanced --bump patch --workspace branch)
-# Note: --preset and --skip are legacy CLI sugar (deprecated). They expand to flags.steps internally.
+PREPARE_OUTPUT_FILE=$(node "$SCRIPT" --output-file --has-plan --auto --bump patch --workspace branch)
+# Pipeline composition (which steps run) comes from config `ship.steps[]`. To override
+# the resolved step list for a single run, pass `--steps <csv>` (e.g.
+# `--steps execute,commit,pr`). To set the model tier forwarded to execute-plan-sdlc,
+# pass `--quality <full|balanced|minimal>` — only forwarded when explicitly passed.
+# Legacy `--preset` and `--skip` are hard-removed (#190) and produce errors.
 # The config-level field is `steps[]` (top-level `version: 2`); preset/skip are no longer persisted.
 EXIT_CODE=$?
 echo "PREPARE_OUTPUT_FILE=$PREPARE_OUTPUT_FILE"
@@ -138,7 +142,7 @@ Auto-skip decisions (from skill/ship.js):
 ```
 
 The parenthetical after `skipped` reflects the step's `skipSource` field:
-- `(cli)` — user passed `--skip` on the command line
+- `(cli)` — user passed `--steps` on the command line
 - `(config)` — skip set loaded from `.sdlc/local.json`
 - `(auto)` — auto-skipped by `computeSteps` logic (e.g., worktree mode)
 - `(condition)` — conditional step whose condition was not met
@@ -160,7 +164,7 @@ The pipeline table is generated from the `steps` array in the `skill/ship.js` ou
 
 | Step | Skill | Status | Args | Pause |
 |------|-------|--------|------|-------|
-| 1 | execute-plan-sdlc | will_run | `--preset balanced` | no |
+| 1 | execute-plan-sdlc | will_run | (none, or `--quality <X>` if user passed `--quality` to ship) | no |
 | 2 | commit-sdlc | will_run | `--auto` | no |
 | 3 | review-sdlc | will_run | `--committed` | no |
 | 4 | received-review-sdlc | conditional | (if crit/high) | YES |
@@ -174,7 +178,7 @@ Not all sub-skills support `--auto`. This table is the source of truth:
 
 | Sub-skill | --auto support | Behavior when ship runs with --auto |
 |-----------|---------------|--------------------------------------|
-| execute-plan-sdlc | No | Forwards a synthesized `--preset <full\|balanced\|minimal>` derived from the resolved `steps[]`. Preset selection prompt is skipped when preset is provided. (execute-plan-sdlc semantics unchanged; ship synthesizes preset at the boundary.) |
+| execute-plan-sdlc | No | Forwards `--quality <X>` only when the user explicitly passed `--quality` to ship; otherwise no quality flag is forwarded and execute-plan-sdlc applies its own selection logic. (Renamed from `--preset` in #190 to disambiguate from ship's step-selection semantics.) |
 | commit-sdlc | Yes | `--auto` forwarded. Skips commit approval prompt. |
 | review-sdlc | No | No interactive prompts to skip — runs fully automatically already. |
 | received-review-sdlc | Yes | `--auto` forwarded. Skips Step 10 consent prompt and Step 12 reply/resolve prompt. Critique gates and verification still run. Only "will fix" items auto-implemented; threads for "will fix" items auto-resolved. |
@@ -226,7 +230,7 @@ Pipeline validation:
 Validation checks:
 - `gh auth status` succeeds
 - Current branch is not the default branch (warn if it is — do not block)
-- All `--skip` values are recognized step names: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`
+- All `--steps` values are recognized step names: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`
 - At least one step will run
 - Flag combinations are coherent (`--bump` without version step → warn)
 
@@ -242,7 +246,7 @@ Ship Pipeline (dry run)
 ────────────────────────────────────────────────────────────────
 Step  Skill                 Status       Args              Pause?
 ────────────────────────────────────────────────────────────────
-1     execute-plan-sdlc     will run     --preset balanced  no
+1     execute-plan-sdlc     will run     (none)             no
 2     commit-sdlc           will run     --auto            no
 3     review-sdlc           will run     --committed       no
 4     received-review-sdlc  conditional  (if crit/high)    YES
@@ -338,8 +342,8 @@ Ship-sdlc retains full control of: pipeline table display, validation output, st
 
 **Execute step resume:** When the pipeline is resuming (`--resume` active) and the execute step's status in the ship state file is `in_progress`:
 1. Check for `<main-worktree>/.sdlc/execution/execute-<branch>-*.json` (an execute-plan-sdlc state file for the current branch). Resolve `<main-worktree>` via `git worktree list --porcelain` (first `worktree` line).
-2. If found, dispatch Agent with args: `"--preset <X> --resume"`
-3. If not found, dispatch Agent normally with args: `"--preset <X>"` (execute restarts from scratch)
+2. If found, dispatch Agent with args from `step.invocation` plus `--resume` (e.g. `"--quality <X> --resume"` if the user passed `--quality` to ship; `"--resume"` otherwise)
+3. If not found, dispatch Agent normally using `step.invocation` (execute restarts from scratch)
 
 ship-sdlc does not manage execute-plan-sdlc's state file — execute-plan-sdlc handles its own creation, updates, and cleanup.
 
@@ -352,7 +356,7 @@ git worktree list --porcelain
 Match the branch from the ship state file against worktree entries. If found and directory exists, `cd <path>` before continuing. If the worktree directory is gone, warn and fall back to running on the current branch.
 
 Example dispatch sequence (use `step.invocation` for actual args):
-- Agent: execute-plan-sdlc, args: `"--preset balanced"`
+- Agent: execute-plan-sdlc, args: from `step.invocation` (e.g. `""` when no `--quality` was forwarded, `"--quality balanced"` when the user passed `--quality balanced` to ship)
 - Agent: commit-sdlc, args: `"--auto"`
 - Agent: review-sdlc, args: `"--committed"`
 - Agent: received-review-sdlc, args: `"--auto"` (when `flags.auto`; otherwise no args)
@@ -521,7 +525,7 @@ Step  Skill                 Result
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Decisions log:
-  - Steps resolved: [execute, commit, review, pr, archive-openspec] (from config default; synthesized --preset balanced for execute-plan-sdlc)
+  - Steps resolved: [execute, commit, review, pr, archive-openspec] (from config default; --quality not forwarded to execute-plan-sdlc — user did not pass --quality)
   - Version step skipped (from config default, bump type: patch)
   - Review found 2 medium issues — below threshold, deferred
   - PR created as draft (from --draft flag)
@@ -612,7 +616,7 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 - Proceed past a failed sub-skill — stop, save state, inform user
 - Skip pipeline steps that were marked "will run" in the pipeline plan. The pipeline plan is a contract with the user. If a step was planned to run and the user confirmed the pipeline, it MUST run. The LLM does not have authority to skip planned steps based on its own assessment of change complexity or risk. Only the skip set and auto-skip rules (computed by skill/ship.js) control which steps run.
 - Copy example args from this document when dispatching sub-skill Agents — use the `invocation` field from the skill/ship.js output, which contains the exact computed args
-- Add `--skip` flags not present in the user's original invocation or ship config. The skip set is user/config-controlled. If skill/ship.js output shows `skipSource` as unexpected (e.g., `flags.skip.length > 0` but `flagSources.skip === 'default'`), warn before proceeding.
+- Add `--steps` flags not present in the user's original invocation. Pipeline composition derives from CLI `--steps` > config `ship.steps[]` > built-in defaults. Legacy `--preset` and `--skip` are hard-removed (#190); passing them produces an error.
 - Dispatch pipeline step Agents without `model: step.model` — the model field is computed by skill/ship.js from each skill's spec. Omitting it defaults all steps to opus.
 - Ignore cleanup validation failures — if `state/ship.js cleanup` exits with code 1, the pipeline contract was violated. Surface the violation and preserve state.
 
@@ -632,7 +636,7 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 
 **Config file is optional.** The pipeline runs with built-in defaults when no ship config exists in `.sdlc/local.json`. Do not error on missing config.
 
-**Skip set validation matters.** Unrecognized values in `--skip` (e.g., `--skip reviw`) should warn, not silently ignore. Typos in skip values cause steps to run when the user expected them skipped.
+**Step set validation matters.** Unrecognized values in `--steps` (e.g., `--steps reviw`) produce an error from `skill/ship.js parseArgs` and abort the run. The single source of truth for step composition is `ship.steps[]` in `.sdlc/local.json`; CLI `--steps` is a one-shot override. The legacy `--preset` and `--skip` flags are hard-removed (#190) and rejected with a migration-pointer error.
 
 **.sdlc/ must be gitignored.** The `.sdlc/` directory contains developer-local config (`local.json`) and ephemeral pipeline state (`execution/`). `--init-config` creates `.sdlc/.gitignore` automatically via `ship-init.js`. If `.sdlc/` is not gitignored, the staging command (`git add -A -- ':!.sdlc/'`) provides a fallback exclusion, but the gitignore is the primary defense.
 
@@ -652,13 +656,13 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 
 **Version step is auto-skipped in worktree mode.** `computeSteps` in skill/ship.js skips the version step when `workspace === 'worktree'`. Tags are repo-global — creating them from an isolated worktree risks collisions with parallel pipelines. The pipeline prints a post-merge advisory: run `/version-sdlc` on main after the PR merges. This also handles changelog — `version-sdlc` generates changelog from `previousTag..HEAD`, capturing all commits from all merged branches regardless of their source worktree.
 
-**Worktree PRs auto-label `skip-version-check`.** When `workspace === 'worktree'` causes the version step to be auto-skipped, `skill/ship.js` adds `--label skip-version-check` to the PR step args. The label is included in `gh pr create` from the start (not added post-creation), so `check-version-bump.yml` sees it on the `opened` event. Only fires for worktree auto-skip, not manual `--skip version`. Prerequisite: the label must exist in the repository (pr-sdlc creates it automatically if missing).
+**Worktree PRs auto-label `skip-version-check`.** When `workspace === 'worktree'` causes the version step to be auto-skipped, `skill/ship.js` adds `--label skip-version-check` to the PR step args. The label is included in `gh pr create` from the start (not added post-creation), so `check-version-bump.yml` sees it on the `opened` event. Only fires for worktree auto-skip, not when `version` is omitted from `ship.steps[]`. Prerequisite: the label must exist in the repository (pr-sdlc creates it automatically if missing).
 
 **Auto mode does not auto-resume without --resume.** When `--auto` is set but `--resume` is not, the pipeline starts fresh even if a state file exists for the current branch. This prevents accidental continuation from stale state. The state file is preserved (not deleted) so the user can explicitly `--resume` later.
 
 **Sub-skill loading and agent isolation.** Each sub-skill's SKILL.md is 200–550 lines. Agent dispatch is the primary mitigation: each Agent loads SKILL.md in its own context and returns only a structured result (5–10 lines). The ship pipeline's context receives structured data, not sub-skill definitions. Without agent dispatch, the Skill tool would load all definitions into the pipeline's context (2000+ lines), degrading context quality in later steps (version, PR) and increasing the risk of hallucination or skipped logic.
 
-**skipSource tracks provenance.** Each step's `skipSource` field records why a step was skipped: `"none"` (not skipped), `"cli"` (user `--skip` flag), `"config"` (from `.sdlc/local.json`), `"auto"` (auto-skipped by `computeSteps` logic), `"condition"` (conditional step not triggered), `"default"` (skip source unresolved — likely fabricated). If a step has `skipSource: "default"`, the fabrication guard in `runValidation` fires a warning. The per-step `skipSource` and the fabrication guard are complementary: `skipSource` makes the issue visible per step, the guard makes it visible at the pipeline level.
+**skipSource tracks provenance.** Each step's `skipSource` field records why a step was skipped: `"none"` (not skipped), `"cli"` (step omitted from CLI `--steps`), `"config"` (omitted from `ship.steps[]` in `.sdlc/local.json`), `"auto"` (auto-skipped by `computeSteps` logic), `"condition"` (conditional step not triggered), `"default"` (built-in defaults excluded the step). The per-step `skipSource` makes the exclusion provenance auditable per step.
 
 ---
 
@@ -669,7 +673,7 @@ After completing the pipeline, append to `.claude/learnings/log.md`:
 - Review verdicts that surprised (threshold too aggressive or too lenient)
 - Sub-skills that failed in unexpected ways during chaining
 - Config combinations that produced unintended pipeline shapes
-- Projects where the default `steps[]` behavior was wrong (or where legacy `--preset`/`--skip` sugar misled users)
+- Projects where the default `steps[]` behavior was wrong, or migrations from legacy v1 configs (`ship.preset`/`ship.skip`) that produced unexpected `steps[]` after auto-migration. CLI `--preset`/`--skip` are no longer accepted (#190 hard-remove); ship-sdlc emits a migration-pointer error if either is passed.
 
 Format:
 ```

--- a/tests/promptfoo/datasets/execute-plan-sdlc.yaml
+++ b/tests/promptfoo/datasets/execute-plan-sdlc.yaml
@@ -1,6 +1,6 @@
 # Fixture appropriateness:
 #   plan-execution-complete        -- CORRECT: simulates completed plan execution, triggers workflow continuation
-#   feature-branch-with-commits   -- CORRECT: provides branch context for plan execution with --preset
+#   feature-branch-with-commits   -- CORRECT: provides branch context for plan execution with --quality
 #   plan-execution-with-guardrails -- CORRECT: provides execution guardrails context for guardrail evaluation testing
 
 - description: "execute-plan-sdlc: shows workflow continuation menu after plan execution"
@@ -32,30 +32,31 @@
         commit (/commit-sdlc), review (/review-sdlc), version (/version-sdlc), pr (/pr-sdlc),
         and done. The user is asked to select an option rather than being given a passive suggestion.
 
-- description: "execute-plan-sdlc: skips preset selection when --preset B is provided"
+- description: "execute-plan-sdlc: skips quality-tier selection when --quality balanced is provided"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-with-commits.md"
     user_request: >
-      Run /execute-plan-sdlc --preset B. A plan with 5 tasks has been loaded and validated.
-      Task classification and wave building are complete. Show the wave structure and proceed
-      with the Balanced preset applied automatically.
+      Run /execute-plan-sdlc --quality balanced. A plan with 5 tasks has been loaded and
+      validated. Task classification and wave building are complete. Show the wave structure
+      and proceed with the Balanced quality tier applied automatically.
   assert:
-    # Behavioral: applies Balanced preset without interactive selection
+    # Behavioral: applies Balanced tier without interactive selection
     - type: llm-rubric
       value: >
-        The response applies preset B (Balanced) without presenting the A/B/C selection menu
-        to the user. It shows the wave structure with model assignments that reflect the
-        Balanced preset (haiku for Trivial, sonnet for Standard, opus for Complex) and
-        proceeds directly to execution. The response does not ask the user to "Select preset
-        (A/B/C)" — the selection is already made via the --preset argument.
+        The response applies the Balanced quality tier (--quality balanced) without
+        presenting the interactive selection menu to the user. It shows the wave structure
+        with model assignments that reflect the Balanced tier (haiku for Trivial, sonnet
+        for Standard, opus for Complex) and proceeds directly to execution. The response
+        does not ask the user to select a quality tier — the selection is already made via
+        the --quality argument. The response uses --quality (not --preset).
 
 - description: "execute-plan-sdlc: loads execution guardrails from config and evaluates during execution"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md"
     project_context: "file://fixtures/plan-execution-with-guardrails.md"
     user_request: >
-      Run /execute-plan-sdlc --preset B. A plan with 4 tasks has been loaded and validated.
+      Run /execute-plan-sdlc --quality balanced. A plan with 4 tasks has been loaded and validated.
       The project has execution guardrails configured in .claude/sdlc.json under execute.guardrails.
       Show how guardrails are loaded and describe how they will be evaluated during execution.
   assert:
@@ -75,7 +76,7 @@
     skill_path: "plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md"
     project_context: "file://fixtures/plan-execution-complete.md"
     user_request: >
-      Run /execute-plan-sdlc --preset B. A plan has been loaded. No execution guardrails are
+      Run /execute-plan-sdlc --quality balanced. A plan has been loaded. No execution guardrails are
       configured in the project. Show how the execution proceeds.
   assert:
     - type: not-icontains
@@ -87,12 +88,12 @@
         evaluation steps or guardrail violations. Execution flows through the standard
         wave dispatch, verification, and reporting steps.
 
-- description: "execute-plan-sdlc: model parameter required on every agent dispatch per preset"
+- description: "execute-plan-sdlc: model parameter required on every agent dispatch per quality tier"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md"
     project_context: "file://fixtures/feature-branch-with-commits.md"
     user_request: >
-      Run /execute-plan-sdlc --preset balanced. A plan with 5 tasks (2 Trivial, 2 Standard,
+      Run /execute-plan-sdlc --quality balanced. A plan with 5 tasks (2 Trivial, 2 Standard,
       1 Complex) is ready. Show the wave structure with model assignments and how
       agents will be dispatched.
   assert:
@@ -103,8 +104,8 @@
     - type: llm-rubric
       value: >
         The response shows wave structure with explicit model assignments per task:
-        Trivial=haiku, Standard=sonnet, Complex=opus (Balanced preset). The dispatch
-        includes model: as a required parameter for each agent.
+        Trivial=haiku, Standard=sonnet, Complex=opus (Balanced quality tier). The
+        dispatch includes model: as a required parameter for each agent.
 
 # OpenSpec post-pipeline archive suggestion tests (issue #162)
 

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -42,47 +42,46 @@
     - type: icontains
       value: '"workspace": "worktree"'
 
-# Preset normalization tests (issue #114)
+# --preset / --skip hard-removal (issue #190)
+# CLI --preset and --skip are no longer accepted by ship-sdlc — they expand to
+# errors with a migration pointer to --steps. Legacy on-disk v1 configs are
+# still auto-migrated by lib/config.js (see migration matrix below).
 
-- description: "ship-prepare: --preset B normalizes to balanced"
+- description: "ship-prepare: --preset is hard-rejected with migration pointer (#190)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --preset B"
+    script_args: "--has-plan --preset balanced"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
   assert:
     - type: icontains
-      value: '"preset": "balanced"'
+      value: "--preset is no longer accepted"
+    - type: icontains
+      value: "--steps"
 
-- description: "ship-prepare: --preset A normalizes to full"
+- description: "ship-prepare: --skip is hard-rejected with migration pointer (#190)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --preset A"
+    script_args: "--has-plan --skip version"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
   assert:
     - type: icontains
-      value: '"preset": "full"'
-
-- description: "ship-prepare: --preset full passes through as full"
-  vars:
-    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --preset full"
-    script_cwd: "{{project_root}}"
-    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
-  assert:
+      value: "--skip is no longer accepted"
     - type: icontains
-      value: '"preset": "full"'
+      value: "--steps"
 
-- description: "ship-prepare: config with legacy preset B normalizes to balanced"
+- description: "ship-prepare: config with legacy preset still auto-migrates to v2 steps[]"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
     script_args: "--has-plan"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-ship-legacy-preset"
   assert:
-    - type: icontains
-      value: '"preset": "balanced"'
+    - type: javascript
+      value: |
+        const o = JSON.parse(output);
+        Array.isArray(o.flags.steps) && o.flags.steps.length > 0
 
 # Auto-mode workspace override for config source (issue #133)
 
@@ -98,33 +97,16 @@
     - type: icontains
       value: "config (auto)"
 
-# Fabrication guard (issue #129; updated for v2 schema #180)
-# Post-v2: --skip is legacy CLI sugar. Source is 'cli' when passed, 'none' otherwise.
-# Fabrication is only possible when flags.skip is non-empty but sources.skip isn't 'cli',
-# which the new mergeFlags shape makes structurally impossible from CLI parsing alone.
-# This test asserts the new behavior: passing --skip explicitly is the legitimate path
-# and produces NO fabrication error (the previous false-positive failure mode is fixed).
+# Bump+steps coherence (issue #146; updated #190)
+# When --bump is set on CLI but the resolved steps[] excludes the version step,
+# this is a contradiction: the user wanted to bump but the pipeline shape skips
+# version. The error fires regardless of whether version was excluded via
+# --steps (CLI) or via config.
 
-- description: "ship-prepare: legitimate --skip use does NOT trigger fabrication guard (post-v2)"
+- description: "ship-prepare: --bump with version excluded from --steps produces error"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --skip pr"
-    script_cwd: "{{project_root}}"
-    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
-  assert:
-    - type: not-icontains
-      value: "likely fabricated"
-    - type: javascript
-      value: |
-        const o = JSON.parse(output);
-        o.flags.sources.skip === 'cli' && Array.isArray(o.flags.skip) && o.flags.skip.includes('pr')
-
-# Bump+skip contradiction blocking error (issue #146)
-
-- description: "ship-prepare: --bump with skipped version step produces error"
-  vars:
-    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --bump minor --skip version"
+    script_args: "--has-plan --bump minor --steps execute,commit,review,pr,archive-openspec"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
   assert:
@@ -181,17 +163,17 @@
 
 # Shared lib import regression tests (issue #152)
 
-- description: "ship-prepare: rejects skip values not in VALID_SKIP (post-refactor)"
+- description: "ship-prepare: rejects unrecognized step values in --steps"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --skip received-review"
+    script_args: "--has-plan --steps execute,reviw,pr"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
   assert:
     - type: icontains
-      value: "Unrecognized skip value"
+      value: "Unrecognized step"
     - type: icontains
-      value: "received-review"
+      value: "reviw"
 
 - description: "ship-prepare: BUILT_IN_DEFAULTS resolve to balanced steps (no version) when no config exists"
   vars:
@@ -204,7 +186,7 @@
       value: |
         const o = JSON.parse(output);
         const expected = ['execute','commit','review','pr','archive-openspec'];
-        JSON.stringify(o.flags.steps) === JSON.stringify(expected) && o.flags.preset === 'balanced'
+        JSON.stringify(o.flags.steps) === JSON.stringify(expected)
     - type: icontains
       value: '"bump": "patch"'
     - type: icontains
@@ -291,10 +273,10 @@
         const step = JSON.parse(output).steps.find(s => s.name === 'archive-openspec');
         step.status === 'skipped' && step.reason === 'change already archived'
 
-- description: "ship-prepare: --skip archive-openspec marks step as skipped"
+- description: "ship-prepare: --steps without archive-openspec marks step as skipped"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --skip archive-openspec --openspec-change add-auth"
+    script_args: "--has-plan --steps execute,commit,review,version,pr --openspec-change add-auth"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-ship-openspec-ready"
   assert:
@@ -303,15 +285,15 @@
         const step = JSON.parse(output).steps.find(s => s.name === 'archive-openspec');
         step.status === 'skipped' && step.reason === 'not in steps[]'
 
-- description: "ship-prepare: VALID_SKIP includes archive-openspec"
+- description: "ship-prepare: VALID_STEPS includes archive-openspec"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --skip archive-openspec"
+    script_args: "--has-plan --steps execute,archive-openspec"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
   assert:
     - type: not-icontains
-      value: "Unrecognized skip value"
+      value: "Unrecognized step"
 
 # ---------------------------------------------------------------------------
 # Migration matrix tests (issue #180)
@@ -331,7 +313,7 @@
         const o = JSON.parse(output);
         const steps = o.flags.steps;
         const expected = ['execute','commit','review','pr','archive-openspec'];
-        JSON.stringify(steps) === JSON.stringify(expected) && o.flags.preset === 'balanced'
+        JSON.stringify(steps) === JSON.stringify(expected)
 
 - description: "ship-prepare: legacy preset:minimal + skip:[pr] migrates to [execute, commit]"
   vars:
@@ -356,7 +338,7 @@
       value: |
         const o = JSON.parse(output);
         const expected = ['execute','commit','review','version','pr','archive-openspec'];
-        JSON.stringify(o.flags.steps) === JSON.stringify(expected) && o.flags.preset === 'full'
+        JSON.stringify(o.flags.steps) === JSON.stringify(expected)
 
 - description: "ship-prepare: legacy A/B/C preset codes resolve to canonical equivalents (B → balanced)"
   vars:
@@ -369,7 +351,7 @@
       value: |
         const o = JSON.parse(output);
         const expected = ['execute','commit','review','pr','archive-openspec'];
-        JSON.stringify(o.flags.steps) === JSON.stringify(expected) && o.flags.preset === 'balanced'
+        JSON.stringify(o.flags.steps) === JSON.stringify(expected)
 
 - description: "ship-prepare: already-migrated v2 config passes through unchanged"
   vars:
@@ -384,10 +366,10 @@
         const expected = ['execute','commit','review','pr','archive-openspec'];
         JSON.stringify(o.flags.steps) === JSON.stringify(expected)
 
-- description: "ship-prepare: CLI --preset minimal overrides config steps (legacy sugar)"
+- description: "ship-prepare: CLI --steps fully overrides config (#190)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --preset minimal"
+    script_args: "--has-plan --steps execute,commit,pr"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-ship-v2-already-migrated"
   assert:
@@ -395,17 +377,57 @@
       value: |
         const o = JSON.parse(output);
         const expected = ['execute','commit','pr'];
-        JSON.stringify(o.flags.steps) === JSON.stringify(expected) && o.flags.preset === 'minimal'
+        JSON.stringify(o.flags.steps) === JSON.stringify(expected) && o.flags.sources.steps === 'cli'
 
-- description: "ship-prepare: CLI --skip pr subtracts from resolved steps[]"
+# #190 repro: config-only steps[] excluding `version` MUST produce a pipeline
+# plan where version is skipped. This is the smoking gun fixed by removing the
+# CLI --preset override path that previously clobbered config steps[].
+
+- description: "ship-prepare: #190 repro — config steps without `version` produces version: skipped"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
-    script_args: "--has-plan --skip pr"
+    script_args: "--has-plan"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/project-ship-v2-already-migrated"
   assert:
     - type: javascript
       value: |
         const o = JSON.parse(output);
-        const expected = ['execute','commit','review','archive-openspec'];
+        const versionStep = o.steps.find(s => s.name === 'version');
+        const expected = ['execute','commit','review','pr','archive-openspec'];
         JSON.stringify(o.flags.steps) === JSON.stringify(expected)
+          && versionStep.status === 'skipped'
+          && versionStep.skipSource === 'config'
+
+# --quality forwarding (issue #190): when ship is invoked with --quality, the
+# resolved flag is emitted; when omitted, no quality is forwarded.
+
+- description: "ship-prepare: --quality balanced is forwarded to execute step args"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan --quality balanced"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: javascript
+      value: |
+        const o = JSON.parse(output);
+        const exec = o.steps.find(s => s.name === 'execute');
+        o.flags.quality === 'balanced'
+          && o.flags.sources.quality === 'cli'
+          && exec.args.includes('--quality balanced')
+
+- description: "ship-prepare: no --quality means no quality forwarded to execute"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--has-plan"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-sdlc-gitignore-inner"
+  assert:
+    - type: javascript
+      value: |
+        const o = JSON.parse(output);
+        const exec = o.steps.find(s => s.name === 'execute');
+        o.flags.quality === undefined
+          && !exec.args.includes('--quality')
+          && !exec.args.includes('--preset')

--- a/tests/promptfoo/datasets/ship-sdlc.yaml
+++ b/tests/promptfoo/datasets/ship-sdlc.yaml
@@ -39,10 +39,10 @@
     skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
     project_context: "file://fixtures/ship-pipeline-ready.md"
     user_request: >
-      Run /ship-sdlc --auto --skip version. Show the pipeline plan and demonstrate
-      that --auto mode skips the interactive approval prompt. Stop after displaying
-      the pipeline table (do not actually invoke sub-skills — treat this as context
-      setup only, not full execution).
+      Run /ship-sdlc --auto --steps execute,commit,review,pr,archive-openspec. Show
+      the pipeline plan and demonstrate that --auto mode skips the interactive
+      approval prompt. Stop after displaying the pipeline table (do not actually
+      invoke sub-skills — treat this as context setup only, not full execution).
   assert:
     # Must forward --auto in the pipeline plan for commit-sdlc
     - type: icontains
@@ -56,41 +56,58 @@
         The response shows the pipeline table and proceeds without presenting an
         interactive "Run this pipeline?" question to the user. The --auto flag is
         shown as forwarded to commit-sdlc and pr-sdlc (the sub-skills that support it).
-        The version step is shown as skipped because of --skip version. The response
-        does NOT ask the user to choose yes/edit/cancel before running.
+        The version step is shown as skipped because it is not in the resolved
+        steps[] (CLI --steps excluded it). The response does NOT ask the user to
+        choose yes/edit/cancel before running.
 
-- description: "ship-sdlc: CLI --preset legacy sugar overrides config steps[]"
+- description: "ship-sdlc: CLI --preset is hard-rejected with migration pointer (#190)"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
     project_context: "file://fixtures/ship-config-present.md"
     user_request: >
-      Run /ship-sdlc --preset minimal --dry-run. The project has a v1 .sdlc/local.json
-      with legacy preset: balanced. The loader auto-migrates to steps[]. The CLI flag
-      --preset minimal (legacy sugar) expands to [execute, commit, pr] and overrides
-      the migrated config steps[]. Show the flag resolution and dry-run pipeline table.
+      Run /ship-sdlc --preset minimal --dry-run. The CLI flag --preset is no longer
+      accepted (#190). Show the error message and stop without running the pipeline.
   assert:
-    # Must show config was loaded (from .sdlc/local.json)
+    # Must surface the rejection
     - type: icontains
-      value: "local.json"
+      value: "--preset is no longer accepted"
+    # Must point at --steps as the replacement
+    - type: icontains
+      value: "--steps"
+    # Behavioral: hard-rejection, no pipeline execution
+    - type: llm-rubric
+      value: >
+        The response surfaces the parseArgs error: --preset is no longer accepted by
+        ship-sdlc. The error suggests --steps <csv> as the replacement for step
+        composition (and --quality for the model-tier flag forwarded to
+        execute-plan-sdlc). The pipeline does NOT run. The response does NOT silently
+        fall back to a default preset — it stops at the validation gate.
+
+- description: "ship-sdlc: CLI --steps fully overrides config steps[] (#190)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
+    project_context: "file://fixtures/ship-config-present.md"
+    user_request: >
+      Run /ship-sdlc --steps execute,commit,pr --dry-run. The CLI --steps fully
+      replaces the resolved step list. Show the flag resolution and dry-run pipeline table.
+  assert:
     # Must show flag resolution section
     - type: icontains
       value: "Flag resolution"
-    # Must show steps were resolved
+    # Must show steps were resolved from CLI
     - type: icontains
       value: "steps"
-    # Must show that the version step is skipped (minimal excludes it)
+    # Must show that the version step is skipped (not in --steps)
     - type: icontains
       value: "skipped"
-    # Behavioral: CLI --preset overrides config steps via legacy sugar expansion
+    # Behavioral: CLI --steps overrides config steps[] entirely
     - type: llm-rubric
       value: >
-        The response shows the ship config was loaded from .sdlc/local.json (v1
-        legacy or v2 — either is acceptable since the loader auto-migrates). The
-        Flag resolution section shows --preset minimal as legacy CLI sugar that
-        expands to a steps[] of [execute, commit, pr], overriding any
-        config-level steps[]. The version step is shown as skipped (not in the
-        resolved steps[]). The output clearly distinguishes between
-        config-resolved steps[] and the CLI override.
+        The response shows the Flag resolution section with steps[] resolved from
+        CLI (source: cli) to [execute, commit, pr]. The version, review, and
+        archive-openspec steps are shown as skipped because they are not in the
+        resolved steps[]. The output clearly indicates that CLI --steps fully
+        replaced the config-level steps[].
 
 - description: "ship-sdlc: critical review finding pauses pipeline and invokes received-review-sdlc"
   vars:
@@ -144,16 +161,16 @@
         to the final summary report. The response does NOT invoke received-review-sdlc.
         It proceeds toward the next pipeline step (version-sdlc or pr-sdlc).
 
-- description: "ship-sdlc: --skip flag excludes specified steps from pipeline"
+- description: "ship-sdlc: --steps narrows pipeline to listed steps only (#190)"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
     project_context: "file://fixtures/ship-pipeline-ready.md"
     user_request: >
-      Run /ship-sdlc --skip execute,review,version --dry-run. Show the pipeline
-      table reflecting that execute, review, and version steps are skipped, while
-      commit and pr steps will run.
+      Run /ship-sdlc --steps commit,pr --dry-run. Show the pipeline table
+      reflecting that only commit-sdlc and pr-sdlc will run; all other steps
+      (execute, review, version, archive-openspec) are skipped.
   assert:
-    # All three skipped steps must appear as skipped
+    # All non-listed steps must appear as skipped
     - type: icontains
       value: "execute-plan-sdlc"
     - type: icontains
@@ -163,14 +180,15 @@
     # PR step should show as will run
     - type: icontains
       value: "pr-sdlc"
-    # Behavioral: correct skip set applied to pipeline table
+    # Behavioral: correct steps[] applied to pipeline table
     - type: llm-rubric
       value: >
-        The response displays a dry-run pipeline table where execute-plan-sdlc,
-        review-sdlc, and version-sdlc all show "skipped" status. commit-sdlc and
-        pr-sdlc show "will run" status. received-review-sdlc shows "conditional"
-        (or skipped because review is skipped). The table accurately reflects all
-        three --skip values. The response stops after displaying the table (dry-run).
+        The response displays a dry-run pipeline table where commit-sdlc and pr-sdlc
+        show "will run" status. execute-plan-sdlc, review-sdlc, version-sdlc, and
+        archive-openspec all show "skipped" status. received-review-sdlc shows
+        "conditional" (or skipped because review is skipped). The table accurately
+        reflects the CLI --steps override. The response stops after displaying the
+        table (dry-run).
 
 - description: "ship-sdlc: dry-run shows config loading, flag resolution, context detection, and auto-skip reasoning"
   vars:


### PR DESCRIPTION
## Summary
Removes the `--preset` and `--skip` flags from `ship-sdlc` and renames `--preset` to `--quality` in `execute-plan-sdlc`. Both removed flags now produce hard errors with clear migration messages, directing users to `--steps` and `--quality` respectively.

## Business Context
Users of the sdlc-marketplace plugin were confused by ambiguous flag names: `--preset` in `execute-plan-sdlc` meant model quality tier, while `ship-sdlc` also had `--preset` as a step-selection shorthand, and `--skip` was an undiscoverable inverse of `--steps`. The overlapping names made the CLI surface harder to reason about and document. Fixes #190.

## Business Benefits
- Users get clear, unambiguous flag names: `--quality` for model tier and `--steps` for step selection
- Hard errors on legacy flags prevent silent misconfiguration; migration path is stated in the error message
- Simpler flag resolution logic in the pipeline reduces edge cases for both users and maintainers

## Github Issue
https://github.com/rafalnagr/sdlc-marketplace/issues/190

## Technical Design
`--preset` and `--skip` were removed at parse time in `ship.js` and `execute.js` (state scripts) — any invocation of these flags immediately exits with a descriptive error message pointing to the replacement flags. No fallback or synthesis logic remains. `--preset` in `execute-plan-sdlc` was renamed to `--quality` with the same semantics. SKILL.md files, skill docs, specs, and test datasets were updated consistently to reflect the new interface.

## Technical Impact
**Breaking change.** Any existing scripts or workflows calling `ship-sdlc --preset` or `ship-sdlc --skip` will now receive a hard error. Migration:
- `--preset full|balanced|minimal` → `--quality full|balanced|minimal`
- `--skip <steps>` → use `--steps <csv>` with the desired steps instead

`execute-plan-sdlc --preset` is similarly hard-errored; replace with `--quality`.

## Changes Overview
- `--preset` and `--skip` are now rejected with hard errors in ship-sdlc, directing users to `--steps` and `--quality`
- `--preset` in execute-plan-sdlc is renamed to `--quality` with identical semantics
- Flag forwarding from ship-sdlc to execute-plan-sdlc updated: only `--quality` is forwarded when explicitly passed
- SKILL.md files for both skills updated to document the new flags and remove legacy flag documentation
- Skill reference docs (docs/skills/) and specs (docs/specs/) updated to match
- Test datasets updated to use `--quality` and `--steps` in all test cases

## Testing
Tested via updated promptfoo datasets for `execute-plan-sdlc`, `ship-sdlc`, and `ship-prepare-exec`. All test cases use the new flag names. Manual verification: confirmed hard-error messages are emitted for `--preset` and `--skip` invocations.