### PR TITLE
feat(#193): version-sdlc, ship-sdlc - add pre-release bump labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.35] - 2026-05-04
+
+### Added
+- version-sdlc, ship-sdlc: support for pre-release bump labels via `--pre-release-bump-label` flag and `preReleaseBumpLabel` config option, enabling automated label assignment during pre-release versioning (#193)
+
 ## [0.17.34] - 2026-05-03
 
 ### Fixed

--- a/docs/skills/setup-sdlc.md
+++ b/docs/skills/setup-sdlc.md
@@ -214,7 +214,7 @@ Plan guardrails    — [N configured via guardrails sub-flow | skipped]
 
 | File | Purpose |
 |------|---------|
-| `.claude/sdlc.json` | Unified project config with `version`, `jira`, `commit`, `pr` sections, and optional `plan.guardrails` |
+| `.claude/sdlc.json` | Unified project config with `version`, `jira`, `commit`, `pr` sections, and optional `plan.guardrails`. The `version` section may include an optional `preRelease` field (lowercase label matching `^[a-z][a-z0-9]*$`) — when set, `version-sdlc` and `ship-sdlc` produce a pre-release version (e.g. `1.2.4-rc.1`) on every default bump until an explicit `major\|minor\|patch` graduates the release. Configured interactively via the customize path of Step 3a (version section). |
 | `.sdlc/local.json` | User-local config with `review` scope preferences and `ship` settings |
 | `.claude/review-dimensions/*.yaml` | Review dimensions created during dimensions sub-flow (via `--dimensions`) |
 | `.claude/pr-template.md` | PR template created during PR template sub-flow (via `--pr-template`) |

--- a/docs/skills/ship-sdlc.md
+++ b/docs/skills/ship-sdlc.md
@@ -29,7 +29,7 @@ This skill is for **expert users working on projects with established quality gu
 ## Usage
 
 ```text
-/ship-sdlc [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]
+/ship-sdlc [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major|<label>] [--draft] [--dry-run] [--resume] [--init-config]
 ```
 
 ---
@@ -41,7 +41,7 @@ This skill is for **expert users working on projects with established quality gu
 | `--auto` | Non-interactive mode. Forwards `--auto` to sub-skills that support it (commit-sdlc, version-sdlc, pr-sdlc). Pipeline still pauses at received-review-sdlc (intentionally interactive). | Off |
 | `--steps <csv>` | Comma-separated list of steps to run, fully replacing the resolved step list. Valid values: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`. The single source of truth for pipeline composition is `ship.steps[]` in `.sdlc/local.json`; CLI `--steps` is a one-shot override. | From config or built-in defaults |
 | `--quality <full\|balanced\|minimal>` | Forwarded to execute-plan-sdlc as `--quality` (model tier). Only forwarded when the user explicitly passes `--quality` to ship; otherwise execute-plan-sdlc applies its own selection. (Renamed from `--preset` in #190 to disambiguate from `--steps`.) | Not forwarded |
-| `--bump patch\|minor\|major` | Version bump type forwarded to version-sdlc. | `patch` |
+| `--bump patch\|minor\|major\|<label>` | Version bump type forwarded to version-sdlc. The `<label>` form (e.g. `--bump rc`, `--bump beta`) is forwarded verbatim and interpreted by version-sdlc as `--bump patch --pre <label>`. Labels must match `^[a-z][a-z0-9]*$` (lowercase, start with a letter, alphanumeric). Example: `ship-sdlc --bump rc` produces a `1.2.4-rc.1` style release. | `patch` |
 | `--draft` | Create the PR as a draft. | Off |
 | `--dry-run` | Display the full pipeline plan and stop. No steps are executed. | Off |
 | `--resume` | Resume from the most recent state file for the current branch. Completed steps are skipped; in-progress steps are retried. | Off |

--- a/docs/skills/version-sdlc.md
+++ b/docs/skills/version-sdlc.md
@@ -18,9 +18,9 @@ Manages the full semantic release workflow: detects the version source, bumps th
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `major` / `minor` / `patch` | Bump type (positional). If omitted, auto-detected from conventional commits. | auto |
+| `major` / `minor` / `patch` / `<label>` | Bump type (positional). If omitted, auto-detected from conventional commits. The `<label>` form (e.g. `version-sdlc rc`) is sugar for `--bump patch --pre <label>` and accepts any pre-release label matching `^[a-z][a-z0-9]*$`. | auto |
 | `--init` | Run the setup wizard and write `.claude/version.json`. Safe to re-run. | — |
-| `--pre <label>` | Create a pre-release version (e.g. `beta`, `rc`). Auto-increments the counter on repeated runs. | — |
+| `--pre <label>` | Create a pre-release version (e.g. `beta`, `rc`). Label must match `^[a-z][a-z0-9]*$`. Auto-increments the counter on repeated runs. | — |
 | `--no-push` | Commit and tag locally, skip `git push`. | — |
 | `--changelog` | With a bump type: generate a CHANGELOG entry as part of the release. Without a bump type: update the changelog for the already-tagged current version (no new tag created). | off |
 | `--hotfix` | Mark this release as a hotfix for DORA metrics tracking. Annotates the commit message with `[hotfix]` and the tag message body with `Type: hotfix`. | off |
@@ -134,6 +134,44 @@ Proceed? (yes / edit / cancel)
 /version-sdlc minor               # 1.3.0-rc.1 → 1.3.0         (graduate to release)
 ```
 
+### Pre-release shorthand: `--bump <label>`
+
+The positional `<label>` form is sugar for `--bump patch --pre <label>`. Useful for short, repeated RC iteration:
+
+```text
+/version-sdlc rc                  # 1.2.3        → 1.2.4-rc.1   (fresh patch + label)
+/version-sdlc rc                  # 1.2.4-rc.1   → 1.2.4-rc.2   (same-label increment)
+/version-sdlc rc                  # 1.2.4-beta.3 → 1.2.4-rc.1   (label change, counter reset)
+/version-sdlc mycorp              # 1.0.0        → 1.0.1-mycorp.1  (any custom label matching ^[a-z][a-z0-9]*$)
+```
+
+Label-form bumps skip the breaking-change suggestion (R3): pre-release trains do not nag on every iteration.
+
+### Default pre-release label via config
+
+Set `version.preRelease` in `.claude/sdlc.json` to apply a default label whenever the user runs `version-sdlc` without an explicit `major|minor|patch` and without `--pre`:
+
+```json
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "package.json",
+    "tagPrefix": "v",
+    "preRelease": "rc"
+  }
+}
+```
+
+With this config:
+
+```text
+/version-sdlc                     # 1.2.3      → 1.2.4-rc.1   (config default applied)
+/version-sdlc                     # 1.2.4-rc.1 → 1.2.4-rc.2   (same as `version-sdlc rc`)
+/version-sdlc major               # 1.2.4-rc.1 → 2.0.0        (explicit base bump graduates)
+```
+
+Configure interactively via `/setup-sdlc` (Step 3a customize path).
+
 ### Example release session
 
 ```text
@@ -231,7 +269,7 @@ git tag -l --format='%(refname:short)%09%(contents:subject)%09%(contents:body)'
 
 | Field | Value |
 |---|---|
-| `argument-hint` | `[major\|minor\|patch] [--pre <label>] [--changelog] [--hotfix]` |
+| `argument-hint` | `[major\|minor\|patch\|<label>] [--pre <label>] [--changelog] [--hotfix]` |
 | Plan mode | Graceful refusal (Step 0) |
 
 ---

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -33,7 +33,7 @@
 - R8: Ship config is developer-local (`.sdlc/local.json`, gitignored), not project-level
 - R9: Content setup sub-flows: review dimensions (`setup-dimensions.md`), PR template (`setup-pr-template.md`), plan guardrails (`setup-guardrails.md`), execution guardrails (`setup-execution-guardrails.md`)
 - R10: Project scan phase runs before content sub-flows to collect signals (dependencies, framework, CI, DB, tests, etc.)
-- R11: Version section requires `mode` field (required by schema): `"file"` when version file detected, `"tag"` when not
+- R11: Version section requires `mode` field (required by schema): `"file"` when version file detected, `"tag"` when not. Optional fields include `versionFile`, `fileType`, `tagPrefix`, `changelog`, `changelogFile`, `ticketPrefix`, and `preRelease`. The `preRelease` field, when set, is a string matching `^[a-z][a-z0-9]*$` that supplies a default pre-release label to version-sdlc when the user runs `version-sdlc` without an explicit base bump or `--pre`. Empty / skipped answers omit the field; the schema (`schemas/sdlc-config.schema.json`) does not require it.
 - R12: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R13: Content sub-flows (setup-dimensions, setup-pr-template, setup-guardrails) inherit the parent skill's permission mode. Sub-flows MUST NOT call ExitPlanMode, change permission settings, or exit any mode.
 - R14: Scan phase (R10) MUST use the Glob tool for all file/directory existence checks. Bash MUST NOT be used with glob patterns — zsh errors on unmatched globs. Bash is permitted only for `git`, `gh`, and `which` commands.
@@ -72,7 +72,7 @@
 - G1: Pre-flight passed — `skill/setup.js` exits successfully
 - G2: Config validation — re-run `skill/setup.js` after writing config to verify correctness
 - G3: No direct file writes — all config writes go through `lib/config.js` functions
-- G4: Version mode present — version section always includes `mode` field
+- G4: Version mode present — version section always includes `mode` field. Optional `preRelease` field, if collected, must match `^[a-z][a-z0-9]*$`; invalid values cause re-prompt before write.
 - G5: Migration consent — legacy files only deleted after explicit user confirmation
 
 ## Prepare Script Contract

--- a/docs/specs/ship-sdlc.md
+++ b/docs/specs/ship-sdlc.md
@@ -11,7 +11,7 @@
 - A1: `--auto` — run pipeline non-interactively; forwarded to sub-skills that support it (default: false)
 - A2: `--steps <csv>` — comma-separated steps to run; valid: execute, commit, review, received-review, commit-fixes, version, pr, archive-openspec. When passed, fully replaces the resolved step list (config `ship.steps[]` and built-in defaults are ignored). The single source of truth for pipeline composition is config `ship.steps[]`; CLI `--steps` is a one-shot override.
 - A3: `--quality full|balanced|minimal` — execution quality (model tier) forwarded to execute-plan-sdlc; only forwarded when explicitly passed via CLI (default: not forwarded; execute-plan-sdlc applies its own selection)
-- A4: `--bump patch|minor|major` — version bump type forwarded to version-sdlc (default: from config or patch)
+- A4: `--bump patch|minor|major|<label>` — version bump type forwarded to version-sdlc; `<label>` is any pre-release label matching `^[a-z][a-z0-9]*$` (e.g., `rc`, `beta`, `alpha`, custom). A label-form value is forwarded verbatim to version-sdlc, where it is interpreted as `--bump patch --pre <label>` (default: from config or patch)
 - A5: `--draft` — create PR as draft (default: from config or false)
 - A6: `--dry-run` — display pipeline plan without executing (default: false)
 - A7: `--resume` — resume pipeline from saved state file (default: false)
@@ -88,7 +88,7 @@
 - G2: Not on default branch — warn if on main/master (do not block)
 - G3: Step values valid — all CLI `--steps` values are recognized step names (`VALID_STEPS` from `lib/ship-fields.js`)
 - G4: At least one step will run — pipeline is not entirely skipped
-- G5: Flag coherence — `--bump` without version step produces error (exit code 1, blocking)
+- G5: Flag coherence — `--bump` without version step produces error (exit code 1, blocking). The `--bump` value space accepts `major|minor|patch` or any pre-release label matching `^[a-z][a-z0-9]*$`; values outside this set are rejected at parse time before the version step runs.
 - G6: Pipeline contract — every `will_run` step was dispatched as Agent
 - G6a: Pipeline completion gate — `state/ship.js cleanup` validates all steps are in terminal state (`completed`, `skipped`, or `failed`) before deleting the state file. Steps still `pending` or `in_progress` cause cleanup to refuse deletion and exit 1.
 - G7: Staging gap filled — `git add -A -- ':!.sdlc/'` ran between execute and commit

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -8,8 +8,8 @@
 
 ## Arguments
 
-- A1: `major|minor|patch` — explicit bump type (default: auto-detected from conventional commits)
-- A2: `--pre <label>` — create or increment a pre-release version with the given label (e.g., beta, rc) (default: none)
+- A1: `major|minor|patch|<label>` — explicit bump type, where `<label>` is any pre-release label matching `^[a-z][a-z0-9]*$` (e.g., `rc`, `beta`, `alpha`, `mycorp`); a label-form value is syntactic sugar for `--bump patch --pre <label>` (default: auto-detected from conventional commits)
+- A2: `--pre <label>` — create or increment a pre-release version with the given label (must match `^[a-z][a-z0-9]*$`; e.g., beta, rc) (default: none)
 - A3: `--changelog` — generate or update a CHANGELOG entry; without a bump type, enters changelog-update workflow (default: from config)
 - A4: `--hotfix` — mark release as a hotfix for DORA metrics tracking (default: false)
 - A5: `--auto` — skip interactive approval prompts; critique gates still run (default: false)
@@ -20,7 +20,7 @@
 
 - R1: Three distinct workflow branches determined by `flow` field: init, release, changelog-update
 - R2: Determine bump type from explicit argument, or auto-detect from conventional commit summary; inform user of auto-selection rationale
-- R3: When `hasBreakingChanges` is true and chosen bump is not major (and not pre-release), warn the user and suggest major bump
+- R3: When `hasBreakingChanges` is true and chosen bump is not major, warn the user and suggest major bump — UNLESS the resolved bump is a pre-release from any source (`--pre <label>`, label-form `--bump <label>`, or `config.preRelease`); pre-release trains skip the warning to avoid nagging on every RC iteration
 - R4: Pre-release handling: `--pre` with bump type computes from base version; `--pre` alone increments existing pre-release counter
 - R5: CHANGELOG entry uses Keep a Changelog format with today's date, mapping commit types to sections (feat→Added, fix→Fixed, refactor/perf→Changed)
 - R6: Skip non-user-facing commit types in CHANGELOG (chore, docs, test, ci, build, style) unless clearly user-facing
@@ -33,6 +33,7 @@
 - R13: Verify pre-conditions before execution: version file exists (file mode), tag does not conflict, no uncommitted changes, git identity configured
 - R14: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
 - R15: When `remoteState.hasUpstream === false`, the push step uses `git push --set-upstream origin <currentBranch>` instead of bare `git push`; the subsequent `git push --tags` is unchanged. This avoids first-push failures on fresh feature branches.
+- R16: Pre-release source precedence (top wins): (1) explicit base bump `major|minor|patch` (with optional `--pre <label>`); (2) explicit label-form `--bump <label>` OR explicit `--pre <label>`; (3) `config.preRelease` from `.claude/sdlc.json`; (4) auto-detection from conventional commits. When `config.preRelease` is set and the user passes neither an explicit base bump nor `--pre` nor a label-form `--bump`, the resolved bump is `patch + --pre <config.preRelease>`. An explicit base bump always graduates the release out of the pre-release train regardless of `config.preRelease`. Label values from any source must match `^[a-z][a-z0-9]*$`.
 
 ## Workflow Phases
 
@@ -62,7 +63,7 @@
 - P2: `config.mode` (string: "file" | "tag") — version storage mode
 - P3: `config.changelog` (boolean) — whether changelog is enabled by default
 - P4: `config.ticketPrefix` (string | null) — Jira/project key prefix for ticket ID extraction
-- P5: `requestedBump` (string | null: "major" | "minor" | "patch") — explicitly requested bump type
+- P5: `requestedBump` (string | null: "major" | "minor" | "patch" | label matching `^[a-z][a-z0-9]*$`) — explicitly requested bump type; a label-form value indicates the user passed `--bump <label>` (sugar for patch + `--pre <label>`), and the script-resolved `flags.preLabel` will reflect this
 - P6: `conventionalSummary.suggestedBump` (string) — auto-detected bump type from commits
 - P7: `conventionalSummary.hasBreakingChanges` (boolean) — whether any commit is a breaking change
 - P8: `bumpOptions` (object: `{ major, minor, patch, preRelease }`) — pre-computed next versions

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.34",
+  "version": "0.17.35",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/ship-fields.js
+++ b/plugins/sdlc-utilities/scripts/lib/ship-fields.js
@@ -31,7 +31,7 @@ const SHIP_FIELDS = [
     type: 'enum',
     options: ['patch', 'minor', 'major'],
     default: 'patch',
-    description: 'Applied by /version-sdlc when no explicit bump argument is passed',
+    description: 'Applied by /version-sdlc when no explicit bump argument is passed. The runtime value space is wider than this questionnaire presents: ship.bump in .sdlc/local.json may also be a pre-release label matching `^[a-z][a-z0-9]*$` (e.g., `rc`, `beta`); enter such values via `ship-init.js --bump <label>` or by editing the config file. Schema (schemas/sdlc-local.schema.json) validates the union pattern.',
   },
   {
     name: 'draft',

--- a/plugins/sdlc-utilities/scripts/lib/version.js
+++ b/plugins/sdlc-utilities/scripts/lib/version.js
@@ -348,6 +348,21 @@ function writeConfig(projectRoot, config) {
 }
 
 // ---------------------------------------------------------------------------
+// Pre-release label validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Single source of truth for valid pre-release label format.
+ * Mirrors the JSON Schema pattern in `schemas/sdlc-config.schema.json` under
+ * `versionSection.properties.preRelease.pattern`. Consumed by:
+ *  - `scripts/skill/version.js` (CLI arg parsing for `--bump <label>` and `--pre <label>`)
+ *  - `scripts/skill/ship.js` (CLI arg parsing for `--bump <label>`)
+ *  - `plugins/sdlc-utilities/scripts/lib/ship-fields.js` (sdlc.json `ship.bump` validation)
+ *  - `plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md` (interactive answer validation)
+ */
+const PRE_RELEASE_LABEL_RE = /^[a-z][a-z0-9]*$/;
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
@@ -374,4 +389,5 @@ module.exports = {
   parseConventionalCommit,
   readConfig,
   writeConfig,
+  PRE_RELEASE_LABEL_RE,
 };

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -45,8 +45,16 @@ const { writeOutput } = require(path.join(LIB, 'output'));
 const { VALID_STEPS, BUILT_IN_DEFAULTS, CANONICAL_STEPS } = require(path.join(LIB, 'ship-fields'));
 const { detectActiveChanges, isArchived } = require(path.join(LIB, 'openspec'));
 const { getAdvisory } = require(path.join(LIB, 'context-advisory'));
+const { PRE_RELEASE_LABEL_RE } = require(path.join(LIB, 'version'));
 
 const VALID_QUALITY = ['full', 'balanced', 'minimal'];
+
+// Bump value space accepted by --bump and ship config `ship.bump`. Mirrors
+// the JSON Schema pattern in `schemas/sdlc-local.schema.json` (shipSection.bump).
+// The value space is the union of the three semver bump types and any
+// pre-release label (forwarded verbatim to version-sdlc, where it is
+// interpreted as `--bump patch --pre <label>`).
+const BUMP_RE = new RegExp(`^(major|minor|patch|${PRE_RELEASE_LABEL_RE.source.slice(1, -1)})$`);
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -87,6 +95,9 @@ function parseArgs(argv) {
       errors.push('--skip is no longer accepted by ship-sdlc. Use --steps <csv> with the desired steps listed instead.');
     } else if (a === '--bump' && args[i + 1]) {
       bump = args[++i];
+      if (!BUMP_RE.test(bump)) {
+        errors.push(`--bump value '${bump}' is invalid. Expected one of: major|minor|patch, or a pre-release label matching ${PRE_RELEASE_LABEL_RE.toString()}.`);
+      }
     } else if (a === '--draft') {
       draft = true;
     } else if (a === '--dry-run') {

--- a/plugins/sdlc-utilities/scripts/skill/version.js
+++ b/plugins/sdlc-utilities/scripts/skill/version.js
@@ -37,7 +37,7 @@ const { checkGitState, getTagList, getCommitsSinceRef, getCommitsBetweenRefs, ge
 const {
   detectVersionFile, readVersion, validateSemver,
   computeNextVersions, computePreRelease, parseConventionalCommit,
-  readConfig,
+  readConfig, PRE_RELEASE_LABEL_RE,
 } = require(path.join(LIB, 'version'));
 const { writeOutput } = require(path.join(LIB, 'output'));
 
@@ -47,6 +47,16 @@ const { writeOutput } = require(path.join(LIB, 'output'));
 
 /**
  * Parse process.argv.slice(2) into a structured args object.
+ *
+ * Bump value space:
+ *  - `major|minor|patch` — explicit base bump
+ *  - `<label>` — pre-release label matching `^[a-z][a-z0-9]*$` (sugar for `--bump patch --pre <label>`)
+ *
+ * When the positional bump matches a label form and the user did not also pass
+ * `--pre <label>`, we set `requestedBump = 'patch'` and `preLabel = <token>`.
+ * If `--pre` is also explicitly passed, that explicit value wins (the
+ * positional label is treated as a duplicate intent and ignored).
+ *
  * @param {string[]} argv  process.argv
  * @returns {{
  *   init: boolean,
@@ -58,20 +68,29 @@ const { writeOutput } = require(path.join(LIB, 'output'));
  *   auto: boolean,
  *   fileOverride: string|null,
  *   warnings: string[],
+ *   errors: string[],
  * }}
  */
 function parseArgs(argv) {
   const args = argv.slice(2);
 
-  let init           = false;
-  let requestedBump  = null;
-  let preLabel       = null;
-  let noPush         = false;
-  let changelog      = false;
-  let hotfix         = false;
-  let auto           = false;
-  let fileOverride   = null;
-  const warnings     = [];
+  let init                = false;
+  let requestedBump       = null;
+  let preLabel            = null;
+  // Track whether --pre was passed explicitly so a label-form positional does
+  // not overwrite an explicit --pre value.
+  let preLabelExplicit    = false;
+  // Track whether the positional bump came from a label-form token; the
+  // skill layer (version-sdlc) consults this to skip the breaking-change
+  // warning (R3 reworded — pre-release source coverage).
+  let bumpFromLabel       = false;
+  let noPush              = false;
+  let changelog           = false;
+  let hotfix              = false;
+  let auto                = false;
+  let fileOverride        = null;
+  const warnings          = [];
+  const errors            = [];
 
   const BUMP_VALUES = new Set(['major', 'minor', 'patch']);
 
@@ -83,7 +102,13 @@ function parseArgs(argv) {
     } else if (a === '--init') {
       init = true;
     } else if (a === '--pre' && args[i + 1]) {
-      preLabel = args[++i];
+      const label = args[++i];
+      if (!PRE_RELEASE_LABEL_RE.test(label)) {
+        errors.push(`Invalid --pre label '${label}'. Labels must match ${PRE_RELEASE_LABEL_RE.toString()} (lowercase, start with a letter, alphanumeric).`);
+      } else {
+        preLabel = label;
+        preLabelExplicit = true;
+      }
     } else if (a === '--no-push') {
       noPush = true;
     } else if (a === '--changelog') {
@@ -96,10 +121,25 @@ function parseArgs(argv) {
       fileOverride = args[++i];
     } else if (a.startsWith('-')) {
       warnings.push(`Unknown flag: ${a}`);
+    } else if (PRE_RELEASE_LABEL_RE.test(a)) {
+      // Label-form bump (e.g. `version-sdlc rc`). Sugar for patch + --pre <label>.
+      if (requestedBump === null) {
+        requestedBump = 'patch';
+        bumpFromLabel = true;
+      }
+      if (!preLabelExplicit) {
+        preLabel = a;
+      }
+    } else {
+      // Token matched no recognized form (positional bump, label, or flag).
+      errors.push(`Unrecognized argument '${a}'. Expected one of: major|minor|patch|<label> (label must match ${PRE_RELEASE_LABEL_RE.toString()}).`);
     }
   }
 
-  return { init, requestedBump, preLabel, noPush, changelog, hotfix, auto, fileOverride, warnings };
+  return {
+    init, requestedBump, preLabel, noPush, changelog, hotfix, auto,
+    fileOverride, warnings, errors, bumpFromLabel, preLabelExplicit,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +176,18 @@ function fileTypeFromPath(filePath) {
 async function main() {
   const projectRoot = process.cwd();
   const args        = parseArgs(process.argv);
+
+  // Fail fast on argument-parse errors (invalid --pre label, unrecognized
+  // positional token). Skip in --init flow because init never accepts a bump
+  // value; flag mismatches there are warnings, not errors.
+  if (!args.init && args.errors.length > 0) {
+    writeOutput({
+      flow:     'release',
+      errors:   args.errors,
+      warnings: args.warnings,
+    }, 'version-context', 1);
+    return;
+  }
 
   // -------------------------------------------------------------------------
   // Init flow
@@ -378,6 +430,39 @@ async function main() {
     return;
   }
 
+  // Validate config.preRelease shape if present (defense in depth — schema
+  // also enforces this). A misconfigured value should fail loudly, not
+  // silently fall through to auto-detection.
+  if (config.preRelease !== undefined && config.preRelease !== null && config.preRelease !== '') {
+    if (typeof config.preRelease !== 'string' || !PRE_RELEASE_LABEL_RE.test(config.preRelease)) {
+      errors.push(`config.preRelease '${config.preRelease}' is invalid. Must match ${PRE_RELEASE_LABEL_RE.toString()}.`);
+      writeOutput({ flow: 'release', errors, warnings }, 'version-context', 1);
+      return;
+    }
+  }
+
+  // Apply config.preRelease default. Per spec R16, the precedence is:
+  //   (1) explicit base bump major|minor|patch (with optional --pre)
+  //   (2) explicit label-form --bump <label> OR explicit --pre <label>
+  //   (3) config.preRelease
+  //   (4) auto-detection from conventional commits (existing path)
+  //
+  // The condition below fires only when the user passed no explicit base
+  // bump AND no preLabel (neither from --pre nor from a label-form bump),
+  // so an explicit --bump major (graduate) or --bump rc (label) bypasses
+  // this branch.
+  let preLabelFromConfig = false;
+  if (
+    args.requestedBump === null &&
+    args.preLabel === null &&
+    typeof config.preRelease === 'string' &&
+    config.preRelease.length > 0
+  ) {
+    args.requestedBump = 'patch';
+    args.preLabel      = config.preRelease;
+    preLabelFromConfig = true;
+  }
+
   // 3. Verify git repo
   let gitState;
   try {
@@ -461,12 +546,53 @@ async function main() {
   const bumpOptions = computeNextVersions(currentVersion);
 
   // 8. Pre-release handling
+  //
+  // Two operating modes:
+  //
+  //   (A) "Pre-release on top of an explicit base bump"
+  //       Triggered by an explicit base bump combined with a pre-release
+  //       label (either via `--minor --pre beta`, or via auto-injected
+  //       patch from `config.preRelease`). Resolves to the next base
+  //       version with the label applied.
+  //         Example: 1.2.3 + --minor --pre beta → 1.3.0-beta.1
+  //
+  //   (B) "Label-form bump (sugar) on the current version"
+  //       Triggered by a positional label-form bump like `version-sdlc rc`.
+  //       The parser sets requestedBump='patch' for downstream code that
+  //       always expects a base, but we delegate to computePreRelease()
+  //       on the CURRENT version so that:
+  //         - 1.2.3        → 1.2.4-rc.1  (no existing pre-release: patch + label)
+  //         - 1.2.4-rc.1   → 1.2.4-rc.2  (same label: increment counter)
+  //         - 1.2.4-beta.3 → 1.2.4-rc.1  (different label: reset counter)
+  //       Note: when the current version has no pre-release, `computePreRelease`
+  //       would produce `1.2.3-rc.1` (no patch). To match the acceptance
+  //       criterion `1.2.3 → 1.2.4-rc.1`, fall back to the patched base in
+  //       that case. This preserves the "fresh pre-release train starts on
+  //       the NEXT release" intuition.
   if (args.preLabel) {
-    if (args.requestedBump) {
-      // Pre-release on top of the next bump, e.g. --minor --pre beta on 1.2.3 → 1.3.0-beta.1
-      const nextBase  = bumpOptions[args.requestedBump]; // e.g. "1.3.0"
+    const currentHasPreRelease = currentVersion.includes('-');
+    // "Sugar mode" covers both the label-form positional bump and the
+    // config.preRelease default — both express "default pre-release intent"
+    // and per spec must behave identically.
+    const sugarMode = args.bumpFromLabel || preLabelFromConfig;
+
+    if (sugarMode) {
+      // Sugar: prefer same-base increment / label-reset on existing
+      // pre-releases; otherwise patch then label (fresh pre-release train).
+      if (currentHasPreRelease) {
+        bumpOptions.preRelease = computePreRelease(currentVersion, args.preLabel);
+      } else {
+        const nextBase = bumpOptions.patch;
+        bumpOptions.preRelease = computePreRelease(nextBase, args.preLabel);
+      }
+    } else if (args.requestedBump) {
+      // Explicit base bump with label (e.g. `--minor --pre beta`):
+      // apply label on top of the bumped base.
+      const nextBase = bumpOptions[args.requestedBump];
       bumpOptions.preRelease = computePreRelease(nextBase, args.preLabel);
     } else {
+      // `--pre <label>` alone: increment / restart pre-release train on the
+      // current version (no base bump).
       bumpOptions.preRelease = computePreRelease(currentVersion, args.preLabel);
     }
   }
@@ -590,11 +716,17 @@ async function main() {
     bumpOptions,
     requestedBump: args.requestedBump,
     flags: {
-      noPush:    args.noPush,
-      changelog: args.changelog,
-      preLabel:  args.preLabel,
-      hotfix:    args.hotfix,
-      auto:      args.auto,
+      noPush:             args.noPush,
+      changelog:          args.changelog,
+      preLabel:           args.preLabel,
+      hotfix:             args.hotfix,
+      auto:               args.auto,
+      // Provenance fields (R16): downstream skill (version-sdlc SKILL.md) uses
+      // these to decide whether the breaking-change warning (R3) applies.
+      // Any pre-release source means "skip the warn".
+      bumpFromLabel:      args.bumpFromLabel,
+      preLabelExplicit:   args.preLabelExplicit,
+      preLabelFromConfig,
     },
     tags:               tagsOutput,
     commits,

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -255,8 +255,25 @@ On **customize**: ask about each field individually using AskUserQuestion:
 4. **tagPrefix** -- prefix for git tags (default: `v`)
 5. **changelog** -- generate changelog on release? yes/no (default: no)
 6. **changelogFile** -- path to changelog file (only if changelog is yes, default: `CHANGELOG.md`)
+7. **preRelease** -- default pre-release label for `version-sdlc` and `ship-sdlc`. Leave empty for stable releases, or set to `rc`/`beta`/`alpha`/etc. Must match `^[a-z][a-z0-9]*$` (lowercase, start with a letter, alphanumeric). When set, running `version-sdlc` (or `ship-sdlc`) without an explicit `major|minor|patch` and without `--pre` produces a pre-release version using this label. Empty/skipped omits the field. Validate against the regex; on mismatch, re-prompt showing the regex.
 
 On **skip**: do not write a version section.
+
+Write the version section with the collected answers. The `preRelease` field is written only if the user supplied a non-empty answer that matched the regex (matching the existing optional-field pattern used for `versionFile` / `changelogFile`):
+```json
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "...",
+    "fileType": "...",
+    "tagPrefix": "v",
+    "changelog": false,
+    "preRelease": "rc"
+  }
+}
+```
+
+The "yes-defaults" path above does NOT write `preRelease` — defaults preserve stable-release behavior.
 
 #### 3b. Ship section
 

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ship-sdlc
-description: "Use this skill when shipping a feature end-to-end after plan acceptance: executing, committing, reviewing, fixing critical issues, versioning, and opening a PR in one flow. Chains execute-plan-sdlc, commit-sdlc, review-sdlc, received-review-sdlc, version-sdlc, and pr-sdlc with conditional review-fix loop. Arguments: [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--init-config]. Triggers on: ship it, ship this, full pipeline, execute to PR, ship feature, run the whole thing."
+description: "Use this skill when shipping a feature end-to-end after plan acceptance: executing, committing, reviewing, fixing critical issues, versioning, and opening a PR in one flow. Chains execute-plan-sdlc, commit-sdlc, review-sdlc, received-review-sdlc, version-sdlc, and pr-sdlc with conditional review-fix loop. Arguments: [--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major|<label>] [--draft] [--dry-run] [--resume] [--init-config]. The `<label>` form for --bump (e.g. `--bump rc`) is forwarded to version-sdlc, where it is interpreted as `--bump patch --pre <label>`; labels must match `^[a-z][a-z0-9]*$`. Triggers on: ship it, ship this, full pipeline, execute to PR, ship feature, run the whole thing."
 user-invocable: true
-argument-hint: "[--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major] [--draft] [--dry-run] [--resume] [--workspace branch|worktree|prompt] [--openspec-change <name>] [--init-config]"
+argument-hint: "[--auto] [--steps <csv>] [--quality full|balanced|minimal] [--bump patch|minor|major|<label>] [--draft] [--dry-run] [--resume] [--workspace branch|worktree|prompt] [--openspec-change <name>] [--init-config]"
 ---
 
 # Ship Pipeline
@@ -232,7 +232,7 @@ Validation checks:
 - Current branch is not the default branch (warn if it is — do not block)
 - All `--steps` values are recognized step names: `execute`, `commit`, `review`, `version`, `pr`, `archive-openspec`
 - At least one step will run
-- Flag combinations are coherent (`--bump` without version step → warn)
+- Flag combinations are coherent (`--bump` without version step → warn). `--bump` accepts `major|minor|patch` or any pre-release label matching `^[a-z][a-z0-9]*$` (e.g. `--bump rc` ships an RC release; the label is forwarded verbatim to version-sdlc).
 
 ---
 

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: version-sdlc
-description: "Use this skill when bumping a project version, creating a git release tag, generating a changelog, or performing a full semantic release workflow, updating an existing changelog entry for the current version. Consumes pre-computed context from skill/version.js and handles the complete release process. Use --changelog without a bump type to update the changelog for the already-tagged current version. Arguments: [major|minor|patch] [--init] [--pre <label>] [--no-push] [--changelog] [--hotfix] [--auto]. Triggers on: version bump, create release, bump version, tag release, generate changelog, semantic versioning, semver bump, pre-release, release candidate. Use --auto to skip interactive approval prompts (release plan is still displayed)."
+description: "Use this skill when bumping a project version, creating a git release tag, generating a changelog, or performing a full semantic release workflow, updating an existing changelog entry for the current version. Consumes pre-computed context from skill/version.js and handles the complete release process. Use --changelog without a bump type to update the changelog for the already-tagged current version. Arguments: [major|minor|patch|<label>] [--init] [--pre <label>] [--no-push] [--changelog] [--hotfix] [--auto]. The positional `<label>` form (e.g. `version-sdlc rc`) is sugar for `--bump patch --pre <label>` and accepts any pre-release label matching `^[a-z][a-z0-9]*$`. Triggers on: version bump, create release, bump version, tag release, generate changelog, semantic versioning, semver bump, pre-release, release candidate. Use --auto to skip interactive approval prompts (release plan is still displayed)."
 user-invocable: true
-argument-hint: "[major|minor|patch] [--pre <label>] [--changelog] [--hotfix] [--auto]"
+argument-hint: "[major|minor|patch|<label>] [--pre <label>] [--changelog] [--hotfix] [--auto]"
 ---
 
 # Versioning Releases Skill
@@ -96,13 +96,13 @@ Read `VERSION_CONTEXT_JSON`. Key fields to extract:
 | `versionSource.currentVersion` | Current version string |
 | `config.mode` | `"file"` or `"tag"` |
 | `config.changelog` | Whether changelog is enabled by default |
-| `requestedBump` | `"major"`, `"minor"`, `"patch"`, or `null` |
+| `requestedBump` | `"major"`, `"minor"`, `"patch"`, or `null`. May be auto-set to `"patch"` by the script when `flags.bumpFromLabel === true` (positional `<label>` sugar) or when `flags.preLabelFromConfig === true` (config-driven default) |
 | `conventionalSummary.suggestedBump` | Auto-detected bump type from commits |
 | `conventionalSummary.hasBreakingChanges` | Whether any commit is a breaking change |
-| `bumpOptions` | `{ major, minor, patch, preRelease }` — pre-computed next versions |
+| `bumpOptions` | `{ major, minor, patch, preRelease }` — pre-computed next versions. `preRelease` is populated whenever any pre-release source is active (`--pre`, label-form `<bump>`, or `config.preRelease`). |
 | `tags.latest` | Most recent tag |
 | `commits` | Array of commits since last tag |
-| `flags` | `{ preLabel, noPush, changelog, hotfix, auto }` — parsed CLI flags |
+| `flags` | `{ preLabel, noPush, changelog, hotfix, auto, bumpFromLabel, preLabelExplicit, preLabelFromConfig }` — parsed CLI flags plus pre-release provenance fields. The provenance flags are mutually exclusive: at most one of `bumpFromLabel`, `preLabelExplicit`, `preLabelFromConfig` is `true`. |
 | `flags.hotfix` | Whether this release is a hotfix (for DORA metrics tracking) |
 | `flags.auto` | Whether `--auto` was passed — skip interactive approval prompts |
 | `config.ticketPrefix` | Optional Jira/project key prefix (e.g. `"PROJ"`). When set, ticket IDs matching this prefix are extracted from commits. |
@@ -113,12 +113,29 @@ Read `VERSION_CONTEXT_JSON`. Key fields to extract:
 
 **Determine new version:**
 
-- If `flags.preLabel` is set:
-  - If `requestedBump` is also set: compute pre-release from the corresponding base version (e.g. `--minor --pre beta` on `1.2.3` → `1.3.0-beta.1`). Use `bumpOptions.preRelease`.
-  - If only `--pre` with no bump type: use `bumpOptions.preRelease` directly (increments existing pre-release counter).
-- If `requestedBump` is explicitly set (and no pre-label): use `bumpOptions[requestedBump]`.
-- Otherwise: use `conventionalSummary.suggestedBump` automatically. Inform the user which bump type was auto-selected and why.
-- If `conventionalSummary.hasBreakingChanges` is true and the chosen bump is not `major` (and is not a pre-release): warn the user that breaking changes were detected and suggest bumping to `major` instead.
+The script (`skill/version.js`) does all label validation and precedence resolution before this step runs. Read the resolved values from `VERSION_CONTEXT_JSON` and select the version verbatim — do not re-derive bump type or label from the original CLI string.
+
+Pre-release intent can come from four sources, with this precedence (top wins):
+
+1. Explicit base bump (`major|minor|patch`) plus optional `--pre <label>`
+2. Explicit label-form positional (e.g. `version-sdlc rc`, equivalent to `--bump patch --pre rc`) OR explicit `--pre <label>`
+3. `config.preRelease` from `.claude/sdlc.json` (active when no explicit bump and no `--pre`)
+4. Auto-detection from conventional commits (no pre-release applied)
+
+The script signals which source fired via `flags.bumpFromLabel`, `flags.preLabelExplicit`, and `flags.preLabelFromConfig`. Use those provenance flags when explaining the choice to the user — do not infer it from raw CLI args.
+
+Decision table:
+
+| `flags.preLabel` | `requestedBump` | Source signal | Use |
+| ---- | ---- | ---- | ---- |
+| set | set (`major`/`minor`/`patch`) | explicit `--pre` plus base bump | `bumpOptions.preRelease` (label on top of bumped base, e.g. `--minor --pre beta` on `1.2.3` → `1.3.0-beta.1`) |
+| set | `"patch"` with `bumpFromLabel: true` | positional label-form (`version-sdlc rc`) | `bumpOptions.preRelease` (script applies same-base same-label increment, label-reset, or fresh patch+label depending on current version state) |
+| set | `"patch"` with `preLabelFromConfig: true` | `config.preRelease` default | `bumpOptions.preRelease` (same semantics as label-form above) |
+| set | `null` | `--pre <label>` alone | `bumpOptions.preRelease` (script computes counter increment / label reset on current version, no base bump) |
+| unset | set (`major`/`minor`/`patch`) | explicit base bump | `bumpOptions[requestedBump]` |
+| unset | `null` | no explicit intent and no `config.preRelease` | `bumpOptions[conventionalSummary.suggestedBump]` (auto-detect) — inform the user of the auto-selection rationale |
+
+**Implements R3 (breaking-change gate, reworded):** if `conventionalSummary.hasBreakingChanges` is `true` AND the chosen bump is not `major`, suggest `major` UNLESS the resolved bump is a pre-release from any source. Detect "is a pre-release" by checking that `flags.preLabel` is non-null (covers all three pre-release sources: explicit `--pre`, label-form positional, and `config.preRelease`). Pre-release trains skip this warning to avoid nagging on every RC iteration.
 
 **Draft CHANGELOG entry** (only if `flags.changelog === true` OR `config.changelog === true`):
 
@@ -291,10 +308,11 @@ If `flags.hotfix === true`, show instead:
 ## Best Practices
 
 1. Always show the full release plan before executing any git commands
-2. Use `--pre beta` or `--pre rc` for pre-release versions; they auto-increment (e.g. `rc.1` → `rc.2`)
-3. For pre-releases: running the full release without `--pre` "graduates" the pre-release to a stable version
-4. Breaking changes require a major bump — suggest it even if the user requested a lower bump type
+2. Use `--pre beta` or `--pre rc` for pre-release versions; they auto-increment (e.g. `rc.1` → `rc.2`). The shorthand `version-sdlc rc` (positional label-form bump) is equivalent to `--bump patch --pre rc`.
+3. For pre-releases: running the full release without `--pre` "graduates" the pre-release to a stable version. An explicit `--bump major|minor|patch` always overrides `config.preRelease` and graduates out of the pre-release train.
+4. Breaking changes require a major bump — suggest it even if the user requested a lower bump type. The suggestion is suppressed when the resolved bump is a pre-release from any source (`--pre`, label-form, or `config.preRelease`).
 5. Changelog entries should be user-facing and outcome-focused, not implementation-focused
+6. Set `version.preRelease` in `.claude/sdlc.json` to default to a pre-release label (e.g. `"rc"`) on every bump until explicit graduation. Configure interactively via `/setup-sdlc`.
 
 ## DO NOT
 

--- a/schemas/sdlc-config.schema.json
+++ b/schemas/sdlc-config.schema.json
@@ -38,6 +38,11 @@
         "ticketPrefix": {
           "type": "string",
           "description": "Jira ticket prefix used to filter commit messages for the changelog (e.g. \"PROJ\")."
+        },
+        "preRelease": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*$",
+          "description": "Default pre-release label applied when no explicit base bump or --pre is given."
         }
       },
       "required": ["mode"],

--- a/schemas/sdlc-local.schema.json
+++ b/schemas/sdlc-local.schema.json
@@ -32,8 +32,8 @@
         },
         "bump": {
           "type": "string",
-          "enum": ["patch", "minor", "major"],
-          "description": "Version bump level."
+          "pattern": "^(major|minor|patch|[a-z][a-z0-9]*)$",
+          "description": "Version bump level. Accepts `major|minor|patch` or any pre-release label matching `^[a-z][a-z0-9]*$` (e.g., `rc`, `beta`, `alpha`). Label values are forwarded verbatim to version-sdlc, where they are interpreted as `--bump patch --pre <label>`."
         },
         "draft": {
           "type": "boolean",

--- a/tests/promptfoo/datasets/ship-sdlc.yaml
+++ b/tests/promptfoo/datasets/ship-sdlc.yaml
@@ -449,3 +449,73 @@
       value: >
         The pipeline table includes the archive-openspec step but shows it as skipped
         with a reason indicating no matching OpenSpec change was found for the current branch.
+
+# ---------------------------------------------------------------------------
+# Pre-release bump labels (#193)
+# ---------------------------------------------------------------------------
+
+- description: "ship-sdlc: --bump rc forwards the label verbatim to version-sdlc"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
+    project_context: >
+      The user runs `/ship-sdlc --bump rc --auto` on feat/payments. ship.js exits 0
+      and emits a pipeline where the version step receives `rc` as its positional
+      bump argument (forwarded verbatim because version-sdlc accepts label-form
+      bumps as sugar for --bump patch --pre rc):
+      {"flags": {"bump": "rc", "auto": true, "steps":
+      ["execute","commit","review","version","pr"]}, "context":
+      {"currentBranch": "feat/payments", "defaultBranch": "main", "ghAuth": true},
+      "steps": [
+        {"skill": "execute-plan-sdlc", "status": "will_run", "args": "", "invocation":
+        "execute-plan-sdlc"},
+        {"skill": "commit-sdlc", "status": "will_run", "args": "--auto", "invocation":
+        "commit-sdlc --auto"},
+        {"skill": "review-sdlc", "status": "will_run", "args": "--committed", "invocation":
+        "review-sdlc --committed"},
+        {"skill": "version-sdlc", "status": "will_run", "args": "rc --auto",
+        "invocation": "version-sdlc rc --auto"},
+        {"skill": "pr-sdlc", "status": "will_run", "args": "--auto", "invocation":
+        "pr-sdlc --auto"}
+      ], "errors": [], "warnings": []}
+    user_request: >
+      Run /ship-sdlc --bump rc --auto. The ship.js output is provided. Show the
+      pipeline table and explain how `rc` flows to the version step.
+  assert:
+    - type: icontains
+      value: "version-sdlc rc"
+    - type: regex
+      value: '(?i)(rc|pre[- ]?release|label)'
+    - type: not-icontains
+      value: "1foo"
+    - type: llm-rubric
+      value: >
+        The pipeline table shows version-sdlc dispatched with `rc` as its positional
+        bump argument. The response notes that `rc` is forwarded verbatim and will
+        be interpreted by version-sdlc as a pre-release label (sugar for
+        --bump patch --pre rc, per the value-space widening). The pipeline does NOT
+        reject the label or coerce it to `patch`. No error about an invalid bump
+        value appears.
+
+- description: "ship-sdlc: --bump 1foo (invalid label) is rejected at parse time"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md"
+    project_context: >
+      The user runs `/ship-sdlc --bump 1foo`. ship.js exits 1 with this output:
+      {"errors": ["--bump value '1foo' is invalid. Expected one of: major|minor|patch,
+      or a pre-release label matching /^[a-z][a-z0-9]*$/."], "warnings": [], "flags":
+      {"bump": "1foo"}, "steps": []}
+    user_request: "Run /ship-sdlc --bump 1foo."
+  assert:
+    - type: icontains
+      value: "1foo"
+    - type: regex
+      value: '(?i)(invalid|reject)'
+    - type: not-icontains
+      value: "Pipeline:"
+    - type: llm-rubric
+      value: >
+        The response surfaces the script's error — `1foo` is invalid because it
+        starts with a digit. The pipeline does NOT proceed; no Agent is dispatched.
+        The response references the regex `^[a-z][a-z0-9]*$` (or paraphrases it)
+        for the valid label format. It does NOT silently coerce the label to
+        `patch` or skip the version step.

--- a/tests/promptfoo/datasets/version-sdlc.yaml
+++ b/tests/promptfoo/datasets/version-sdlc.yaml
@@ -269,3 +269,218 @@
         name "feat/bar" does NOT appear in the push command. This is the regression-guard
         case: ensure auto-upstream behaviour does not leak into branches that already
         have an upstream.
+
+# ---------------------------------------------------------------------------
+# Pre-release bump labels (#193)
+# ---------------------------------------------------------------------------
+
+- description: "version-sdlc: --bump rc from clean 1.2.3 produces 1.2.4-rc.1 with no breaking-change warning"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is on feat/payments. Running version-prepare.js with `rc` (positional
+      label-form bump, sugar for --bump patch --pre rc) produces this version-context
+      JSON (excerpt):
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "changelog": false}, "versionSource": {"currentVersion": "1.2.3"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.4", "minor": "1.3.0",
+      "major": "2.0.0", "preRelease": "1.2.4-rc.1"}, "tags": {"latest": "v1.2.3"},
+      "commits": [{"type": "fix", "subject": "fix payment timeout"}],
+      "flags": {"noPush": false, "auto": false, "hotfix": false, "changelog": false,
+      "preLabel": "rc", "bumpFromLabel": true, "preLabelExplicit": false,
+      "preLabelFromConfig": false}, "conflictsWithNext": {"patch": false,
+      "minor": false, "major": false}, "currentBranch": "feat/payments",
+      "remoteState": {"hasUpstream": true}, "errors": [], "warnings": []}
+    user_request: >
+      Run /version-sdlc rc. The version-prepare.js output is provided in the project
+      context. Show the resolved version and the release plan.
+  assert:
+    - type: icontains
+      value: "1.2.4-rc.1"
+    - type: not-icontains
+      value: "breaking change"
+    - type: not-regex
+      value: '(?i)suggest.*major'
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.preRelease (1.2.4-rc.1) as the resolved release
+        version. It does NOT propose 1.2.4 (plain patch) or 1.3.0 (minor). It does NOT
+        warn about breaking changes or suggest a major bump (R3 reworded — pre-release
+        sources skip the warning). It recognises bumpFromLabel=true and explains that
+        `rc` was treated as a pre-release label. The release plan tag is v1.2.4-rc.1.
+
+- description: "version-sdlc: --bump rc from existing 1.2.4-rc.1 increments counter to 1.2.4-rc.2"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is iterating on an RC. Running version-prepare.js with `rc` produces:
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v"}, "versionSource": {"currentVersion": "1.2.4-rc.1"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.5", "minor": "1.3.0",
+      "major": "2.0.0", "preRelease": "1.2.4-rc.2"}, "tags": {"latest": "v1.2.4-rc.1"},
+      "commits": [{"type": "fix", "subject": "address RC1 review feedback"}],
+      "flags": {"noPush": false, "auto": false, "preLabel": "rc",
+      "bumpFromLabel": true, "preLabelExplicit": false, "preLabelFromConfig": false},
+      "conflictsWithNext": {"patch": false, "preRelease": false},
+      "currentBranch": "feat/payments", "remoteState": {"hasUpstream": true},
+      "errors": [], "warnings": []}
+    user_request: >
+      Run /version-sdlc rc. The version-prepare.js output is provided. Show the
+      resolved version.
+  assert:
+    - type: icontains
+      value: "1.2.4-rc.2"
+    - type: not-icontains
+      value: "1.2.5"
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.preRelease (1.2.4-rc.2) — the same-base counter
+        increment of 1.2.4-rc.1. It does NOT propose 1.2.5-rc.1 (which would be a stale
+        same-label semantic) or 1.2.5 (plain patch). It explicitly notes the counter
+        increment (rc.1 -> rc.2) on the same base.
+
+- description: "version-sdlc: --bump rc from 1.2.4-beta.3 resets counter on label change to 1.2.4-rc.1"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is switching pre-release tracks from beta to rc. Running version-prepare.js
+      with `rc` produces:
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v"}, "versionSource": {"currentVersion": "1.2.4-beta.3"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.5", "minor": "1.3.0",
+      "major": "2.0.0", "preRelease": "1.2.4-rc.1"}, "tags": {"latest": "v1.2.4-beta.3"},
+      "commits": [], "flags": {"noPush": false, "auto": false, "preLabel": "rc",
+      "bumpFromLabel": true, "preLabelExplicit": false, "preLabelFromConfig": false},
+      "conflictsWithNext": {"preRelease": false}, "currentBranch": "feat/payments",
+      "remoteState": {"hasUpstream": true}, "errors": [], "warnings": []}
+    user_request: >
+      Run /version-sdlc rc. The version-prepare.js output is provided. Show the
+      resolved version.
+  assert:
+    - type: icontains
+      value: "1.2.4-rc.1"
+    - type: not-icontains
+      value: "beta"
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.preRelease (1.2.4-rc.1). The counter resets to
+        1 on label change from beta to rc, on the same base 1.2.4. The response does
+        NOT propose 1.2.4-beta.4 (continuing the beta train) or 1.2.5-rc.1 (bumping
+        the base). The label change is acknowledged.
+
+- description: "version-sdlc: --pre with invalid label '1bad' is rejected by the script"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user invokes `/version-sdlc --pre 1bad`. version-prepare.js exits 1 with
+      this output:
+      {"flow": "release", "errors": ["Invalid --pre label '1bad'. Labels must match
+      /^[a-z][a-z0-9]*$/ (lowercase, start with a letter, alphanumeric)."],
+      "warnings": []}
+    user_request: "Run /version-sdlc --pre 1bad."
+  assert:
+    - type: icontains
+      value: "1bad"
+    - type: regex
+      value: '(?i)(invalid|reject|cannot)'
+    - type: not-icontains
+      value: "Release Plan"
+    - type: llm-rubric
+      value: >
+        The response surfaces the script's error verbatim or paraphrased — the label
+        '1bad' is invalid because it starts with a digit. It does NOT proceed to a
+        release plan, does NOT silently coerce the label, and does NOT attempt any
+        git command. It points the user at the regex `^[a-z][a-z0-9]*$` for the
+        valid label format.
+
+- description: "version-sdlc: custom label 'mycorp' is accepted as positional bump"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user wants a private-tag pre-release. Running version-prepare.js with
+      `mycorp` produces:
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v"}, "versionSource": {"currentVersion": "1.0.0"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.0.1", "minor": "1.1.0",
+      "major": "2.0.0", "preRelease": "1.0.1-mycorp.1"}, "tags": {"latest": "v1.0.0"},
+      "commits": [{"type": "feat", "subject": "internal hardening"}],
+      "flags": {"preLabel": "mycorp", "bumpFromLabel": true, "preLabelExplicit": false,
+      "preLabelFromConfig": false, "auto": false}, "conflictsWithNext": {"preRelease": false},
+      "currentBranch": "feat/internal", "remoteState": {"hasUpstream": true},
+      "errors": [], "warnings": []}
+    user_request: "Run /version-sdlc mycorp."
+  assert:
+    - type: icontains
+      value: "1.0.1-mycorp.1"
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.preRelease (1.0.1-mycorp.1) and accepts the
+        custom label. It does NOT reject the label as unrecognized — any label
+        matching `^[a-z][a-z0-9]*$` is valid.
+
+- description: "version-sdlc: config.preRelease=rc with no flags behaves like --bump rc"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user has set `version.preRelease: "rc"` in .claude/sdlc.json. Running
+      version-prepare.js with no positional bump and no flags produces:
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "preRelease": "rc"}, "versionSource": {"currentVersion": "1.2.3"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.2.4", "minor": "1.3.0",
+      "major": "2.0.0", "preRelease": "1.2.4-rc.1"}, "tags": {"latest": "v1.2.3"},
+      "commits": [{"type": "fix", "subject": "fix flaky test"}],
+      "flags": {"preLabel": "rc", "bumpFromLabel": false, "preLabelExplicit": false,
+      "preLabelFromConfig": true, "auto": false}, "conflictsWithNext": {"preRelease": false},
+      "currentBranch": "feat/payments", "remoteState": {"hasUpstream": true},
+      "errors": [], "warnings": []}
+    user_request: "Run /version-sdlc."
+  assert:
+    - type: icontains
+      value: "1.2.4-rc.1"
+    - type: regex
+      value: '(?i)(config|preRelease|sdlc\.json)'
+    - type: not-regex
+      value: '(?i)suggest.*major'
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.preRelease (1.2.4-rc.1) and explicitly mentions
+        that the pre-release label was sourced from config.preRelease (preLabelFromConfig=true)
+        rather than a CLI flag. The behavior matches `--bump rc`. The breaking-change
+        warning is NOT triggered (no breaking changes anyway, but the principle holds).
+
+- description: "version-sdlc: explicit --bump major overrides config.preRelease and graduates"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user has `version.preRelease: "rc"` in .claude/sdlc.json but is graduating
+      with --bump major. Running version-prepare.js with `major` produces:
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "preRelease": "rc"}, "versionSource": {"currentVersion": "1.2.4-rc.1"},
+      "requestedBump": "major", "conventionalSummary": {"suggestedBump": "major",
+      "hasBreakingChanges": true}, "bumpOptions": {"patch": "1.2.5", "minor": "1.3.0",
+      "major": "2.0.0"}, "tags": {"latest": "v1.2.4-rc.1"},
+      "commits": [{"type": "feat", "subject": "feat!: redesign API", "breaking": true}],
+      "flags": {"preLabel": null, "bumpFromLabel": false, "preLabelExplicit": false,
+      "preLabelFromConfig": false, "auto": false}, "conflictsWithNext": {"major": false},
+      "currentBranch": "feat/v2", "remoteState": {"hasUpstream": true},
+      "errors": [], "warnings": []}
+    user_request: "Run /version-sdlc major."
+  assert:
+    - type: icontains
+      value: "2.0.0"
+    - type: not-icontains
+      value: "rc"
+    - type: not-icontains
+      value: "preRelease"
+    - type: llm-rubric
+      value: >
+        The response uses bumpOptions.major (2.0.0) — a clean, non-pre-release version.
+        Explicit base bump overrides config.preRelease (precedence rule). The release
+        plan does NOT include any pre-release suffix. bumpOptions.preRelease is absent
+        from the output (script did not compute one). The user has graduated out of
+        the rc train.


### PR DESCRIPTION
## Summary
Adds pre-release bump label support to `version-sdlc`, `ship-sdlc`, and `setup-sdlc`. Users can now pass a label like `rc`, `beta`, or `alpha` as a bump value (e.g. `version-sdlc rc` or `ship-sdlc --bump rc`) to produce versioned pre-releases such as `1.2.4-rc.1`. A `preRelease` config field in `.claude/sdlc.json` enables a project-level default so every default bump produces a pre-release until an explicit base bump graduates the release.

## Business Context
Teams running incremental release trains (e.g. RC, beta, alpha cycles) had no direct way to produce pre-release versions from the SDLC pipeline without manually passing `--pre <label>` every time. The `--bump <label>` shorthand and config default make pre-release versioning a first-class workflow in the plugin.

## Business Benefits
- Faster RC iteration: `version-sdlc rc` or `ship-sdlc --bump rc` replaces the longer `version-sdlc --pre rc` — fewer flags, same result
- Config-driven pre-release default (`version.preRelease` in `sdlc.json`) lets teams automate RC builds without per-invocation flags
- Invalid label values (e.g. `1bad`, `foo-bar`) are caught at parse time with clear error messages instead of producing silently wrong tags
- Breaking-change warnings are suppressed during pre-release trains (no nagging on every RC iteration), while still firing on stable bumps

## Github Issue
Fixes #193

## Technical Design
Three changes compose the feature:

1. **Label-form positional bump**: `version.js` parser detects when a positional argument matches `^[a-z][a-z0-9]*$` and is not `major|minor|patch`, sets `requestedBump='patch'` and `preLabel=<token>`, and marks `bumpFromLabel=true`. This flag is propagated to the skill layer so it can explain provenance to the user and suppress the R3 breaking-change warning.

2. **`config.preRelease` default**: After reading `.claude/sdlc.json`, the script checks whether `requestedBump` and `preLabel` are both unset; if `config.preRelease` is a valid label string, it injects `requestedBump='patch'` and `preLabel=config.preRelease` and sets `preLabelFromConfig=true`. This is evaluated after CLI arg parsing so explicit flags always win.

3. **Shared `PRE_RELEASE_LABEL_RE`**: A single regex constant in `lib/version.js` is the canonical validation source used by both `skill/version.js` and `skill/ship.js` parsers, the `setup-sdlc` SKILL.md interactive prompt, and the JSON schema patterns.

The decision table in `version-sdlc SKILL.md` was extended to cover all provenance combinations, and R3 was reworded to explicitly exclude pre-release sources from the breaking-change suggestion path.

## Technical Impact
- `schemas/sdlc-config.schema.json`: new optional `preRelease` field under `versionSection`
- `schemas/sdlc-local.schema.json`: `ship.bump` changed from `enum` to `pattern` to accept label values — backward-compatible (existing `patch|minor|major` values still match the pattern)
- No breaking changes to existing CLI flags; all existing invocations continue to work unchanged
- `skill/version.js` output gains three new provenance fields in `flags`: `bumpFromLabel`, `preLabelExplicit`, `preLabelFromConfig` — downstream consumers (version-sdlc SKILL.md) must read these to correctly explain bump rationale

## Changes Overview
- Pre-release label-form bump added to `version-sdlc` and `ship-sdlc` as positional sugar (`version-sdlc rc` = `--bump patch --pre rc`)
- `config.preRelease` config field introduced in `sdlc-config.schema.json` and `setup-sdlc` interactive flow, enabling a project-level default pre-release label
- Label validation centralized in `PRE_RELEASE_LABEL_RE` constant exported from `lib/version.js`, consumed by CLI parsers, SKILL.md, and JSON schemas
- Breaking-change warning gate (R3) updated to suppress nagging during pre-release trains from any source
- Specs (`docs/specs/`) and user docs (`docs/skills/`) updated in sync with implementation
- Comprehensive promptfoo test cases added for all label-form scenarios: fresh pre-release, counter increment, label reset, invalid label rejection, config default, and explicit graduation override

## Testing
Covered by new promptfoo test cases in `tests/promptfoo/datasets/version-sdlc.yaml` and `tests/promptfoo/datasets/ship-sdlc.yaml`. Test scenarios include:
- `version-sdlc rc` from clean `1.2.3` → `1.2.4-rc.1`
- `version-sdlc rc` from `1.2.4-rc.1` → `1.2.4-rc.2` (counter increment)
- `version-sdlc rc` from `1.2.4-beta.3` → `1.2.4-rc.1` (label reset)
- `version-sdlc --pre 1bad` rejected with clear error
- Custom label `mycorp` accepted
- `config.preRelease=rc` with no flags behaves identically to `--bump rc`
- Explicit `--bump major` overrides `config.preRelease` and graduates
- `ship-sdlc --bump rc` forwards `rc` verbatim to `version-sdlc`
- `ship-sdlc --bump 1foo` rejected at parse time