### PR TITLE
feat(#191): setup-sdlc - replace linear walkthrough with selective-section menu

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,9 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-04 — pr-sdlc: PR #196 for feat/191-setup-sdlc-menu
+Custom template active (`.claude/pr-template.md`); 8 custom sections used. Branch was already pushed ("Everything up-to-date" on push). Label `enhancement` inferred from `feat/` branch prefix and `feat(#191)` commit subjects. `prConfig.titlePattern` required `type(#issue): scope - description` form — title validated before `gh pr create`. No JIRA ticket detected (null in context); `Github Issue` section populated with GitHub issue URL from pipeline context instead.
+
 ## 2026-04-29 — pr-sdlc: PR #189 for fix/185-skill-docs-required-guardrail
 Custom template present in repo (`.claude/pr-template.md`); all 8 custom sections used. `skill-docs-required` guardrail config-field-only change — no script or hook needed. Branch was already pushed; `push` step returned "Everything up-to-date". Label `bug` inferred from `fix/` branch prefix.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.36] - 2026-05-04
+
+### Added
+- setup-sdlc: replaced linear configuration flow with a selective multiselect menu; each section now shows a verbose header with purpose, affected files, and current value before prompting (#191)
+
+### Fixed
+- setup-sdlc: corrected stale documentation references, improved error logging, and replaced magic literals with named constants (#191)
+
 ## [0.17.35] - 2026-05-04
 
 ### Added

--- a/docs/skills/setup-sdlc.md
+++ b/docs/skills/setup-sdlc.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Configures the SDLC plugin for a project in one interactive flow. Creates `.claude/sdlc.json` (project-level config) and `.sdlc/local.json` (user-local preferences), and orchestrates content setup (review dimensions, PR template). Replaces the fragmented first-use experience of running multiple init commands separately.
+Configures the SDLC plugin for a project. On invocation, `/setup-sdlc` shows a single multi-select menu listing every section it manages — version tracking, ship pipeline preferences, Jira, review scope, commit/PR patterns, review dimensions, PR template, plan and execution guardrails, and openspec enrichment. Each row shows a state badge (`set`, `not set`, or `legacy`), and only the sections you tick get configured. For every selected section, the skill prints a verbose header before any prompt — purpose, files modified, consuming skills, and a per-option description block — so you know exactly what each toggle controls before you answer.
+
+Creates `.claude/sdlc.json` (project-level config), `.sdlc/local.json` (user-local preferences), and content artifacts (`.claude/review-dimensions/*.yaml`, `.claude/pr-template.md`, `openspec/config.yaml` managed block).
 
 ---
 
@@ -12,6 +14,20 @@ Configures the SDLC plugin for a project in one interactive flow. Creates `.clau
 /setup-sdlc
 ```
 
+Renders the selective-section menu. Sections in state `not set` are pre-checked; `legacy` (migration-required) sections are locked and auto-checked; `set` sections are unchecked by default. Confirm with no rows selected to exit without changes.
+
+```text
+/setup-sdlc --only jira,review
+```
+
+Skip the menu, configure only `jira` and `review`. Useful for scripted runs or follow-up tweaks. Valid ids: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`.
+
+```text
+/setup-sdlc --force
+```
+
+Pre-check every row in the menu (reconfigure everything) instead of pre-selecting only `not set` rows.
+
 ---
 
 ## Flags
@@ -20,8 +36,9 @@ Configures the SDLC plugin for a project in one interactive flow. Creates `.clau
 |------|-------------|---------|
 | `--migrate` | Migrate legacy config files (`.claude/version.json`, `.sdlc/ship-config.json`, etc.) into unified config | — |
 | `--skip <section>` | Skip a config section during setup (version, ship, jira, review, commit, pr, content) | — |
-| `--force` | Reconfigure already-configured sections | — |
-| `--dimensions` | Jump directly to review dimensions sub-flow (skip config builder) | — |
+| `--force` | Pre-check every menu row (reconfigure all sections) | — |
+| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | — |
+| `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | — |
 | `--pr-template` | Jump directly to PR template sub-flow (skip config builder) | — |
 | `--guardrails` | Jump directly to plan guardrails sub-flow (skip config builder) | — |
 | `--execution-guardrails` | Jump directly to execution guardrails sub-flow (skip config builder) | — |
@@ -112,6 +129,58 @@ Expansion mode: proposes only guardrails not already configured.
 
 - Must be inside a git repository
 - Node.js >= 16 (for `setup-prepare.js`)
+
+---
+
+## Sections
+
+Every section the menu can configure. The label, purpose, files modified, and consumed-by columns mirror `scripts/lib/setup-sections.js` — the single source of truth that drives both the menu and the per-prompt help text.
+
+| Section id | Purpose | Files modified | Consumed by |
+|---|---|---|---|
+| `version` | Tells `/version-sdlc` and `/ship-sdlc` where the canonical version lives (file or git tags) and how releases are tagged. | `.claude/sdlc.json` | `/version-sdlc`, `/ship-sdlc` |
+| `ship` | Developer-local pipeline preferences for `/ship-sdlc`: steps, default bump, draft PRs, auto-approve, workspace, rebase policy, review threshold. Stored in gitignored `.sdlc/local.json`. | `.sdlc/local.json` | `/ship-sdlc` |
+| `jira` | Default Jira project key used by `/jira-sdlc`, `/commit-sdlc`, and `/pr-sdlc` when extracting or assigning ticket IDs. | `.claude/sdlc.json` | `/jira-sdlc`, `/commit-sdlc`, `/pr-sdlc` |
+| `review` | Default scope for `/review-sdlc` (committed/staged/working/worktree/all). Local to each developer. | `.sdlc/local.json` | `/review-sdlc` |
+| `commit` | Commit message validation rules used by `/commit-sdlc` (subject regex, allowed types/scopes, required trailers). | `.claude/sdlc.json` | `/commit-sdlc` |
+| `pr` | PR title validation rules used by `/pr-sdlc` (title regex, allowed types/scopes, required trailers). | `.claude/sdlc.json` | `/pr-sdlc` |
+| `review-dimensions` | Review dimensions installed under `.claude/review-dimensions/*.yaml`. Each dimension is a focused check set used by `/review-sdlc`. | `.claude/review-dimensions/*.yaml` | `/review-sdlc` |
+| `pr-template` | PR description template at `.claude/pr-template.md`, used by `/pr-sdlc` when drafting PRs. | `.claude/pr-template.md` | `/pr-sdlc` |
+| `plan-guardrails` | Custom rules at `.claude/sdlc.json#plan.guardrails` evaluated by `/plan-sdlc` during critique phases. | `.claude/sdlc.json` | `/plan-sdlc` |
+| `execution-guardrails` | Runtime guardrails at `.claude/sdlc.json#execute.guardrails` evaluated by `/execute-plan-sdlc` and `/ship-sdlc` before/after each wave. | `.claude/sdlc.json` | `/execute-plan-sdlc`, `/ship-sdlc` |
+| `openspec-block` | Managed block in `openspec/config.yaml` providing sdlc-utilities workflow guidance to OpenSpec-aware skills. Idempotent across plugin versions. | `openspec/config.yaml` | `/plan-sdlc`, `/execute-plan-sdlc`, `/ship-sdlc` |
+
+### Field reference (selected sections)
+
+For each non-delegated section, these are the fields the verbose header reveals before any prompt. Descriptions are the same strings shown at runtime.
+
+#### `version`
+
+| Field | Default | Description |
+|---|---|---|
+| `mode` | `file` | Tells `/version-sdlc` and `/ship-sdlc` whether the canonical version lives in a file or only in git tags. The default `file` mode requires a versionFile path; pick `tag` for projects that derive every release from `git describe`. |
+| `versionFile` | `package.json` | Path to the file that holds the canonical version string. `/version-sdlc` reads and rewrites this file on each bump; setup auto-detects common paths. Ignored when mode is `tag`. |
+| `fileType` | `package.json` | Format used by `/version-sdlc` to parse and rewrite the version file. The default `package.json` reads the top-level `version` key; `version-file` is a plain-text file containing only the version string. |
+| `tagPrefix` | `v` | Prefix prepended to the version when `/version-sdlc` creates a release tag (e.g., prefix `v` produces `v1.2.3`). Empty string is allowed. |
+| `changelog` | `false` | When true, `/version-sdlc` and `/ship-sdlc` append a release entry to `changelogFile` on every bump. |
+| `changelogFile` | `CHANGELOG.md` | Path to the changelog file appended by `/version-sdlc` when changelog is enabled. |
+| `preRelease` | (empty) | When set (e.g., `rc`, `beta`), `/version-sdlc` and `/ship-sdlc` default to a pre-release bump on every default invocation until an explicit `major\|minor\|patch` graduates the release. Must match `^[a-z][a-z0-9]*$`. |
+
+#### `jira`
+
+| Field | Default | Description |
+|---|---|---|
+| `defaultProject` | (empty) | Project key (2–10 uppercase letters, e.g., `PROJ`) used by `/jira-sdlc` when no explicit project is supplied. `/commit-sdlc` and `/pr-sdlc` also use it when extracting ticket IDs from branch names. |
+
+#### `review`
+
+| Field | Default | Description |
+|---|---|---|
+| `scope` | `committed` | Default scope for `/review-sdlc` when no `--committed`/`--staged`/`--working`/`--worktree` flag is passed. `committed` reviews commits on the current branch vs the default branch; `working` reviews staged + unstaged; `all` includes untracked. |
+
+#### `ship`
+
+The seven `ship` fields are imported verbatim from `scripts/lib/ship-fields.js` (single source of truth for both `/ship-sdlc` and `/setup-sdlc`). Run `/setup-sdlc --only ship` to see each field's default and description in the verbose header before answering.
 
 ---
 

--- a/docs/skills/setup-sdlc.md
+++ b/docs/skills/setup-sdlc.md
@@ -35,7 +35,7 @@ Pre-check every row in the menu (reconfigure everything) instead of pre-selectin
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--migrate` | Migrate legacy config files (`.claude/version.json`, `.sdlc/ship-config.json`, etc.) into unified config | — |
-| `--skip <section>` | Skip a config section during setup (version, ship, jira, review, commit, pr, content) | — |
+| `--skip <section>` | Skip a config section during setup (version, ship, jira, review, commit, pr) | — |
 | `--force` | Pre-check every menu row (reconfigure all sections) | — |
 | `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | — |
 | `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | — |

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -19,7 +19,7 @@
 - A9: `--no-copilot` — skip GitHub Copilot instructions, used with `--dimensions` (default: false)
 - A10: `--openspec-enrich` — jump directly to openspec enrichment sub-flow (default: false)
 - A11: `--remove-openspec` — remove the managed block from `openspec/config.yaml` and exit (default: false)
-- A12: Unnamed flag routing: `--dimensions`, `--pr-template`, `--guardrails`, `--execution-guardrails`, `--openspec-enrich` each bypass the main config builder flow and enter their sub-flow directly
+- A12: Flag routing: `--dimensions`, `--pr-template`, `--guardrails`, `--execution-guardrails`, `--openspec-enrich` are sugar for `--only <id>` (translated in Step 0 before the menu runs); they skip the menu and enter the corresponding sub-flow directly
 - A13: `--only <ids>` — comma-separated section ids (matching `prepare.sections[].id`) configured non-interactively; skips the Step 1 menu (default: none). Legacy direct-entry flags (`--dimensions` etc.) are sugar for `--only <id>`.
 
 ## Core Requirements

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -20,6 +20,7 @@
 - A10: `--openspec-enrich` — jump directly to openspec enrichment sub-flow (default: false)
 - A11: `--remove-openspec` — remove the managed block from `openspec/config.yaml` and exit (default: false)
 - A12: Unnamed flag routing: `--dimensions`, `--pr-template`, `--guardrails`, `--execution-guardrails`, `--openspec-enrich` each bypass the main config builder flow and enter their sub-flow directly
+- A13: `--only <ids>` — comma-separated section ids (matching `prepare.sections[].id`) configured non-interactively; skips the Step 1 menu (default: none). Legacy direct-entry flags (`--dimensions` etc.) are sugar for `--only <id>`.
 
 ## Core Requirements
 
@@ -45,27 +46,34 @@
 - R20: `--openspec-enrich` flag provides direct entry to the openspec enrichment sub-flow, bypassing the main config builder (same pattern as `--dimensions`, `--pr-template`)
 - R21: `--remove-openspec` flag removes the managed block (restores user-authored content verbatim) and exits
 - R22: Content outside the managed block is never modified. If the config file lacks a section where the block would naturally fit, the managed block is appended at end-of-file with a preceding blank line.
+- R-menu-1: Step 1 renders a single multi-select menu populated from `prepare.sections[]`. Every visible row, badge, and per-option description is sourced from `scripts/lib/setup-sections.js` — SKILL.md MUST NOT hardcode option labels.
+- R-menu-2: Each menu row shows the section's state badge (`set` | `not-set` | `legacy`) computed from detection state (project config presence, local config, legacy file presence, `localIsV1`, openspec managed-block version).
+- R-menu-3: Migration rows are auto-selected and locked when `needsMigration === true` AND the row's `state === 'legacy'`. Locked rows refuse uncheck and always proceed into Step 3.
+- R-menu-4: Only sections present in the user's selection (from menu confirm OR `--only <ids>`) enter the Step 3 dispatch loop. Unselected sections are not configured.
+- R-menu-5: Empty selection at the menu (when `--only` was not passed) exits cleanly with a "no changes" summary; no config files are written.
+- R-verbose-1: Each section sub-flow in Step 3 prints a verbose header sourced from `prepare.sections[i]` BEFORE any AskUserQuestion: a `Purpose:` line, a `Files modified:` line, a `Consumed by:` line, a `Config file:` line, and a `Current value:` line. For sections with non-empty `fields[]`, the header is followed by an `Options:` block listing every field's name, type, default, and description.
+- R-verbose-2: All option copy (purpose, per-field description, default, options) comes from `scripts/lib/setup-sections.js` (single source of truth). SKILL.md MUST NOT duplicate or paraphrase that copy.
 
 ## Workflow Phases
 
 1. PRE-FLIGHT — run `skill/setup.js` to detect current config state, legacy files, content status
    - **Script:** `skill/setup.js`
    - **Params:** none
-   - **Output:** JSON → P1-P6 (project config state/sections/path, local config state, legacy file detection, content counts, detected version file/tag prefix/default branch, migration flag)
-2. STATUS REPORT — display what is configured vs missing
+   - **Output:** JSON → P1-P8 plus P-sections (project config state/sections/path, local config state, legacy file detection, content counts, detected version file/tag prefix/default branch, migration flag, openspec block, joined `sections[]`)
+2. SELECTIVE-SECTION MENU — render rows from `prepare.sections[]`; user selects which sections to configure (legacy rows auto-selected and locked); empty selection exits without changes
 3. MIGRATION (conditional) — migrate legacy config files to unified format
    - **Script:** `lib/config.js` → `migrateConfig()` via inline Node.js
    - **Params:** project root, legacy config paths
    - **Output:** merged config written to `.claude/sdlc.json`
-4. CONFIG BUILDER — interactively configure missing sections (version, ship, jira, review, commit, PR)
-   - **Script:** `lib/config.js` → `writeProjectConfig()`, `writeLocalConfig()` via inline Node.js
-   - **Params:** section name, config values (per interactive session)
-   - **Output:** config files written to `.claude/sdlc.json` (project) and `.sdlc/local.json` (local/ship)
-5. CONTENT SETUP — delegate to sub-flows for review dimensions, PR template, guardrails
-6. SUMMARY — display what was created, updated, or migrated
+4. DISPATCH LOOP — for each selected section, print a verbose header (purpose, files-modified, consumed-by, config-file, current-value) sourced from `prepare.sections[i]`, then dispatch the appropriate branch:
+   - `delegatedTo: null` → generic field loop (one AskUserQuestion per `section.fields[]` entry, optionally gated by `section.confirmDetected`)
+   - `delegatedTo: 'inline-commit-builder' | 'inline-pr-builder'` → conditional inline pattern builders for `commit` / `pr` sections
+   - `delegatedTo: 'setup-<sub>'` → invoke the sub-flow document (review-dimensions, pr-template, plan-guardrails, execution-guardrails, openspec-block)
+   - **Output:** config files written to `.claude/sdlc.json` and `.sdlc/local.json` via `lib/config.js::writeProjectConfig`/`writeLocalConfig`; content artifacts written by sub-flows
+5. SUMMARY — display what was created, updated, or migrated
    - **Script:** `skill/setup.js` (re-run for G2 validation)
    - **Params:** none
-   - **Output:** JSON → P1-P6 (re-read to verify correctness of written config)
+   - **Output:** JSON → P-fields re-read to verify correctness of written config
 
 ## Quality Gates
 
@@ -86,6 +94,21 @@
 - P6a: `localIsV1` (boolean) — true when `.sdlc/local.json` ship section has legacy `preset`/`skip` keys, or lacks a top-level `version: 2` stamp
 - P7: `shipFields` (array) — authoritative list of interactive ship-config fields sourced from `scripts/lib/ship-fields.js`. Each entry: `{ name, label, type, options, default, description }`. `name` is the local-config key; `options` is an array of valid values; `default` is the value applied if the user accepts the default answer.
 - P8: `openspecConfig` (object) — `{ exists: boolean, path: string, managedBlockVersion: number|null }` state of `openspec/config.yaml` and its managed block
+- P-sections: `sections` (array) — joined view of `SETUP_SECTIONS` (manifest) × `detect()` state. Drives the Step 1 selective menu and the Step 3 verbose dispatch loop. Each row has shape:
+  - `id` (string) — canonical section id (used by `--only`); one of `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`
+  - `label` (string) — human-readable section name
+  - `state` (string) — `'set'` (configured) | `'not-set'` (no config) | `'legacy'` (legacy file present, `localIsV1`, or managed-block-version below current)
+  - `summary` (string) — one-line summary of the current configuration (empty for `not-set`)
+  - `locked` (boolean) — `true` when `needsMigration === true` and `state === 'legacy'`; locked rows are auto-selected in the menu and cannot be unchecked
+  - `purpose` (string) — one-paragraph runtime explanation of what this section does
+  - `configFile` (string) — `.claude/sdlc.json` | `.sdlc/local.json` | `<delegated>` | `openspec/config.yaml`
+  - `configPath` (string|null) — dot-path within `configFile`, or `null` for delegated/content sections
+  - `consumedBy` (string[]) — skill ids that read this section at runtime
+  - `filesModified` (string[]) — workspace artifacts created or touched
+  - `optional` (boolean) — `true` if the section is safe to leave unset
+  - `delegatedTo` (string|null) — sub-skill id (`setup-dimensions`, `setup-pr-template`, `setup-guardrails`, `setup-execution-guardrails`, `setup-openspec`), inline-builder id (`inline-commit-builder`, `inline-pr-builder`), or `null` for generic field-loop sections
+  - `confirmDetected` (boolean) — `true` when the dispatcher must ask `yes` / `customize` / `skip` BEFORE iterating fields (currently only `version`)
+  - `fields` (array) — entries with shape `{ name, label, type, options, default, description, validate? }` matching the `SHIP_FIELDS` shape; empty for delegated and inline-builder sections
 
 ## Error Handling
 
@@ -135,3 +158,4 @@
 - I10: `jira-sdlc` — consumes jira config written by this skill
 - I11: `setup-openspec.md` — sub-flow for openspec config enrichment
 - I12: `util/openspec-enrich.js` — deterministic script for managed-block operations on `openspec/config.yaml`
+- I13: `lib/setup-sections.js` — single source of truth for the `SETUP_SECTIONS` manifest consumed by `skill/setup.js` to emit `prepare.sections[]` (P-sections) and by SKILL.md Step 1 / Step 3 to render menu rows and verbose headers

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.35",
+  "version": "0.17.36",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/setup-sections.js
+++ b/plugins/sdlc-utilities/scripts/lib/setup-sections.js
@@ -1,0 +1,414 @@
+'use strict';
+
+/**
+ * @file lib/setup-sections.js
+ * @description Single source of truth for setup-sdlc section descriptors.
+ *
+ * Consumed by:
+ *   - scripts/skill/setup.js   → joins SETUP_SECTIONS with detect() state to
+ *                                 emit prepare.sections[] (the menu rows).
+ *   - skills/setup-sdlc/SKILL.md → Step 1 renders rows; Step 3 dispatch loop
+ *                                 reads section.fields, section.purpose,
+ *                                 section.filesModified, section.consumedBy
+ *                                 to build verbose headers and per-field
+ *                                 prompts.
+ *
+ * Schema:
+ *   {
+ *     id,                  // canonical section id (used by --only flag)
+ *     label,               // short human-readable name (menu row)
+ *     purpose,             // one-paragraph runtime explanation
+ *     configFile,          // '.claude/sdlc.json' | '.sdlc/local.json' | <delegated>
+ *     configPath,          // dot-path within configFile, or null for delegated/content sections
+ *     consumedBy: [],      // skill ids that read this section at runtime
+ *     filesModified: [],   // workspace artifacts created or touched
+ *     optional: bool,      // true → safe to leave unset
+ *     delegatedTo: null,   // sub-skill id (for content sections) or null
+ *     confirmDetected: bool, // optional gate prompt before iterating fields
+ *                            //   (true → ask "use detected? / customize / skip")
+ *     fields: [            // each entry uses ship-fields.js shape:
+ *       { name, label, type, options, default, description, validate? }
+ *     ],
+ *     summarize(cfg, detected) -> string,  // one-liner for menu row
+ *   }
+ *
+ * Rules:
+ *   - SHIP_FIELDS is re-exported (===) for id: 'ship'. Do NOT duplicate.
+ *   - field.description must be one or two full sentences naming the
+ *     consuming skill, what runtime behavior changes, and what the default
+ *     produces. No bare labels.
+ *   - Content sections (review-dimensions, pr-template, plan-guardrails,
+ *     execution-guardrails, openspec-block) carry fields: [] and
+ *     delegatedTo: '<sub-skill-id>'. The menu still surfaces purpose,
+ *     filesModified, consumedBy, and state.
+ *   - Sections with conditional sub-prompts that don't fit a flat field
+ *     schema (commit, pr) carry fields: [] and delegatedTo:
+ *     'inline-<id>-builder'. The Step 3 dispatch loop runs the existing
+ *     inline logic for these; the manifest still owns purpose, filesModified,
+ *     consumedBy, and the verbose header copy.
+ *
+ * Keep the schemas (schemas/sdlc-config.schema.json, schemas/sdlc-local.schema.json)
+ * in sync with any field options added here.
+ */
+
+const { SHIP_FIELDS } = require('./ship-fields');
+
+// ---------------------------------------------------------------------------
+// Section descriptors
+// ---------------------------------------------------------------------------
+
+const VERSION_FIELDS = [
+  {
+    name: 'mode',
+    label: 'Version source mode',
+    type: 'enum',
+    options: ['file', 'tag'],
+    default: 'file',
+    description: 'Tells /version-sdlc and /ship-sdlc whether the canonical version lives in a file (`file`) or only in git tags (`tag`). The default `file` mode requires a versionFile path; pick `tag` for projects that derive every release from `git describe`.',
+  },
+  {
+    name: 'versionFile',
+    label: 'Version file path',
+    type: 'string',
+    options: null,
+    default: 'package.json',
+    description: 'Path to the file that holds the canonical version string. /version-sdlc reads and rewrites this file on each bump; setup auto-detects common paths (package.json, Cargo.toml, pyproject.toml, plugin.json) but you can override here. Ignored when mode is `tag`.',
+  },
+  {
+    name: 'fileType',
+    label: 'Version file format',
+    type: 'enum',
+    options: ['package.json', 'cargo.toml', 'pyproject.toml', 'pubspec.yaml', 'plugin.json', 'version-file'],
+    default: 'package.json',
+    description: 'Format used by /version-sdlc to parse and rewrite the version file. The default `package.json` reads the top-level `version` key; `version-file` is a plain-text file containing only the version string. Ignored when mode is `tag`.',
+  },
+  {
+    name: 'tagPrefix',
+    label: 'Git tag prefix',
+    type: 'string',
+    options: null,
+    default: 'v',
+    description: 'Prefix prepended to the version when /version-sdlc creates a release tag (e.g., prefix `v` produces `v1.2.3`). Empty string is allowed for projects that tag with bare semver. Detected from existing tags when possible.',
+  },
+  {
+    name: 'changelog',
+    label: 'Generate CHANGELOG on release?',
+    type: 'boolean',
+    options: ['yes', 'no'],
+    default: false,
+    description: 'When true, /version-sdlc and /ship-sdlc append a release entry to changelogFile (default `CHANGELOG.md`) on every bump. Default `no` keeps the workflow lean — enable if your project publishes release notes.',
+  },
+  {
+    name: 'changelogFile',
+    label: 'CHANGELOG file path',
+    type: 'string',
+    options: null,
+    default: 'CHANGELOG.md',
+    description: 'Path to the changelog file appended by /version-sdlc when changelog is enabled. Default `CHANGELOG.md` matches the conventional location at repo root. Ignored when changelog is disabled.',
+  },
+  {
+    name: 'preRelease',
+    label: 'Default pre-release label',
+    type: 'string',
+    options: null,
+    default: '',
+    description: 'When set (e.g., `rc`, `beta`, `alpha`), /version-sdlc and /ship-sdlc default to a pre-release bump (e.g., `1.2.4-rc.1`) on every default invocation until an explicit `major|minor|patch` graduates the release. Must match `^[a-z][a-z0-9]*$`; empty string omits the field and preserves stable-release behavior.',
+    validate: (v) => v === '' || /^[a-z][a-z0-9]*$/.test(v),
+  },
+];
+
+const JIRA_FIELDS = [
+  {
+    name: 'defaultProject',
+    label: 'Default Jira project key',
+    type: 'string',
+    options: null,
+    default: '',
+    description: 'Project key (2–10 uppercase letters, e.g., `PROJ`) used by /jira-sdlc when no explicit project is supplied. /commit-sdlc and /pr-sdlc also use it when extracting ticket IDs from branch names. Empty string disables Jira integration for the project.',
+    validate: (v) => v === '' || /^[A-Z][A-Z0-9]{1,9}$/.test(v),
+  },
+];
+
+const REVIEW_FIELDS = [
+  {
+    name: 'scope',
+    label: 'Default review scope',
+    type: 'enum',
+    options: ['all', 'committed', 'staged', 'working', 'worktree'],
+    default: 'committed',
+    description: 'Default scope for /review-sdlc when no `--committed`/`--staged`/`--working`/`--worktree` flag is passed. `committed` (default) reviews commits on the current branch vs the default branch; `working` reviews staged + unstaged; `all` includes untracked.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers used by summarize() functions
+// ---------------------------------------------------------------------------
+
+function summarizeVersion(cfg, detected) {
+  if (!cfg) {
+    if (detected && detected.versionFile) {
+      return `detected: ${detected.versionFile} (${detected.fileType}), tag: ${detected.tagPrefix || 'v'}`;
+    }
+    return '';
+  }
+  const parts = [];
+  if (cfg.mode === 'file' && cfg.versionFile) parts.push(`file: ${cfg.versionFile}`);
+  if (cfg.mode === 'tag') parts.push('mode: tag');
+  if (cfg.tagPrefix != null) parts.push(`tag: ${cfg.tagPrefix}`);
+  if (cfg.preRelease) parts.push(`pre: ${cfg.preRelease}`);
+  return parts.join(', ');
+}
+
+function summarizeShip(cfg) {
+  if (!cfg) return '';
+  const parts = [];
+  if (Array.isArray(cfg.steps)) parts.push(`steps: ${cfg.steps.join(',')}`);
+  if (cfg.bump) parts.push(`bump: ${cfg.bump}`);
+  if (cfg.workspace) parts.push(`workspace: ${cfg.workspace}`);
+  return parts.join('  ');
+}
+
+function summarizeJira(cfg) {
+  if (!cfg || !cfg.defaultProject) return '';
+  return `project: ${cfg.defaultProject}`;
+}
+
+function summarizeReview(cfg) {
+  if (!cfg || !cfg.scope) return '';
+  return `scope: ${cfg.scope}`;
+}
+
+function summarizeCommit(cfg) {
+  if (!cfg) return '';
+  const parts = [];
+  if (cfg.subjectPattern) {
+    const trimmed = cfg.subjectPattern.length > 40
+      ? cfg.subjectPattern.slice(0, 37) + '...'
+      : cfg.subjectPattern;
+    parts.push(`pattern: ${trimmed}`);
+  }
+  if (Array.isArray(cfg.allowedTypes) && cfg.allowedTypes.length > 0) {
+    parts.push(`types: ${cfg.allowedTypes.length}`);
+  }
+  return parts.join('  ');
+}
+
+function summarizePr(cfg) {
+  if (!cfg) return '';
+  const parts = [];
+  if (cfg.titlePattern) {
+    const trimmed = cfg.titlePattern.length > 40
+      ? cfg.titlePattern.slice(0, 37) + '...'
+      : cfg.titlePattern;
+    parts.push(`pattern: ${trimmed}`);
+  }
+  return parts.join('  ');
+}
+
+function summarizeReviewDimensions(_cfg, detected) {
+  if (!detected) return '';
+  const count = detected?.content?.reviewDimensions?.count || 0;
+  return count > 0 ? `${count} installed` : '';
+}
+
+function summarizePrTemplate(_cfg, detected) {
+  if (!detected) return '';
+  return detected?.content?.prTemplate?.exists ? 'installed' : '';
+}
+
+function summarizePlanGuardrails(_cfg, detected) {
+  if (!detected) return '';
+  const count = detected?.content?.planGuardrails?.count || 0;
+  return count > 0 ? `${count} configured` : '';
+}
+
+function summarizeExecutionGuardrails(_cfg, detected) {
+  // execute.guardrails count — read from parsed project config when available
+  if (!detected || !detected._parsedProjectConfig) return '';
+  const guardrails = detected._parsedProjectConfig?.execute?.guardrails;
+  if (Array.isArray(guardrails) && guardrails.length > 0) {
+    return `${guardrails.length} configured`;
+  }
+  return '';
+}
+
+function summarizeOpenspecBlock(_cfg, detected) {
+  if (!detected || !detected.openspecConfig?.exists) return '';
+  const v = detected.openspecConfig.managedBlockVersion;
+  if (v == null) return 'config present, no managed block';
+  return `managed-block v${v}`;
+}
+
+// ---------------------------------------------------------------------------
+// SETUP_SECTIONS — 11 entries, ordered by typical setup flow
+// ---------------------------------------------------------------------------
+
+const SETUP_SECTIONS = [
+  {
+    id: 'version',
+    label: 'version',
+    purpose: 'Tells /version-sdlc and /ship-sdlc where the canonical version string lives (a file, or only git tags) and how releases are tagged. Without this section, version bumps and release tagging fall back to defaults that may not match your project layout.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'version',
+    consumedBy: ['version-sdlc', 'ship-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: false,
+    delegatedTo: null,
+    confirmDetected: true,
+    fields: VERSION_FIELDS,
+    summarize: summarizeVersion,
+  },
+  {
+    id: 'ship',
+    label: 'ship',
+    purpose: 'Developer-local pipeline preferences for /ship-sdlc: which steps run by default, default version bump, draft-PR mode, auto-approve, workspace isolation, rebase policy, and review-failure threshold. Stored in .sdlc/local.json (gitignored) so each developer can tune the pipeline without affecting teammates.',
+    configFile: '.sdlc/local.json',
+    configPath: 'ship',
+    consumedBy: ['ship-sdlc'],
+    filesModified: ['.sdlc/local.json'],
+    optional: false,
+    delegatedTo: null,
+    confirmDetected: false,
+    fields: SHIP_FIELDS,
+    summarize: summarizeShip,
+  },
+  {
+    id: 'jira',
+    label: 'jira',
+    purpose: 'Default Jira project key used by /jira-sdlc, /commit-sdlc, and /pr-sdlc when extracting or assigning ticket IDs. Without it, Jira-aware skills require an explicit project on every invocation; with it, branch names like `feat/PROJ-123-foo` resolve automatically.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'jira',
+    consumedBy: ['jira-sdlc', 'commit-sdlc', 'pr-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    delegatedTo: null,
+    confirmDetected: false,
+    fields: JIRA_FIELDS,
+    summarize: summarizeJira,
+  },
+  {
+    id: 'review',
+    label: 'review',
+    purpose: 'Default scope for /review-sdlc (committed/staged/working/worktree/all). Each developer typically prefers a different default — committed for PR-style review, working for in-progress feedback. Stored in .sdlc/local.json.',
+    configFile: '.sdlc/local.json',
+    configPath: 'review',
+    consumedBy: ['review-sdlc'],
+    filesModified: ['.sdlc/local.json'],
+    optional: true,
+    delegatedTo: null,
+    confirmDetected: false,
+    fields: REVIEW_FIELDS,
+    summarize: summarizeReview,
+  },
+  {
+    id: 'commit',
+    label: 'commit',
+    purpose: 'Commit message validation rules used by /commit-sdlc: subject regex, allowed Conventional-Commits types/scopes, types that require a body, required trailer headers. The skill enforces these patterns when generating and validating commit messages.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'commit',
+    consumedBy: ['commit-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    // Conditional sub-prompts (conventional/ticket-prefix/custom/skip with
+    // per-strategy refinement) don't fit a flat field schema. The Step 3
+    // dispatch loop runs the existing inline 3e logic for this section.
+    delegatedTo: 'inline-commit-builder',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizeCommit,
+  },
+  {
+    id: 'pr',
+    label: 'pr',
+    purpose: 'PR title validation rules used by /pr-sdlc: title regex, allowed Conventional-Commits types/scopes, required trailers. Mirrors commit patterns; can copy the commit config or use a different style.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'pr',
+    consumedBy: ['pr-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    // Same conditional-sub-prompt model as commit — see id: 'commit' note.
+    delegatedTo: 'inline-pr-builder',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizePr,
+  },
+  {
+    id: 'review-dimensions',
+    label: 'review-dimensions',
+    purpose: 'Review dimensions installed under .claude/review-dimensions/*.yaml. Each dimension is a focused check set (security, performance, type safety, etc.) that /review-sdlc applies as a pass over the diff. Without dimensions installed, /review-sdlc has nothing to evaluate.',
+    configFile: '<delegated>',
+    configPath: null,
+    consumedBy: ['review-sdlc'],
+    filesModified: ['.claude/review-dimensions/*.yaml'],
+    optional: true,
+    delegatedTo: 'setup-dimensions',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizeReviewDimensions,
+  },
+  {
+    id: 'pr-template',
+    label: 'pr-template',
+    purpose: 'PR description template at .claude/pr-template.md, used by /pr-sdlc when drafting PRs. The sub-flow scans existing GitHub PR templates, recent PRs, and Jira evidence to propose a tailored template; without it, /pr-sdlc uses a built-in fallback.',
+    configFile: '<delegated>',
+    configPath: null,
+    consumedBy: ['pr-sdlc'],
+    filesModified: ['.claude/pr-template.md'],
+    optional: true,
+    delegatedTo: 'setup-pr-template',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizePrTemplate,
+  },
+  {
+    id: 'plan-guardrails',
+    label: 'plan-guardrails',
+    purpose: 'Custom rules at .claude/sdlc.json#plan.guardrails evaluated by /plan-sdlc during its critique phases. Each guardrail is a natural-language constraint (e.g., "no direct DB access from controllers") that flags drift in plans before execution.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'plan.guardrails',
+    consumedBy: ['plan-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    delegatedTo: 'setup-guardrails',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizePlanGuardrails,
+  },
+  {
+    id: 'execution-guardrails',
+    label: 'execution-guardrails',
+    purpose: 'Runtime guardrails at .claude/sdlc.json#execute.guardrails evaluated by /execute-plan-sdlc and /ship-sdlc before and after each wave. Error-severity violations halt execution; warning-severity violations are reported but non-blocking.',
+    configFile: '.claude/sdlc.json',
+    configPath: 'execute.guardrails',
+    consumedBy: ['execute-plan-sdlc', 'ship-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    delegatedTo: 'setup-execution-guardrails',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizeExecutionGuardrails,
+  },
+  {
+    id: 'openspec-block',
+    label: 'openspec-block',
+    purpose: 'Managed block injected into openspec/config.yaml that supplies sdlc-utilities workflow guidance to OpenSpec-aware skills (/plan-sdlc, /execute-plan-sdlc, /ship-sdlc). Idempotent: re-running at the same plugin version is a no-op; version bumps update the block in place.',
+    configFile: 'openspec/config.yaml',
+    configPath: '<managed-block>',
+    consumedBy: ['plan-sdlc', 'execute-plan-sdlc', 'ship-sdlc'],
+    filesModified: ['openspec/config.yaml'],
+    optional: true,
+    delegatedTo: 'setup-openspec',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizeOpenspecBlock,
+  },
+];
+
+// Identity sanity check: id: 'ship' MUST re-export SHIP_FIELDS by reference,
+// not by copy. Fail loudly if a future edit breaks this invariant.
+const _shipEntry = SETUP_SECTIONS.find(s => s.id === 'ship');
+if (_shipEntry.fields !== SHIP_FIELDS) {
+  throw new Error('setup-sections.js: id=ship must re-export SHIP_FIELDS by reference (===).');
+}
+
+module.exports = { SETUP_SECTIONS };

--- a/plugins/sdlc-utilities/scripts/skill/setup.js
+++ b/plugins/sdlc-utilities/scripts/skill/setup.js
@@ -17,6 +17,7 @@ const { detectVersionFile } = require(path.join(LIB, 'version'));
 const { LEGACY, PROJECT_CONFIG_PATH, LOCAL_CONFIG_PATH, PROJECT_SECTIONS } = require(path.join(LIB, 'config'));
 const { writeOutput } = require(path.join(LIB, 'output'));
 const { SHIP_FIELDS } = require(path.join(LIB, 'ship-fields'));
+const { SETUP_SECTIONS } = require(path.join(LIB, 'setup-sections'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -194,6 +195,143 @@ function detect(projectRoot) {
     misplacedSections.length > 0 ||
     localIsV1;
   result.localIsV1 = localIsV1;
+
+  // ---------------------------------------------------------------------------
+  // sections[] — joined view of SETUP_SECTIONS × detect() state. Drives the
+  // selective-section menu in setup-sdlc/SKILL.md Step 1 and the verbose
+  // dispatch loop in Step 3. See lib/setup-sections.js for the manifest.
+  // Existing top-level keys above are preserved for back-compat.
+  // ---------------------------------------------------------------------------
+
+  // Read local config once (parsed) so summarize() can render set-state rows.
+  let parsedLocalConfig = null;
+  if (localExists) {
+    try {
+      parsedLocalConfig = JSON.parse(fs.readFileSync(localPath, 'utf8'));
+    } catch (_) { /* unreadable — leave null */ }
+  }
+
+  // Build a detected-context object for summarize() consumers. The leading
+  // underscore on _parsedProjectConfig signals "internal — not part of the
+  // P-field contract" but it is still serialized in the JSON output, which is
+  // fine because summarize() runs server-side here, not in the LLM.
+  const detectedContext = {
+    versionFile: detectedVersionFile,
+    fileType: detectedFileType,
+    tagPrefix,
+    defaultBranch,
+    content: result.content,
+    openspecConfig: result.openspecConfig,
+    _parsedProjectConfig: parsedProjectConfig,
+  };
+
+  // Resolve current config slice for a given section, used as `summarize(cfg, detected)`.
+  function currentCfgFor(section) {
+    if (section.configFile === '.claude/sdlc.json' && section.configPath) {
+      // Walk dot-path. `plan.guardrails`, `execute.guardrails` need split.
+      let cfg = parsedProjectConfig;
+      if (!cfg) return null;
+      for (const key of section.configPath.split('.')) {
+        cfg = cfg?.[key];
+        if (cfg == null) return null;
+      }
+      return cfg;
+    }
+    if (section.configFile === '.sdlc/local.json' && section.configPath) {
+      return parsedLocalConfig?.[section.configPath] ?? null;
+    }
+    // Delegated/content sections — no direct config slice; summarize reads detected
+    return null;
+  }
+
+  // Compute state: 'set' | 'not-set' | 'legacy'
+  function computeState(section) {
+    // Legacy detection per section
+    if (section.id === 'version' && result.legacy.version.exists) return 'legacy';
+    if (section.id === 'ship') {
+      if (result.legacy.ship.exists) return 'legacy';
+      if (localIsV1) return 'legacy';
+    }
+    if (section.id === 'review') {
+      if (result.legacy.review.exists || result.legacy.reviewLegacy.exists) return 'legacy';
+      if (localIsV1) return 'legacy';
+    }
+    if (section.id === 'jira' && result.legacy.jira.exists) return 'legacy';
+    if (section.id === 'openspec-block') {
+      // Legacy when managed block version is set but below current. The current
+      // plugin-shipped version is encoded inside util/openspec-enrich.js; we
+      // approximate "legacy" here as managedBlockVersion < 2 (v1 was the first
+      // shipped block version). Keep this conservative — a false 'set' is
+      // safer than a false 'legacy', the user can re-run with --force anyway.
+      const v = result.openspecConfig.managedBlockVersion;
+      if (v != null && v < 2) return 'legacy';
+    }
+    // Misplaced section in project config (e.g., `ship` keyed at project level)
+    if (misplacedSections.includes(section.id)) return 'legacy';
+
+    // Set detection
+    if (section.configFile === '.claude/sdlc.json') {
+      // Top-level key for simple sections (version, jira, commit, pr); nested
+      // for plan-guardrails (plan.guardrails) and execution-guardrails
+      // (execute.guardrails).
+      if (section.configPath) {
+        const slice = currentCfgFor(section);
+        if (slice != null) {
+          // For arrays (guardrails), require length > 0 to count as set
+          if (Array.isArray(slice)) return slice.length > 0 ? 'set' : 'not-set';
+          return 'set';
+        }
+      }
+    }
+    if (section.configFile === '.sdlc/local.json') {
+      if (parsedLocalConfig?.[section.configPath] != null) return 'set';
+    }
+    // Content/delegated sections
+    if (section.id === 'review-dimensions') {
+      return result.content.reviewDimensions.count > 0 ? 'set' : 'not-set';
+    }
+    if (section.id === 'pr-template') {
+      return result.content.prTemplate.exists ? 'set' : 'not-set';
+    }
+    if (section.id === 'openspec-block') {
+      return result.openspecConfig.managedBlockVersion != null ? 'set' : 'not-set';
+    }
+    return 'not-set';
+  }
+
+  // Locked: row cannot be unchecked when migration applies and this section is
+  // a migration trigger. The user must run migration; the menu auto-selects it.
+  function computeLocked(section, state) {
+    if (!result.needsMigration) return false;
+    return state === 'legacy';
+  }
+
+  result.sections = SETUP_SECTIONS.map(section => {
+    const state = computeState(section);
+    const cfg = currentCfgFor(section);
+    let summary = '';
+    try {
+      summary = section.summarize(cfg, detectedContext) || '';
+    } catch (_) {
+      summary = '';
+    }
+    return {
+      id: section.id,
+      label: section.label,
+      state,
+      summary,
+      locked: computeLocked(section, state),
+      purpose: section.purpose,
+      configFile: section.configFile,
+      configPath: section.configPath,
+      consumedBy: section.consumedBy,
+      filesModified: section.filesModified,
+      optional: section.optional,
+      delegatedTo: section.delegatedTo,
+      confirmDetected: section.confirmDetected || false,
+      fields: section.fields,
+    };
+  });
 
   return result;
 }

--- a/plugins/sdlc-utilities/scripts/skill/setup.js
+++ b/plugins/sdlc-utilities/scripts/skill/setup.js
@@ -18,6 +18,7 @@ const { LEGACY, PROJECT_CONFIG_PATH, LOCAL_CONFIG_PATH, PROJECT_SECTIONS } = req
 const { writeOutput } = require(path.join(LIB, 'output'));
 const { SHIP_FIELDS } = require(path.join(LIB, 'ship-fields'));
 const { SETUP_SECTIONS } = require(path.join(LIB, 'setup-sections'));
+const { OPENSPEC_ENRICH_VERSION } = require(path.join(__dirname, '..', 'util', 'openspec-enrich'));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -258,13 +259,12 @@ function detect(projectRoot) {
     }
     if (section.id === 'jira' && result.legacy.jira.exists) return 'legacy';
     if (section.id === 'openspec-block') {
-      // Legacy when managed block version is set but below current. The current
-      // plugin-shipped version is encoded inside util/openspec-enrich.js; we
-      // approximate "legacy" here as managedBlockVersion < 2 (v1 was the first
-      // shipped block version). Keep this conservative — a false 'set' is
-      // safer than a false 'legacy', the user can re-run with --force anyway.
+      // Legacy when managed block version is set but below the current plugin-shipped
+      // version (OPENSPEC_ENRICH_VERSION from util/openspec-enrich.js). Keep this
+      // conservative — a false 'set' is safer than a false 'legacy'; the user can
+      // re-run with --force anyway.
       const v = result.openspecConfig.managedBlockVersion;
-      if (v != null && v < 2) return 'legacy';
+      if (v != null && v < OPENSPEC_ENRICH_VERSION) return 'legacy';
     }
     // Misplaced section in project config (e.g., `ship` keyed at project level)
     if (misplacedSections.includes(section.id)) return 'legacy';
@@ -312,7 +312,8 @@ function detect(projectRoot) {
     let summary = '';
     try {
       summary = section.summarize(cfg, detectedContext) || '';
-    } catch (_) {
+    } catch (err) {
+      process.stderr.write(`[setup.js] summarize() failed for section "${section.id}": ${err.message}\n`);
       summary = '';
     }
     return {

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -20,7 +20,7 @@ delegates content creation to specialized skills.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--migrate` | Force migration of legacy config files even if no legacy files are auto-detected | off |
-| `--skip <section>` | Skip a config section during setup. Valid values: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `content` | none |
+| `--skip <section>` | Skip a config section during setup. Valid values: `version`, `ship`, `jira`, `review`, `commit`, `pr` | none |
 | `--force` | Pre-check every menu row (reconfigure everything) instead of selecting only `not-set` rows | off |
 | `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid ids match `prepare.sections[].id`: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | none |
 | `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | off |
@@ -130,17 +130,7 @@ Render every row in `prepare.sections[]` exactly once, in array order. Use `sect
 | `--only <ids>` passed | only the listed ids; other rows hidden, menu skipped |
 | Otherwise | rows where `section.state === 'not-set'` |
 
-**Flag aliases** (legacy direct-entry flags map onto `--only`):
-
-| Flag | Equivalent `--only` |
-|---|---|
-| `--dimensions` | `--only review-dimensions` |
-| `--pr-template` | `--only pr-template` |
-| `--guardrails` | `--only plan-guardrails` |
-| `--execution-guardrails` | `--only execution-guardrails` |
-| `--openspec-enrich` | `--only openspec-block` |
-
-When any of these flags is passed (and `--only` is not), translate to the equivalent `--only <id>`, skip the menu, and proceed to Step 3 with that single id selected. Pass through `--add`, `--no-copilot`, and `--remove-openspec` to the corresponding sub-flow when invoked.
+**Flag aliases:** See the flag-alias routing table in Step 0. When any direct-entry flag is passed (and `--only` is not), the translation is already applied before Step 1 runs — skip the menu and proceed to Step 3 with the resolved id selected.
 
 **Empty selection guard:** If the user confirms with no rows selected (and `--only` was not passed), print:
 
@@ -148,7 +138,7 @@ When any of these flags is passed (and `--only` is not), translate to the equiva
 No sections selected — no changes made.
 ```
 
-Skip Steps 2–4, jump to Step 5 (which will print "no changes" since nothing was written).
+Skip Steps 2–3b, jump to Step 4 (which will print "no changes" since nothing was written).
 
 **Locked rows refuse toggle:** If the user attempts to uncheck a `locked: true` row, re-display the menu with a one-line note: `"<id> is locked — needsMigration is true; complete migration first."` Locked rows always proceed into Step 3 regardless of selection.
 
@@ -452,7 +442,7 @@ If validation fails (sections missing or file unreadable), warn the user and off
 ---
 
 
-### Step 5 -- Summary
+### Step 4 -- Summary
 
 Show what was created or updated:
 

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: setup-sdlc
-description: "Use this skill when setting up the SDLC plugin for a project, initializing configuration, or when any skill reports missing config. Handles unified config creation (.claude/sdlc.json), local config (.sdlc/local.json), and orchestrates content setup (review dimensions, PR template, plan guardrails, execution guardrails, openspec enrichment). Supports direct sub-flow entry via --dimensions, --pr-template, --guardrails, --execution-guardrails, --openspec-enrich. Arguments: [--migrate] [--skip <section>] [--force] [--dimensions] [--pr-template] [--guardrails] [--execution-guardrails] [--openspec-enrich] [--remove-openspec] [--add] [--no-copilot]"
+description: "Use this skill when setting up the SDLC plugin for a project, initializing configuration, or when any skill reports missing config. Renders a selective-section menu so users choose which sections to configure; each selected section prints a verbose header (purpose, files-modified, consuming skills, per-option description) before any prompt. Supports direct sub-flow entry via --only, --dimensions, --pr-template, --guardrails, --execution-guardrails, --openspec-enrich. Arguments: [--migrate] [--skip <section>] [--force] [--only <ids>] [--dimensions] [--pr-template] [--guardrails] [--execution-guardrails] [--openspec-enrich] [--remove-openspec] [--add] [--no-copilot]"
 user-invocable: true
-argument-hint: "[--migrate] [--skip <section>] [--force] [--dimensions] [--pr-template] [--guardrails] [--execution-guardrails] [--openspec-enrich] [--remove-openspec] [--add] [--no-copilot]"
+argument-hint: "[--migrate] [--skip <section>] [--force] [--only <ids>] [--dimensions] [--pr-template] [--guardrails] [--execution-guardrails] [--openspec-enrich] [--remove-openspec] [--add] [--no-copilot]"
 ---
 
 # SDLC Setup
@@ -21,8 +21,9 @@ delegates content creation to specialized skills.
 |------|-------------|---------|
 | `--migrate` | Force migration of legacy config files even if no legacy files are auto-detected | off |
 | `--skip <section>` | Skip a config section during setup. Valid values: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `content` | none |
-| `--force` | Reconfigure all sections even if already configured | off |
-| `--dimensions` | Jump directly to review dimensions sub-flow (skip config builder) | off |
+| `--force` | Pre-check every menu row (reconfigure everything) instead of selecting only `not-set` rows | off |
+| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid ids match `prepare.sections[].id`: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | none |
+| `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | off |
 | `--pr-template` | Jump directly to PR template sub-flow (skip config builder) | off |
 | `--guardrails` | Jump directly to plan guardrails sub-flow (skip config builder) | off |
 | `--execution-guardrails` | Jump directly to execution guardrails sub-flow (skip config builder) | off |
@@ -65,29 +66,19 @@ Parse the JSON output from `$PREPARE_OUTPUT_FILE`. If exit code != 0, display th
 
 **Flag routing (check after pre-flight succeeds):**
 
-If `--dimensions` was passed:
-1. Run the shared project scan phase (same scan defined in Step 4, scan phase).
-2. Read and follow `@setup-dimensions.md`, passing the scan results as "Scan Input". Pass through `--add` and `--no-copilot` modifiers if present.
-3. Jump to Step 5 (summary). Skip Steps 1–4.
+The legacy direct-entry flags map onto `--only` (which now drives Step 3 directly):
 
-If `--pr-template` was passed:
-1. Run the shared project scan phase (same scan defined in Step 4, scan phase).
-2. Read and follow `@setup-pr-template.md`, passing the scan results as "Scan Input". Pass through `--add` if present.
-3. Jump to Step 5 (summary). Skip Steps 1–4.
+| Flag passed | Equivalent `--only <id>` |
+|---|---|
+| `--dimensions` | `--only review-dimensions` |
+| `--pr-template` | `--only pr-template` |
+| `--guardrails` | `--only plan-guardrails` |
+| `--execution-guardrails` | `--only execution-guardrails` |
+| `--openspec-enrich` | `--only openspec-block` |
 
-If `--guardrails` was passed:
-1. Read and follow `@setup-guardrails.md` (it runs its own skill/guardrails.js script internally). Pass through `--add` if present.
-2. Jump to Step 5 (summary). Skip Steps 1–4.
+If any of those flags is passed (and `--only` is not), translate it into `--only <id>`. If `--only <ids>` is passed (directly or via translation), skip Step 1's menu and proceed to Step 2 → Step 3 with `selectedIds = <ids>`. Pass through `--add`, `--no-copilot`, and `--remove-openspec` to the relevant sub-flow when invoked.
 
-If `--execution-guardrails` was passed:
-1. Read and follow `@setup-execution-guardrails.md`. Pass through `--add` if present.
-2. Jump to Step 5 (summary). Skip Steps 1–4.
-
-If `--openspec-enrich` was passed:
-1. Read and follow `@setup-openspec.md`. Pass through `--remove-openspec` as `--remove` if present.
-2. Jump to Step 5 (summary). Skip Steps 1–4.
-
-If none of `--dimensions`, `--pr-template`, `--guardrails`, `--execution-guardrails`, or `--openspec-enrich` was passed: continue with the full interactive flow (Steps 1–4) as normal.
+If none of the direct-entry flags or `--only` were passed: continue with the full interactive flow (Steps 1 → 2 → 3 → 5).
 
 The JSON contains these top-level keys:
 - `projectConfig` -- `{ exists, sections, misplaced, path }`
@@ -97,63 +88,71 @@ The JSON contains these top-level keys:
 - `content` -- `{ reviewDimensions: { count, path }, prTemplate: { exists, path }, jiraTemplates: { count, path } }`
 - `detected` -- `{ versionFile, fileType, tagPrefix, defaultBranch }`
 - `needsMigration` -- boolean: `true` when any legacy file exists OR any misplaced section found in project config
+- `sections` -- array of section descriptors driving Steps 1 and 3 (selective menu + verbose dispatch). Each row: `{ id, label, state ('set'|'not-set'|'legacy'), summary, locked, purpose, configFile, configPath, consumedBy, filesModified, optional, delegatedTo, confirmDetected, fields[] }`. Source of truth: `scripts/lib/setup-sections.js`.
 
 ---
 
-### Step 1 -- Status Report
+### Step 1 -- Selective-Section Menu
 
-Display what is configured vs missing. Use this exact format:
+Render a single multi-select menu populated from `prepare.sections[]`. Every visible row, badge, and per-option description is sourced from the manifest in `scripts/lib/setup-sections.js` — do NOT hardcode option labels here.
+
+**State badge per row** (driven by `section.state`):
+- `[set]` — section is already configured (greyed-out toggle, off by default).
+- `[not set]` — section has no config (toggle on by default).
+- `[legacy]` — section needs migration; toggle is auto-checked AND locked when `section.locked` is true.
+
+**Layout:**
 
 ```
-SDLC Setup Status
+SDLC Setup
 ---------------------------------------------------
-Project config (.claude/sdlc.json):
-  version:  [checkmark] configured / [x] not configured
-  jira:     [checkmark] configured / [x] not configured (optional)
-  commit:   [checkmark] configured / [x] not configured (optional)
-  pr:       [checkmark] configured / [x] not configured (optional)
+Detected configuration:
 
-Local config (.sdlc/local.json):
-  review:   [checkmark] configured / [x] not configured (defaults work)
-  ship:     [checkmark] configured / [x] not configured (defaults work)
+  [set]      <id>            <summary>
+  [not set]  <id>            <summary or "—">
+  [legacy]   <id>            <summary>  (locked — migration required)
+  ...
 
-Content:
-  Review dimensions:  N installed [checkmark] / [x] not installed (required for /review-sdlc)
-  PR template:        installed [checkmark] / [x] not installed (optional, fallback exists)
-  Jira templates:     N installed [checkmark] / [x] not installed (optional)
-
-Legacy files found:
-  .claude/version.json -- will migrate
-  .sdlc/ship-config.json -- will migrate
+Select sections to configure (space toggle, enter confirm):
+  [ ] <id>  — <one-line: section.purpose first sentence>
+  [x] <id>  — <one-line: section.purpose first sentence>
   ...
 ```
 
-Determine configured status:
-- `version`: configured if `projectConfig.sections` includes `"version"`
-- `jira`: configured if `projectConfig.sections` includes `"jira"`
-- `commit`: configured if `projectConfig.sections` includes `"commit"`
-- `pr`: configured if `projectConfig.sections` includes `"pr"`
-- `review`: configured if `localConfig.exists` is true
-- `ship`: configured if `localConfig.exists` is true and local config includes a `"ship"` section
-- Review dimensions: installed if `content.reviewDimensions.count > 0`
-- PR template: installed if `content.prTemplate.exists` is true
-- Jira templates: installed if `content.jiraTemplates.count > 0`
+Render every row in `prepare.sections[]` exactly once, in array order. Use `section.label` and `section.summary` verbatim for the status block; use the first sentence of `section.purpose` for the menu hint.
 
-Legacy files: list each legacy entry where `exists` is true. If none, omit the "Legacy files found" section.
+**Default selection (which rows are pre-checked):**
 
-Misplaced sections: if `projectConfig.misplaced` is non-empty, display a warning:
+| Condition | Pre-checked rows |
+|---|---|
+| `section.locked` is `true` | always checked, cannot toggle |
+| `--force` passed | every row |
+| `--only <ids>` passed | only the listed ids; other rows hidden, menu skipped |
+| Otherwise | rows where `section.state === 'not-set'` |
+
+**Flag aliases** (legacy direct-entry flags map onto `--only`):
+
+| Flag | Equivalent `--only` |
+|---|---|
+| `--dimensions` | `--only review-dimensions` |
+| `--pr-template` | `--only pr-template` |
+| `--guardrails` | `--only plan-guardrails` |
+| `--execution-guardrails` | `--only execution-guardrails` |
+| `--openspec-enrich` | `--only openspec-block` |
+
+When any of these flags is passed (and `--only` is not), translate to the equivalent `--only <id>`, skip the menu, and proceed to Step 3 with that single id selected. Pass through `--add`, `--no-copilot`, and `--remove-openspec` to the corresponding sub-flow when invoked.
+
+**Empty selection guard:** If the user confirms with no rows selected (and `--only` was not passed), print:
+
 ```
-Misplaced sections in project config:
-  ship — should be in .sdlc/local.json (will migrate)
+No sections selected — no changes made.
 ```
 
-**Early exit:** If everything is configured (all project config sections present, local config exists, review dimensions count > 0) AND `needsMigration` is `false` AND `--force` was NOT passed, print:
+Skip Steps 2–4, jump to Step 5 (which will print "no changes" since nothing was written).
 
-```
-All configured. Use --force to reconfigure.
-```
+**Locked rows refuse toggle:** If the user attempts to uncheck a `locked: true` row, re-display the menu with a one-line note: `"<id> is locked — needsMigration is true; complete migration first."` Locked rows always proceed into Step 3 regardless of selection.
 
-And stop.
+Use AskUserQuestion with `multiSelect` to dispatch the menu. The question text is `"Select sections to configure"`; choices are the rows; selected values are the section ids to process. Defer migration and field collection to Step 2 / Step 3.
 
 ---
 
@@ -212,137 +211,85 @@ On **no** (configure from scratch): proceed directly to Step 3 without migration
 
 ---
 
-### Step 3 -- Config Builder
+### Step 3 -- Dispatch Loop (Verbose Per-Section Configuration)
 
-For each missing section (skip any section passed via `--skip`), interactively configure it. When `--force` is passed, treat all sections as missing (reconfigure everything).
+For each id selected in Step 1 (call this list `selectedIds`), in `prepare.sections[]` order, look up the row `section = prepare.sections.find(s => s.id === id)` and:
 
-Write config files via inline Node.js that calls `writeProjectConfig` and `writeLocalConfig` from `lib/config.js`. Resolve the script directory using the same pattern as Step 2.
+1. **Print the verbose header** (every line below sourced from `section.*` — do NOT hardcode):
 
-#### 3a. Version section
+   ```
+   --- Configuring: <section.label> ----------------------------------
+   Purpose:        <section.purpose>
 
-Use the `detected` values from skill/setup.js output to pre-fill. Use AskUserQuestion:
+   Files modified: <section.filesModified joined with ", ">
+   Consumed by:    <section.consumedBy joined with ", ">
+   Config file:    <section.configFile> (path: <section.configPath || "—">)
+   Current value:  <section.summary or "<none>">
+   ```
 
-> Version configuration detected:
->   Version file: {detected.versionFile} ({detected.fileType})
->   Tag prefix: {detected.tagPrefix} (from existing tags)
->
-> Confirm version setup?
+   The header text comes verbatim from the manifest (`scripts/lib/setup-sections.js`). Do NOT rewrite, paraphrase, or omit any of these four lines for any selected section.
 
-Options:
-- **yes** -- use detected settings
-- **customize** -- change settings
-- **skip** -- don't configure versioning
+2. **Print the per-option description block** (only when `section.fields.length > 0`):
 
-On **yes**: write version section with detected values:
-```json
-{
-  "version": {
-    "mode": "file",
-    "versionFile": "{detected.versionFile}",
-    "fileType": "{detected.fileType}",
-    "tagPrefix": "{detected.tagPrefix}",
-    "changelog": false
-  }
-}
-```
+   ```
+   Options:
+     <field.name>  ({field.type}, default: <field.default>)
+                   <field.description>
+     ...
+   ```
 
-If `detected.versionFile` is null (no version file detected), set `mode` to `"tag"` and omit `versionFile` and `fileType`.
+3. **Run the dispatcher for the section's `delegatedTo` value**:
 
-On **customize**: ask about each field individually using AskUserQuestion:
-1. **mode** -- `file` (version tracked in a file) or `tag` (version from git tags only). Required.
-2. **versionFile** -- path to version file (only if mode is `file`)
-3. **fileType** -- format: package.json, cargo.toml, pyproject.toml, pubspec.yaml, plugin.json, version-file (only if mode is `file`)
-4. **tagPrefix** -- prefix for git tags (default: `v`)
-5. **changelog** -- generate changelog on release? yes/no (default: no)
-6. **changelogFile** -- path to changelog file (only if changelog is yes, default: `CHANGELOG.md`)
-7. **preRelease** -- default pre-release label for `version-sdlc` and `ship-sdlc`. Leave empty for stable releases, or set to `rc`/`beta`/`alpha`/etc. Must match `^[a-z][a-z0-9]*$` (lowercase, start with a letter, alphanumeric). When set, running `version-sdlc` (or `ship-sdlc`) without an explicit `major|minor|patch` and without `--pre` produces a pre-release version using this label. Empty/skipped omits the field. Validate against the regex; on mismatch, re-prompt showing the regex.
+   | `delegatedTo` value | Dispatcher |
+   |---|---|
+   | `null` | Generic field-loop (3.G below) — dispatch one AskUserQuestion per `section.fields[]` entry, optionally gated by `section.confirmDetected` |
+   | `'inline-commit-builder'` | Inline commit-pattern builder (3.commit below) — same conditional logic as legacy Step 3e, gated by the verbose header above |
+   | `'inline-pr-builder'` | Inline PR-pattern builder (3.pr below) — same conditional logic as legacy Step 3f |
+   | `'setup-dimensions'` | Run scan phase (Step 3.S below), then read and follow `@setup-dimensions.md` passing scan results as "Scan Input". Pass through `--add` and `--no-copilot` modifiers if present. |
+   | `'setup-pr-template'` | Run scan phase (Step 3.S), then read and follow `@setup-pr-template.md` passing scan results. Pass through `--add` if present. |
+   | `'setup-guardrails'` | Read and follow `@setup-guardrails.md` (it runs its own scan internally). Pass through `--add` if present. |
+   | `'setup-execution-guardrails'` | Read and follow `@setup-execution-guardrails.md`. Pass through `--add` if present. |
+   | `'setup-openspec'` | Read and follow `@setup-openspec.md`. Pass through `--remove-openspec` as `--remove` if present. |
 
-On **skip**: do not write a version section.
+After the loop, write any pending project-config and local-config slices via the "Writing config files" sub-section at the end of Step 3.
 
-Write the version section with the collected answers. The `preRelease` field is written only if the user supplied a non-empty answer that matched the regex (matching the existing optional-field pattern used for `versionFile` / `changelogFile`):
-```json
-{
-  "version": {
-    "mode": "file",
-    "versionFile": "...",
-    "fileType": "...",
-    "tagPrefix": "v",
-    "changelog": false,
-    "preRelease": "rc"
-  }
-}
-```
+#### 3.G. Generic field loop (delegatedTo === null)
 
-The "yes-defaults" path above does NOT write `preRelease` — defaults preserve stable-release behavior.
+For sections with `delegatedTo: null` (`version`, `ship`, `jira`, `review`):
 
-#### 3b. Ship section
+If `section.confirmDetected === true` (currently only `version`), dispatch a meta-prompt FIRST using AskUserQuestion:
 
-Note to the user: "Ship config is stored in `.sdlc/local.json` (developer-local, gitignored). Each developer has their own ship preferences."
+> Use detected settings, customize each field, or skip this section?
 
-Iterate over every entry in `prepare.shipFields` (the P7 contract field from Step 0 prepare output). For each entry, dispatch exactly one `AskUserQuestion` using:
-- **Question prompt:** the entry's `label`
-- **Helper text / description:** the entry's `description`
-- **Answer choices:** the entry's `options`
-- **Default answer:** the entry's `default`
+Options: `yes` (write detected values directly), `customize` (iterate `section.fields`), `skip` (write nothing for this section).
 
-You must issue exactly `prepare.shipFields.length` `AskUserQuestion` calls. Do not skip, reorder, batch, or infer answers. Do not hand-enumerate the field list — the shared lib owns it.
+- On **yes**: Build the section value from `prepare.detected.*` (e.g., for `version`: `{ mode: 'file', versionFile, fileType, tagPrefix }`; if `prepare.detected.versionFile` is null, use `{ mode: 'tag', tagPrefix }`). Do NOT write `preRelease` on the yes path.
+- On **customize**: continue to the field iteration below.
+- On **skip**: stop processing this section; do not write anything.
 
-**Answer mapping when writing `.sdlc/local.json`:**
-- `enum` fields → write the selected option string verbatim (no translation)
-- `multi-select` fields → write the selected options as a JSON array
-- `boolean` fields (`draft`, `auto`) → map `yes`→`true`, `no`→`false`
-- For `rebase` specifically, write the selected string (`auto`, `skip`, or `prompt`) verbatim — do NOT translate to `yes`/`no`, as `ship.js` only accepts those three strings or legacy booleans
+For each entry `field` in `section.fields` (when iterating), dispatch one AskUserQuestion:
 
-After the loop, collect answers into a `ship` object (keys = entry `name`, values = normalized per above) and write via the existing `setup-init.js --local-config '{"ship":{...}}'` path.
+- **Question prompt:** `field.label`
+- **Helper text:** `field.description` (verbatim from manifest)
+- **Choices:** `field.options` (or free-text input when `options` is `null`)
+- **Default:** `field.default`
+- **Validation:** if `field.validate` is defined, re-prompt on failure showing the regex/constraint inline
 
-Implements R15; reads P7.
+Skip a field when an upstream answer makes it irrelevant: for `version`, skip `versionFile` and `fileType` if `mode === 'tag'`; skip `changelogFile` if `changelog === false`; omit `preRelease` from the written config when the user enters an empty string.
 
-#### 3c. Jira section
+**Answer mapping when assembling the section object:**
+- `enum` fields → write the selected option string verbatim
+- `multi-select` fields → write the array of selected options
+- `boolean` fields → map `yes` → `true`, `no` → `false` (exception: `rebase` writes `auto`/`skip`/`prompt` verbatim — do NOT translate to yes/no)
+- `string` fields → write the entered string; omit when empty (and the field is optional)
 
-Use AskUserQuestion:
+You MUST issue exactly one AskUserQuestion per `section.fields[]` entry that survives the gating above. Do not batch, reorder, or hand-enumerate fields — the manifest owns the list.
 
-> Do you use Jira for this project?
+After the field loop, store the assembled section object keyed by id; the "Writing config files" step will persist it.
 
-Options:
-- **yes** -- configure Jira integration
-- **no** -- skip Jira setup
+#### 3.commit. Inline commit-pattern builder (delegatedTo === 'inline-commit-builder')
 
-On **yes**: ask for the default project key (2-10 uppercase letters, e.g., PROJ). Write the jira section:
-```json
-{
-  "jira": {
-    "defaultProject": "PROJ"
-  }
-}
-```
-
-On **no**: do not write a jira section.
-
-#### 3d. Review section (local config)
-
-Use AskUserQuestion:
-
-> Default review scope for /review-sdlc?
-
-Options:
-- **all** -- review all changes (staged + unstaged + untracked)
-- **committed** -- only committed changes vs base branch
-- **staged** -- only staged changes
-- **working** -- staged + unstaged (no untracked)
-- **worktree** -- all changes in the worktree
-
-Default: committed
-
-Write `.sdlc/local.json` with the review section:
-```json
-{
-  "review": {
-    "scope": "committed"
-  }
-}
-```
-
-#### 3e. Commit message patterns
+The verbose header from Step 3 (purpose / files-modified / consumed-by / config-file / current-value) has already been printed. Then run the existing conditional builder:
 
 Use AskUserQuestion:
 
@@ -370,33 +317,15 @@ On **conventional**: Use AskUserQuestion for sequential refinement:
 
 5. "Required trailers?" -- free text comma-separated (e.g., `Ticket`, `Reviewed-By`) or skip → Sets `trailers` array
 
-Assemble the `commit` section object with the following fields:
-```json
-{
-  "commit": {
-    "subjectPattern": "regex-here",
-    "subjectPatternError": "Commit subject must follow Conventional Commits format",
-    "allowedTypes": ["feat", "fix", ...],
-    "allowedScopes": ["scope1", "scope2"],
-    "requiresBody": ["feat", "fix"],
-    "trailers": ["Ticket", "Reviewed-By"]
-  }
-}
-```
-
-Only include optional fields if the user provided values. Omit empty arrays.
+Assemble the `commit` section object. Only include optional fields if the user provided values; omit empty arrays.
 
 On **ticket-prefix**: Use AskUserQuestion for sequential refinement:
 
 1. "Ticket pattern?" -- free text regex (default: `[A-Z]{2,10}-\\d+` for `PROJ-123`) → Sets `ticketPattern`
-
 2. "Combine with conventional type?" -- yes / no:
    - yes: `subjectPattern` becomes `^PROJ-\\d+ (feat|fix|...)(\\(.*\\))?: .+$`
    - no: `subjectPattern` becomes `^PROJ-\\d+: .+$`
-
 3. If combined with types, ask the same type/scope/body/trailer refinement questions as **conventional**.
-
-Assemble the `commit` section with `ticketPattern` and `subjectPattern`.
 
 On **custom**: Use AskUserQuestion:
 
@@ -407,33 +336,22 @@ On **skip**: Do not write a commit section.
 
 Store the assembled `commit` config for use in the "Writing config files" step.
 
-#### 3f. PR title patterns
+#### 3.pr. Inline PR-pattern builder (delegatedTo === 'inline-pr-builder')
+
+Verbose header from Step 3 already printed. Then:
 
 Use AskUserQuestion:
 
 > Do you enforce PR title patterns?
 
 Options:
-- **same-as-commit** -- Use the same pattern as commit messages (only if Step 3e produced a config)
-- **conventional** -- Conventional format for PR titles
+- **same-as-commit** -- Use the same pattern as commit (only when 3.commit produced a config)
+- **conventional** -- Conventional format
 - **ticket-prefix** -- Ticket prefix format
 - **custom** -- Enter your own regex
 - **skip** -- Don't configure PR title patterns
 
-On **same-as-commit** (if available): Copy the commit config fields to PR config with renamed fields:
-- `subjectPattern` → `titlePattern`
-- `subjectPatternError` → `titlePatternError`
-- Keep `allowedTypes`, `allowedScopes`, `requiresBody`, `trailers` as-is
-
-Assemble the `pr` section:
-```json
-{
-  "pr": {
-    "titlePattern": "regex-from-commit",
-    "titlePatternError": "PR title must follow Conventional Commits format"
-  }
-}
-```
+On **same-as-commit** (if available): Copy the commit config fields to PR config with renamed fields: `subjectPattern` → `titlePattern`, `subjectPatternError` → `titlePatternError`. Keep `allowedTypes`, `allowedScopes`, `requiresBody`, `trailers` as-is.
 
 On **conventional**: Use sequential AskUserQuestion:
 
@@ -442,17 +360,55 @@ On **conventional**: Use sequential AskUserQuestion:
 3. "Allowed scopes?" -- free text comma-separated or skip
 4. "Required trailers?" -- free text comma-separated or skip
 
-Assemble the `pr` section with `titlePattern`, `titlePatternError`, `allowedTypes`, `allowedScopes`, `trailers`.
-
-On **ticket-prefix**: Ask same questions as commit (ticket pattern, combine with types, etc.). Assemble `pr` section with `titlePattern`.
+On **ticket-prefix**: Ask same questions as commit (ticket pattern, combine with types, etc.).
 
 On **custom**: Ask:
+
 1. "Enter your regex pattern for PR title:" → free text → `titlePattern`
 2. "Enter error message if pattern doesn't match:" → free text → `titlePatternError`
 
 On **skip**: Do not write a pr section.
 
 Store the assembled `pr` config for use in the "Writing config files" step.
+
+#### 3.S. Scan phase (delegated content sections only)
+
+Before invoking `setup-dimensions` or `setup-pr-template`, run the project signal scan:
+
+> **Shell safety:** Use the **Glob** tool for all file/directory existence checks.
+> Do NOT use Bash `ls` with glob patterns — zsh (macOS default) errors on unmatched globs.
+> Use Bash only for `git` commands, `gh` CLI, and `which`.
+
+- **Dependency manifests:** Use Glob for `package.json`, `requirements.txt`, `Pipfile`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`. Read each found file.
+- **Framework config:** Use Glob for `**/jest.config.*`, `**/vitest.config.*`, `**/.eslintrc*`, `**/tsconfig.json`, `**/openapi.yaml`, `**/openapi.json`, `**/.prettierrc*`.
+- **Directory structure:** Use Glob for `src/`, `lib/`, `controllers/`, `services/`, `middleware/`, `models/`, `routes/`, `api/`, `pkg/`, `cmd/`, `internal/` and patterns from `@scan-patterns.md`.
+- **CI/CD config:** Use Glob for `.github/workflows/*.yml`, `Jenkinsfile`, `.circleci/config.yml`, `.gitlab-ci.yml`.
+- **Database presence:** Use Glob for `prisma/`, `migrations/`, `alembic.ini`, `db/migrate/`, `**/sequelize*`, `**/typeorm*`, `**/sqlalchemy*`.
+- **Test structure:** Use Glob for `test/`, `tests/`, `spec/`, `__tests__/`, `cypress/`, `**/playwright.config.*`.
+- **Existing review dimensions:** Use Glob for `.claude/review-dimensions/*` (count and names).
+- **Existing guardrails:** Use Read on `.claude/sdlc.json` → `plan.guardrails` array if present.
+- **GitHub hosting detection:** Bash for `git remote -v` and `gh repo view` (safe). Use Glob for `.github/`.
+- **CLAUDE.md / AGENTS.md:** Use Read on `CLAUDE.md`, `AGENTS.md`, `.claude/CLAUDE.md` if present.
+- **PR template:** Use Glob for `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`.
+- **Recent PRs:** Bash for `gh pr list --limit 5 --json title,body` (safe).
+- **Existing PR template:** Use Glob for `.claude/pr-template.md`.
+- **JIRA evidence:** Bash for `git log --oneline -20` and `git rev-parse --abbrev-ref HEAD` (safe).
+
+Collect all signals into a "Scan Input" object to pass to the sub-flow. Run the scan once per setup invocation; cache the result for any subsequent delegated section in the same selectedIds list.
+
+#### Legacy section reference
+
+The historical step labels map onto the dispatcher above for anyone updating tests or docs:
+
+| Legacy step | Manifest section id | Dispatcher branch |
+|---|---|---|
+| 3a | `version` | 3.G with `confirmDetected: true` |
+| 3b | `ship` | 3.G |
+| 3c | `jira` | 3.G |
+| 3d | `review` | 3.G |
+| 3e | `commit` | 3.commit |
+| 3f | `pr` | 3.pr |
+
 
 #### Writing config files
 
@@ -495,66 +451,6 @@ If validation fails (sections missing or file unreadable), warn the user and off
 
 ---
 
-### Step 4 -- Content Setup
-
-#### Scan Phase
-
-Before presenting the content menu, collect all project signals needed by the sub-flows:
-
-> **Shell safety:** Use the **Glob** tool for all file/directory existence checks.
-> Do NOT use Bash `ls` with glob patterns — zsh (macOS default) errors on unmatched globs.
-> Use Bash only for `git` commands, `gh` CLI, and `which`.
-
-- **Dependency manifests:** Use Glob for `package.json`, `requirements.txt`, `Pipfile`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`. Read each found file.
-- **Framework config:** Use Glob for `**/jest.config.*`, `**/vitest.config.*`, `**/.eslintrc*`, `**/tsconfig.json`, `**/openapi.yaml`, `**/openapi.json`, `**/.prettierrc*`.
-- **Directory structure:** Use Glob for `src/`, `lib/`, `controllers/`, `services/`, `middleware/`, `models/`, `routes/`, `api/`, `pkg/`, `cmd/`, `internal/` and patterns from `@scan-patterns.md`.
-- **CI/CD config:** Use Glob for `.github/workflows/*.yml`, `Jenkinsfile`, `.circleci/config.yml`, `.gitlab-ci.yml`.
-- **Database presence:** Use Glob for `prisma/`, `migrations/`, `alembic.ini`, `db/migrate/`, `**/sequelize*`, `**/typeorm*`, `**/sqlalchemy*`.
-- **Test structure:** Use Glob for `test/`, `tests/`, `spec/`, `__tests__/`, `cypress/`, `**/playwright.config.*`.
-- **Existing review dimensions:** Use Glob for `.claude/review-dimensions/*` (count and names).
-- **Existing guardrails:** Use Read on `.claude/sdlc.json` → `plan.guardrails` array if present.
-- **GitHub hosting detection:** Bash for `git remote -v` and `gh repo view` (safe). Use Glob for `.github/`.
-- **CLAUDE.md / AGENTS.md:** Use Read on `CLAUDE.md`, `AGENTS.md`, `.claude/CLAUDE.md` if present.
-- **PR template:** Use Glob for `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`.
-- **Recent PRs:** Bash for `gh pr list --limit 5 --json title,body` (safe).
-- **Existing PR template:** Use Glob for `.claude/pr-template.md`.
-- **JIRA evidence:** Bash for `git log --oneline -20` and `git rev-parse --abbrev-ref HEAD` (safe).
-
-Collect all signals into a "Scan Input" object to pass to sub-flows.
-
-#### Content Menu
-
-Use AskUserQuestion with multiSelect:
-
-> Content setup (optional):
->   1. Review dimensions -- required for /review-sdlc
->   2. PR template -- customized PR descriptions
->   3. Plan guardrails -- custom rules for /plan-sdlc critique phases
->   4. OpenSpec enrichment -- add sdlc guidance block to openspec/config.yaml (shown only when `openspecConfig.exists` is true)
->   5. All (dimensions → guardrails → PR template + openspec if detected)
->   6. Skip content setup
-
-Options:
-- **review-dimensions** -- install review dimensions
-- **pr-template** -- create PR template
-- **plan-guardrails** -- configure plan guardrails
-- **openspec-enrich** -- enrich openspec/config.yaml with managed block (shown only when prepare output `openspecConfig.exists` is true AND `openspecConfig.managedBlockVersion` is null)
-- **all** -- run all sequentially (dimensions → guardrails → PR template → openspec enrichment if detected)
-- **skip** -- skip content setup
-
-On **review-dimensions**: Read and follow `@setup-dimensions.md`, passing the scan results as "Scan Input".
-
-On **pr-template**: Read and follow `@setup-pr-template.md`, passing the scan results as "Scan Input".
-
-On **plan-guardrails**: Read and follow `@setup-guardrails.md` (it runs skill/guardrails.js internally).
-
-On **openspec-enrich**: Read and follow `@setup-openspec.md`.
-
-On **all**: Run sequentially in this order: read and follow `@setup-dimensions.md` (passing scan results), then `@setup-guardrails.md`, then `@setup-pr-template.md` (passing scan results), then `@setup-openspec.md` (only if `openspecConfig.exists` is true).
-
-On **skip**: proceed to Step 5.
-
----
 
 ### Step 5 -- Summary
 

--- a/tests/promptfoo/datasets/setup-sdlc.yaml
+++ b/tests/promptfoo/datasets/setup-sdlc.yaml
@@ -1,0 +1,167 @@
+# Behavioral tests for setup-sdlc selective-section menu (issue #191).
+# Covers: full-flow menu, single-section selection, legacy migration row locking,
+# empty selection no-op, --only flag bypassing menu, and verbose-header rendering.
+#
+# Fixture appropriateness:
+#   setup-fully-configured  -- all rows state:'set'; user picks one section to tweak
+#   setup-clean-project     -- all rows state:'not-set'; pre-checked; full flow
+#   setup-legacy-migration  -- legacy rows locked; auto-selected; cannot toggle off
+#
+# All cases run via the LLM provider against `plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md`.
+
+- description: "setup-sdlc: fully-configured project + user picks one section, only that section runs"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-fully-configured.md"
+    user_request: >
+      Run /setup-sdlc. The menu appears; I want to reconfigure only the `jira` section.
+      Show me what the menu looks like, accept my selection of `jira`, then walk me through
+      configuring just that section.
+  assert:
+    # Menu must surface every section row at least by id
+    - type: icontains-all
+      value:
+        - "version"
+        - "ship"
+        - "jira"
+        - "review"
+    # Must render state badges
+    - type: regex
+      value: "(\\[set\\]|set\\b)"
+    # Must show only jira's verbose header in the dispatch (not all sections)
+    - type: icontains
+      value: "jira"
+    # Behavioral
+    - type: llm-rubric
+      value: >
+        The response renders the multi-select menu populated from prepare.sections[]. All 11
+        rows show up at least by id. The user's selection of `jira` is honored, and ONLY the
+        jira section enters the dispatch loop in Step 3 — the response does NOT walk through
+        version, ship, review, commit, or pr. Before asking any jira-specific question, the
+        response prints a verbose header for jira including Purpose, Files modified, and
+        Consumed by lines sourced from the manifest.
+
+- description: "setup-sdlc: clean project + user accepts pre-checked menu, full flow runs"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-clean-project.md"
+    user_request: >
+      Run /setup-sdlc. Nothing is configured; the menu should pre-check every not-set row.
+      Confirm the default selection and show me the first verbose header you'd render
+      (for the `version` section).
+  assert:
+    - type: icontains
+      value: "version"
+    # Pre-check expectation: every row defaulted on
+    - type: regex
+      value: "(\\[x\\]|pre-check|default selection|all selected)"
+    # Verbose header for version
+    - type: icontains-all
+      value:
+        - "Purpose"
+        - "Files modified"
+        - "Consumed by"
+    - type: llm-rubric
+      value: >
+        The response acknowledges that on a clean project all not-set rows are pre-checked
+        in the multi-select menu by default. It confirms the default selection and proceeds
+        to render Step 3 for the first selected section (`version`). The verbose header for
+        version contains four labelled lines: Purpose, Files modified, Consumed by, and
+        Config file (or equivalent). The header text comes from the manifest, not freeform copy.
+
+- description: "setup-sdlc: legacy fixture + migration row locked and cannot be toggled off"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-legacy-migration.md"
+    user_request: >
+      Run /setup-sdlc. The version row is `legacy` (locked: true) and so are ship and review.
+      I want to UNCHECK the `version` row to skip migration. Tell me what happens.
+  assert:
+    - type: icontains-any
+      value:
+        - "locked"
+        - "cannot toggle"
+        - "auto-selected"
+        - "migration"
+    # Must NOT silently allow uncheck
+    - type: llm-rubric
+      value: >
+        The response refuses to allow the user to uncheck the `version` row because it is
+        locked (locked: true in prepare.sections). It explains that locked rows are
+        auto-selected and proceed into Step 3 regardless of user input — migration must
+        complete first. The response does NOT proceed with version skipped; instead it
+        either re-displays the menu with a note, or confirms migration will run.
+
+- description: "setup-sdlc: empty selection at menu exits cleanly with no changes"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-fully-configured.md"
+    user_request: >
+      Run /setup-sdlc. The menu appears. I uncheck every (non-locked) row and confirm
+      with no rows selected. Tell me what happens.
+  assert:
+    - type: icontains-any
+      value:
+        - "no changes"
+        - "no sections selected"
+        - "nothing to configure"
+    # Must NOT walk through any section
+    - type: llm-rubric
+      value: >
+        The response detects the empty selection and exits cleanly with a "no changes" /
+        "no sections selected" summary. It does NOT enter the Step 3 dispatch loop, does
+        NOT run any AskUserQuestion for individual fields, and does NOT write any config
+        files. The summary at Step 5 reflects "nothing was configured."
+
+- description: "setup-sdlc --only jira,review: menu skipped, both sections run"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-fully-configured.md"
+    user_request: >
+      Run /setup-sdlc --only jira,review. Skip the menu entirely; configure only those
+      two sections in dispatch order.
+  assert:
+    - type: icontains-all
+      value:
+        - "jira"
+        - "review"
+    # Must not enumerate sections that were not selected
+    - type: llm-rubric
+      value: >
+        The response treats --only jira,review as bypassing the Step 1 menu and proceeds
+        straight to Step 3 with only those two ids selected. It prints a verbose header
+        for jira and another for review (in that order), runs the per-field prompts (or
+        delegates) for each, and does NOT touch version, ship, commit, pr, or any content
+        sub-flow. The final summary lists only jira and review as configured.
+
+- description: "setup-sdlc: verbose header sourced from manifest precedes any prompt"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: "file://fixtures/setup-clean-project.md"
+    user_request: >
+      Run /setup-sdlc --only jira. Before asking me anything, print the verbose header
+      that the manifest drives — purpose, files modified, consuming skills, and per-option
+      description block.
+  assert:
+    # The four verbose-header labels must appear before any AskUserQuestion
+    - type: icontains-all
+      value:
+        - "Purpose"
+        - "Files modified"
+        - "Consumed by"
+        - "/jira-sdlc"
+    # Field description sentence (substring from manifest)
+    - type: icontains-any
+      value:
+        - "default Jira project"
+        - "ticket"
+        - "PROJ"
+    - type: llm-rubric
+      value: >
+        Before asking any AskUserQuestion, the response prints a verbose header for the
+        jira section. The header contains at minimum: a Purpose line explaining what the
+        jira section does at runtime, a Files modified line listing .claude/sdlc.json,
+        a Consumed by line listing /jira-sdlc, /commit-sdlc, /pr-sdlc, and an Options
+        block describing the defaultProject field with at least one full sentence covering
+        what runtime behavior changes when set. The header copy comes from the manifest
+        (scripts/lib/setup-sections.js), not freeform LLM-generated text.

--- a/tests/promptfoo/fixtures/setup-clean-project.md
+++ b/tests/promptfoo/fixtures/setup-clean-project.md
@@ -1,0 +1,46 @@
+# Project Context: Clean Project (Nothing Configured)
+
+## Project State
+- Branch: main
+- Working directory: /tmp/test-project
+- No `.claude/sdlc.json`, no `.sdlc/local.json`, no review dimensions, no PR template
+
+## Prepare Script Output (setup.js)
+
+```json
+{
+  "projectConfig": { "exists": false, "sections": [], "misplaced": [], "path": ".claude/sdlc.json" },
+  "localConfig": { "exists": false, "path": ".sdlc/local.json" },
+  "legacy": {
+    "version": { "exists": false, "path": ".claude/version.json" },
+    "ship": { "exists": false, "path": ".sdlc/ship-config.json" },
+    "review": { "exists": false, "path": ".sdlc/review.json" },
+    "reviewLegacy": { "exists": false, "path": ".claude/review.json" },
+    "jira": { "exists": false, "path": ".sdlc/jira-config.json" }
+  },
+  "content": {
+    "reviewDimensions": { "count": 0, "path": ".claude/review-dimensions/" },
+    "prTemplate": { "exists": false, "path": ".claude/pr-template.md" },
+    "jiraTemplates": { "count": 0, "path": ".claude/jira-templates/" },
+    "planGuardrails": { "count": 0 }
+  },
+  "detected": { "versionFile": "package.json", "fileType": "package.json", "tagPrefix": "v", "defaultBranch": "main" },
+  "openspecConfig": { "exists": false, "path": "openspec/config.yaml", "managedBlockVersion": null },
+  "shipFields": [],
+  "needsMigration": false,
+  "localIsV1": false,
+  "sections": [
+    {"id":"version","label":"version","state":"not-set","summary":"detected: package.json (package.json), tag: v","locked":false,"purpose":"Tells /version-sdlc and /ship-sdlc where the canonical version string lives.","configFile":".claude/sdlc.json","configPath":"version","consumedBy":["version-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":false,"delegatedTo":null,"confirmDetected":true,"fields":[]},
+    {"id":"ship","label":"ship","state":"not-set","summary":"","locked":false,"purpose":"Developer-local pipeline preferences for /ship-sdlc.","configFile":".sdlc/local.json","configPath":"ship","consumedBy":["ship-sdlc"],"filesModified":[".sdlc/local.json"],"optional":false,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"jira","label":"jira","state":"not-set","summary":"","locked":false,"purpose":"Default Jira project key.","configFile":".claude/sdlc.json","configPath":"jira","consumedBy":["jira-sdlc","commit-sdlc","pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"review","label":"review","state":"not-set","summary":"","locked":false,"purpose":"Default scope for /review-sdlc.","configFile":".sdlc/local.json","configPath":"review","consumedBy":["review-sdlc"],"filesModified":[".sdlc/local.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"commit","label":"commit","state":"not-set","summary":"","locked":false,"purpose":"Commit message validation rules.","configFile":".claude/sdlc.json","configPath":"commit","consumedBy":["commit-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-commit-builder","confirmDetected":false,"fields":[]},
+    {"id":"pr","label":"pr","state":"not-set","summary":"","locked":false,"purpose":"PR title validation rules.","configFile":".claude/sdlc.json","configPath":"pr","consumedBy":["pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-pr-builder","confirmDetected":false,"fields":[]},
+    {"id":"review-dimensions","label":"review-dimensions","state":"not-set","summary":"","locked":false,"purpose":"Review dimensions installed under .claude/review-dimensions.","configFile":"<delegated>","configPath":null,"consumedBy":["review-sdlc"],"filesModified":[".claude/review-dimensions/*.yaml"],"optional":true,"delegatedTo":"setup-dimensions","confirmDetected":false,"fields":[]},
+    {"id":"pr-template","label":"pr-template","state":"not-set","summary":"","locked":false,"purpose":"PR description template.","configFile":"<delegated>","configPath":null,"consumedBy":["pr-sdlc"],"filesModified":[".claude/pr-template.md"],"optional":true,"delegatedTo":"setup-pr-template","confirmDetected":false,"fields":[]},
+    {"id":"plan-guardrails","label":"plan-guardrails","state":"not-set","summary":"","locked":false,"purpose":"Custom rules at .claude/sdlc.json#plan.guardrails.","configFile":".claude/sdlc.json","configPath":"plan.guardrails","consumedBy":["plan-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"execution-guardrails","label":"execution-guardrails","state":"not-set","summary":"","locked":false,"purpose":"Runtime guardrails at .claude/sdlc.json#execute.guardrails.","configFile":".claude/sdlc.json","configPath":"execute.guardrails","consumedBy":["execute-plan-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-execution-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"openspec-block","label":"openspec-block","state":"not-set","summary":"","locked":false,"purpose":"Managed block in openspec/config.yaml.","configFile":"openspec/config.yaml","configPath":"<managed-block>","consumedBy":["plan-sdlc","execute-plan-sdlc","ship-sdlc"],"filesModified":["openspec/config.yaml"],"optional":true,"delegatedTo":"setup-openspec","confirmDetected":false,"fields":[]}
+  ]
+}
+```

--- a/tests/promptfoo/fixtures/setup-fully-configured.md
+++ b/tests/promptfoo/fixtures/setup-fully-configured.md
@@ -1,0 +1,46 @@
+# Project Context: Fully-Configured Project
+
+## Project State
+- Branch: feat/something
+- Working directory: /tmp/test-project
+- All sections in `.claude/sdlc.json` and `.sdlc/local.json` already configured
+
+## Prepare Script Output (setup.js)
+
+```json
+{
+  "projectConfig": { "exists": true, "sections": ["version","jira","commit","pr","plan","execute"], "misplaced": [], "path": ".claude/sdlc.json" },
+  "localConfig": { "exists": true, "path": ".sdlc/local.json" },
+  "legacy": {
+    "version": { "exists": false, "path": ".claude/version.json" },
+    "ship": { "exists": false, "path": ".sdlc/ship-config.json" },
+    "review": { "exists": false, "path": ".sdlc/review.json" },
+    "reviewLegacy": { "exists": false, "path": ".claude/review.json" },
+    "jira": { "exists": false, "path": ".sdlc/jira-config.json" }
+  },
+  "content": {
+    "reviewDimensions": { "count": 4, "path": ".claude/review-dimensions/" },
+    "prTemplate": { "exists": true, "path": ".claude/pr-template.md" },
+    "jiraTemplates": { "count": 0, "path": ".claude/jira-templates/" },
+    "planGuardrails": { "count": 2 }
+  },
+  "detected": { "versionFile": "package.json", "fileType": "package.json", "tagPrefix": "v", "defaultBranch": "main" },
+  "openspecConfig": { "exists": false, "path": "openspec/config.yaml", "managedBlockVersion": null },
+  "shipFields": [],
+  "needsMigration": false,
+  "localIsV1": false,
+  "sections": [
+    {"id":"version","label":"version","state":"set","summary":"file: package.json, tag: v","locked":false,"purpose":"Tells /version-sdlc and /ship-sdlc where the canonical version string lives (a file, or only git tags) and how releases are tagged.","configFile":".claude/sdlc.json","configPath":"version","consumedBy":["version-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":false,"delegatedTo":null,"confirmDetected":true,"fields":[]},
+    {"id":"ship","label":"ship","state":"set","summary":"steps: execute,commit,review,pr  bump: patch","locked":false,"purpose":"Developer-local pipeline preferences for /ship-sdlc","configFile":".sdlc/local.json","configPath":"ship","consumedBy":["ship-sdlc"],"filesModified":[".sdlc/local.json"],"optional":false,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"jira","label":"jira","state":"set","summary":"project: PROJ","locked":false,"purpose":"Default Jira project key.","configFile":".claude/sdlc.json","configPath":"jira","consumedBy":["jira-sdlc","commit-sdlc","pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"review","label":"review","state":"set","summary":"scope: committed","locked":false,"purpose":"Default scope for /review-sdlc.","configFile":".sdlc/local.json","configPath":"review","consumedBy":["review-sdlc"],"filesModified":[".sdlc/local.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"commit","label":"commit","state":"set","summary":"pattern: ^(feat|fix): .+$","locked":false,"purpose":"Commit message validation rules.","configFile":".claude/sdlc.json","configPath":"commit","consumedBy":["commit-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-commit-builder","confirmDetected":false,"fields":[]},
+    {"id":"pr","label":"pr","state":"set","summary":"pattern: ^(feat|fix): .+$","locked":false,"purpose":"PR title validation rules.","configFile":".claude/sdlc.json","configPath":"pr","consumedBy":["pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-pr-builder","confirmDetected":false,"fields":[]},
+    {"id":"review-dimensions","label":"review-dimensions","state":"set","summary":"4 installed","locked":false,"purpose":"Review dimensions installed under .claude/review-dimensions.","configFile":"<delegated>","configPath":null,"consumedBy":["review-sdlc"],"filesModified":[".claude/review-dimensions/*.yaml"],"optional":true,"delegatedTo":"setup-dimensions","confirmDetected":false,"fields":[]},
+    {"id":"pr-template","label":"pr-template","state":"set","summary":"installed","locked":false,"purpose":"PR description template.","configFile":"<delegated>","configPath":null,"consumedBy":["pr-sdlc"],"filesModified":[".claude/pr-template.md"],"optional":true,"delegatedTo":"setup-pr-template","confirmDetected":false,"fields":[]},
+    {"id":"plan-guardrails","label":"plan-guardrails","state":"set","summary":"2 configured","locked":false,"purpose":"Custom rules at .claude/sdlc.json#plan.guardrails.","configFile":".claude/sdlc.json","configPath":"plan.guardrails","consumedBy":["plan-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"execution-guardrails","label":"execution-guardrails","state":"set","summary":"1 configured","locked":false,"purpose":"Runtime guardrails at .claude/sdlc.json#execute.guardrails.","configFile":".claude/sdlc.json","configPath":"execute.guardrails","consumedBy":["execute-plan-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-execution-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"openspec-block","label":"openspec-block","state":"not-set","summary":"","locked":false,"purpose":"Managed block in openspec/config.yaml.","configFile":"openspec/config.yaml","configPath":"<managed-block>","consumedBy":["plan-sdlc","execute-plan-sdlc","ship-sdlc"],"filesModified":["openspec/config.yaml"],"optional":true,"delegatedTo":"setup-openspec","confirmDetected":false,"fields":[]}
+  ]
+}
+```

--- a/tests/promptfoo/fixtures/setup-legacy-migration.md
+++ b/tests/promptfoo/fixtures/setup-legacy-migration.md
@@ -1,0 +1,48 @@
+# Project Context: Legacy Migration Required
+
+## Project State
+- Branch: main
+- Working directory: /tmp/test-project
+- `.claude/version.json` exists (legacy file)
+- `.sdlc/local.json` exists with v1 ship section (`preset` key, no top-level `version: 2`)
+- `needsMigration: true`
+
+## Prepare Script Output (setup.js)
+
+```json
+{
+  "projectConfig": { "exists": false, "sections": [], "misplaced": [], "path": ".claude/sdlc.json" },
+  "localConfig": { "exists": true, "path": ".sdlc/local.json" },
+  "legacy": {
+    "version": { "exists": true, "path": ".claude/version.json" },
+    "ship": { "exists": false, "path": ".sdlc/ship-config.json" },
+    "review": { "exists": false, "path": ".sdlc/review.json" },
+    "reviewLegacy": { "exists": false, "path": ".claude/review.json" },
+    "jira": { "exists": false, "path": ".sdlc/jira-config.json" }
+  },
+  "content": {
+    "reviewDimensions": { "count": 0, "path": ".claude/review-dimensions/" },
+    "prTemplate": { "exists": false, "path": ".claude/pr-template.md" },
+    "jiraTemplates": { "count": 0, "path": ".claude/jira-templates/" },
+    "planGuardrails": { "count": 0 }
+  },
+  "detected": { "versionFile": "package.json", "fileType": "package.json", "tagPrefix": "v", "defaultBranch": "main" },
+  "openspecConfig": { "exists": false, "path": "openspec/config.yaml", "managedBlockVersion": null },
+  "shipFields": [],
+  "needsMigration": true,
+  "localIsV1": true,
+  "sections": [
+    {"id":"version","label":"version","state":"legacy","summary":"detected: package.json (package.json), tag: v","locked":true,"purpose":"Tells /version-sdlc and /ship-sdlc where the canonical version string lives.","configFile":".claude/sdlc.json","configPath":"version","consumedBy":["version-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":false,"delegatedTo":null,"confirmDetected":true,"fields":[]},
+    {"id":"ship","label":"ship","state":"legacy","summary":"","locked":true,"purpose":"Developer-local pipeline preferences for /ship-sdlc.","configFile":".sdlc/local.json","configPath":"ship","consumedBy":["ship-sdlc"],"filesModified":[".sdlc/local.json"],"optional":false,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"jira","label":"jira","state":"not-set","summary":"","locked":false,"purpose":"Default Jira project key.","configFile":".claude/sdlc.json","configPath":"jira","consumedBy":["jira-sdlc","commit-sdlc","pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"review","label":"review","state":"legacy","summary":"","locked":true,"purpose":"Default scope for /review-sdlc.","configFile":".sdlc/local.json","configPath":"review","consumedBy":["review-sdlc"],"filesModified":[".sdlc/local.json"],"optional":true,"delegatedTo":null,"confirmDetected":false,"fields":[]},
+    {"id":"commit","label":"commit","state":"not-set","summary":"","locked":false,"purpose":"Commit message validation rules.","configFile":".claude/sdlc.json","configPath":"commit","consumedBy":["commit-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-commit-builder","confirmDetected":false,"fields":[]},
+    {"id":"pr","label":"pr","state":"not-set","summary":"","locked":false,"purpose":"PR title validation rules.","configFile":".claude/sdlc.json","configPath":"pr","consumedBy":["pr-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"inline-pr-builder","confirmDetected":false,"fields":[]},
+    {"id":"review-dimensions","label":"review-dimensions","state":"not-set","summary":"","locked":false,"purpose":"Review dimensions installed under .claude/review-dimensions.","configFile":"<delegated>","configPath":null,"consumedBy":["review-sdlc"],"filesModified":[".claude/review-dimensions/*.yaml"],"optional":true,"delegatedTo":"setup-dimensions","confirmDetected":false,"fields":[]},
+    {"id":"pr-template","label":"pr-template","state":"not-set","summary":"","locked":false,"purpose":"PR description template.","configFile":"<delegated>","configPath":null,"consumedBy":["pr-sdlc"],"filesModified":[".claude/pr-template.md"],"optional":true,"delegatedTo":"setup-pr-template","confirmDetected":false,"fields":[]},
+    {"id":"plan-guardrails","label":"plan-guardrails","state":"not-set","summary":"","locked":false,"purpose":"Custom rules at .claude/sdlc.json#plan.guardrails.","configFile":".claude/sdlc.json","configPath":"plan.guardrails","consumedBy":["plan-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"execution-guardrails","label":"execution-guardrails","state":"not-set","summary":"","locked":false,"purpose":"Runtime guardrails.","configFile":".claude/sdlc.json","configPath":"execute.guardrails","consumedBy":["execute-plan-sdlc","ship-sdlc"],"filesModified":[".claude/sdlc.json"],"optional":true,"delegatedTo":"setup-execution-guardrails","confirmDetected":false,"fields":[]},
+    {"id":"openspec-block","label":"openspec-block","state":"not-set","summary":"","locked":false,"purpose":"Managed block in openspec/config.yaml.","configFile":"openspec/config.yaml","configPath":"<managed-block>","consumedBy":["plan-sdlc","execute-plan-sdlc","ship-sdlc"],"filesModified":["openspec/config.yaml"],"optional":true,"delegatedTo":"setup-openspec","confirmDetected":false,"fields":[]}
+  ]
+}
+```

--- a/tests/promptfoo/promptfooconfig.yaml
+++ b/tests/promptfoo/promptfooconfig.yaml
@@ -18,6 +18,7 @@ tests:
   - file://datasets/pr-sdlc.yaml
   - file://datasets/review-sdlc.yaml
   - file://datasets/version-sdlc.yaml
+  - file://datasets/setup-sdlc.yaml
   - file://datasets/setup-sdlc-dimensions.yaml
   - file://datasets/setup-sdlc-pr-template.yaml
   - file://datasets/execute-plan-sdlc.yaml


### PR DESCRIPTION
## Summary
`/setup-sdlc` now opens with a multi-select menu listing every configurable section (version tracking, ship pipeline, Jira, review scope, commit/PR validation, review dimensions, PR template, plan/execution guardrails, openspec block). Each section shows a state badge (`set`, `not set`, `legacy`) and a verbose header before any prompt. Users configure only what they select; `legacy` sections are auto-checked and locked for forced migration.

## Business Context
The previous linear walkthrough forced users through every configuration section on each invocation, regardless of what they needed to change. For teams adopting the plugin incrementally — or returning to reconfigure a single setting — this made `setup-sdlc` tedious and error-prone (users had to skip unwanted sections manually).

## Business Benefits
- Users can configure only the sections they need in a single run, reducing time-to-configured-state significantly
- `legacy` sections are surfaced automatically with required-migration badges, eliminating silent breakage when upgrading
- Verbose per-section headers (purpose, files modified, consuming skills, current value) let users make informed decisions without reading documentation
- New `--only <ids>` flag enables scripted or follow-up single-section reconfiguration

## Github Issue
https://github.com/rafal-sdlc/sdlc-marketplace/issues/191

## Technical Design
The section manifest (`scripts/lib/setup-sections.js`) is the single source of truth: it drives the menu UI labels, state badges, per-option descriptions, and the Step 3 dispatcher. The main `setup.js` script was refactored from a sequential flow into a dispatcher pattern — Step 3 routes to `3.G` (generic JSON-field sections), `3.commit`, `3.pr`, or `3.S` (content-producing scan sections) based on section type. Legacy direct-entry flags (`--dimensions`, `--pr-template`, `--guardrails`, `--execution-guardrails`) map to `--only <id>`, preserving backward compatibility.

## Technical Impact
None. The SKILL.md interface is unchanged — existing flag behavior is preserved via aliases. Plugin manifest version bumped to 0.17.36 via the release commit.

## Changes Overview
- Replaced linear configuration walkthrough with a selective multiselect menu; sections show state badges and verbose headers before prompts
- Extracted section manifest into `scripts/lib/setup-sections.js`; this drives menu rendering, state detection, and dispatcher routing
- Refactored Step 3 into a dispatcher pattern (generic, commit, pr, content-scan handlers) eliminating duplicated prompt logic
- Added `--only <ids>` flag as the canonical non-interactive entry point; legacy flags aliased to it
- Updated `docs/skills/setup-sdlc.md` with new usage, flags table, and full sections reference
- Updated `docs/specs/setup-sdlc.md` to reflect behavioral requirements for menu, state badges, and verbose headers
- Added promptfoo test fixtures and dataset entries for clean-project, fully-configured, and legacy-migration scenarios

## Testing
Manual invocation of `/setup-sdlc` verified the menu renders correctly with state badges. `--only jira` and `--force` flags tested. Promptfoo fixtures and dataset entries added for three representative project states (clean, fully configured, legacy migration). Stale doc references fixed and confirmed against actual script behavior.