### PR TITLE
feat(#197): pr-labels - add configurable modes (off/rules/llm)

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,9 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-04 — pr-sdlc: PR #200 for feat/configurable-pr-labels
+Custom template active (8 custom sections). Branch already pushed and tracked (`origin/feat/configurable-pr-labels`); `remoteState.pushed: false` in context JSON was stale — branch was current. Labels `enhancement` and `documentation` inferred: `feat/` branch prefix + `feat(#197)` commits → `enhancement`; doc files (`docs/skills/*.md`, `docs/specs/*.md`) in changedFiles → `documentation`. `prConfig.titlePattern` required `type(#issue): scope - description` — title validated before `gh pr create`. No JIRA ticket (null); Github Issue section populated with GitHub issue URL from pipeline context. Chore release commit (`v0.17.37`) included in branch commits — correctly ignored for PR title inference; feature commit used instead.
+
 ## 2026-05-04 — pr-sdlc: PR #196 for feat/191-setup-sdlc-menu
 Custom template active (`.claude/pr-template.md`); 8 custom sections used. Branch was already pushed ("Everything up-to-date" on push). Label `enhancement` inferred from `feat/` branch prefix and `feat(#191)` commit subjects. `prConfig.titlePattern` required `type(#issue): scope - description` form — title validated before `gh pr create`. No JIRA ticket detected (null in context); `Github Issue` section populated with GitHub issue URL from pipeline context instead.
 

--- a/docs/skills/pr-sdlc.md
+++ b/docs/skills/pr-sdlc.md
@@ -123,19 +123,93 @@ Run `/setup-sdlc --pr-template` to create or edit the template interactively.
 
 ## Auto-Labeling
 
-When creating or updating a PR, the skill analyzes the PR context — branch name, commit messages, changed file paths, diff content — and suggests repository labels that match.
+Label assignment is **mode-driven** via the `pr.labels` block in `.claude/sdlc.json` ([issue #197](https://github.com/rnagrodzki/sdlc-marketplace/issues/197)). Three modes are supported; the default is `off`.
 
-**How it works:**
-1. Available labels are fetched from the repository via `gh label list`
-2. PR signals (branch prefix, commit types, file paths, diff size) are fuzzy-matched against available labels
-3. Suggested labels are displayed in the approval prompt alongside the title and description
-4. Labels are applied only after explicit user approval
+| Mode | What it does |
+|---|---|
+| `off` (default) | No automatic labels. Only forced labels from `--label` apply. |
+| `rules` | Evaluates user-defined `{ label, when }` rules deterministically. Each rule maps one signal (branch prefix, commit type, changed-path glob, JIRA issue type, or diff size) to one repo label. |
+| `llm` | Legacy fuzzy matching by the model — opt-in only. Preserves the pre-#197 behavior for projects that explicitly want it. |
 
-**Update mode:** Existing labels on the PR are preserved. Only new labels are added — the skill never removes labels.
+Configure a project's mode by running:
 
-**Forced labels:** The `--label` flag bypasses signal matching — forced labels are always included in the PR. If a forced label doesn't exist in the repository, it is created automatically before the PR is opened. Forced labels are marked with `(forced)` in the approval prompt to distinguish them from inferred labels. This is used by `/ship-sdlc` to auto-apply `skip-version-check` on worktree PRs.
+```bash
+/setup-sdlc --only pr-labels
+```
 
-**When labeling is skipped:** If the repository has no labels defined or `gh` is unavailable, the labeling step is silently skipped. Forced labels (via `--label`) still work — they are created in the repo if needed.
+The sub-flow scans `gh label list`, prompts for a mode, and (for `rules`) walks you through rule entry. See [setup-sdlc](setup-sdlc.md) for details.
+
+**Provenance tags** appear in the Step 5 Labels line so it is always clear how a label was selected:
+
+- `(forced)` — applied via `--label` or by `/ship-sdlc` (e.g. `skip-version-check`)
+- `(rule)` — matched a deterministic rule under `pr.labels.rules`
+- `(llm)` — fuzzy-matched by the model (mode `llm` only)
+
+### Example: `mode = "off"` (default)
+
+```json
+{
+  "pr": {
+    "labels": { "mode": "off" }
+  }
+}
+```
+
+No labels are suggested. Forced labels still work. `/pr-sdlc --label bug` adds `bug` regardless of mode.
+
+### Example: `mode = "rules"`
+
+```json
+{
+  "pr": {
+    "labels": {
+      "mode": "rules",
+      "rules": [
+        { "label": "bug",           "when": { "branchPrefix": ["fix/", "bugfix/"] } },
+        { "label": "feature",       "when": { "commitType":   ["feat"] } },
+        { "label": "documentation", "when": { "pathGlob":     ["**/*.md"] } },
+        { "label": "small-change",  "when": { "diffSizeUnder": 50 } }
+      ]
+    }
+  }
+}
+```
+
+Each rule names exactly one target label and one signal in `when`:
+
+| Signal | Match condition |
+|---|---|
+| `branchPrefix: string[]` | Current branch starts with any listed prefix |
+| `commitType: string[]` | Any commit subject begins with `<type>:` or `<type>(scope):` |
+| `pathGlob: string[]` | **Every** changed file matches at least one glob (all-changed-files semantics) |
+| `jiraType: string[]` | Detected JIRA ticket type is in the list |
+| `diffSizeUnder: integer` | Total lines changed is strictly less than the threshold |
+
+Multiple rules may target the same label — they OR together. Rules whose `label` is not in `repoLabels` are stripped at validation time with a warning (no fabrication).
+
+### Example: `mode = "llm"` (opt-in only)
+
+```json
+{
+  "pr": {
+    "labels": { "mode": "llm" }
+  }
+}
+```
+
+The legacy fuzzy heuristic runs: branch prefixes, commit types, file paths, and diff size are fuzzy-matched against `repoLabels`. Used only when explicitly chosen during setup.
+
+### Forced labels
+
+The `--label` flag bypasses `pr.labels.mode` entirely. Forced labels apply in all three modes (including `off`). If a forced label doesn't exist in the repository, it is created automatically before the PR is opened. `/ship-sdlc` uses this to auto-apply `skip-version-check` on worktree PRs.
+
+### Update mode
+
+Existing labels on the PR are preserved. Only new labels are added — the skill never removes labels.
+
+### When labeling is skipped
+
+If the repository has no labels defined or `gh` is unavailable, the inferred labeling step is skipped. Forced labels (via `--label`) still work — they are created in the repo if needed.
 
 ---
 

--- a/docs/skills/setup-sdlc.md
+++ b/docs/skills/setup-sdlc.md
@@ -20,7 +20,7 @@ Renders the selective-section menu. Sections in state `not set` are pre-checked;
 /setup-sdlc --only jira,review
 ```
 
-Skip the menu, configure only `jira` and `review`. Useful for scripted runs or follow-up tweaks. Valid ids: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`.
+Skip the menu, configure only `jira` and `review`. Useful for scripted runs or follow-up tweaks. Valid ids: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `pr-labels`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`.
 
 ```text
 /setup-sdlc --force
@@ -37,7 +37,7 @@ Pre-check every row in the menu (reconfigure everything) instead of pre-selectin
 | `--migrate` | Migrate legacy config files (`.claude/version.json`, `.sdlc/ship-config.json`, etc.) into unified config | — |
 | `--skip <section>` | Skip a config section during setup (version, ship, jira, review, commit, pr) | — |
 | `--force` | Pre-check every menu row (reconfigure all sections) | — |
-| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | — |
+| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `pr-labels`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | — |
 | `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | — |
 | `--pr-template` | Jump directly to PR template sub-flow (skip config builder) | — |
 | `--guardrails` | Jump directly to plan guardrails sub-flow (skip config builder) | — |
@@ -144,6 +144,7 @@ Every section the menu can configure. The label, purpose, files modified, and co
 | `review` | Default scope for `/review-sdlc` (committed/staged/working/worktree/all). Local to each developer. | `.sdlc/local.json` | `/review-sdlc` |
 | `commit` | Commit message validation rules used by `/commit-sdlc` (subject regex, allowed types/scopes, required trailers). | `.claude/sdlc.json` | `/commit-sdlc` |
 | `pr` | PR title validation rules used by `/pr-sdlc` (title regex, allowed types/scopes, required trailers). | `.claude/sdlc.json` | `/pr-sdlc` |
+| `pr-labels` | PR label assignment policy under `pr.labels`. Mode `off` (default) adds no automatic labels — `--label` overrides still work. Mode `rules` evaluates user-defined deterministic rules (branch prefix, commit type, path glob, JIRA type, diff size). Mode `llm` opts into the legacy fuzzy match. Configured via `--only pr-labels`. | `.claude/sdlc.json` | `/pr-sdlc` |
 | `review-dimensions` | Review dimensions installed under `.claude/review-dimensions/*.yaml`. Each dimension is a focused check set used by `/review-sdlc`. | `.claude/review-dimensions/*.yaml` | `/review-sdlc` |
 | `pr-template` | PR description template at `.claude/pr-template.md`, used by `/pr-sdlc` when drafting PRs. | `.claude/pr-template.md` | `/pr-sdlc` |
 | `plan-guardrails` | Custom rules at `.claude/sdlc.json#plan.guardrails` evaluated by `/plan-sdlc` during critique phases. | `.claude/sdlc.json` | `/plan-sdlc` |

--- a/docs/specs/pr-sdlc.md
+++ b/docs/specs/pr-sdlc.md
@@ -23,9 +23,11 @@
 - R5: PR title must be under 72 characters
 - R6: When `prConfig.titlePattern` is set, validate title against the regex before executing `gh` CLI (hard gate)
 - R7: When `prConfig.allowedTypes` or `allowedScopes` are set, constrain title generation accordingly
-- R8: Label inference via fuzzy-match against `repoLabels` using 5 signal types: branch prefix, commit subjects, changed file paths, diff size, Jira ticket type
-- R9: Labels must exist in `repoLabels` — never fabricate labels not in the repository
-- R10: Forced labels (`--label`) are always included, merged with inferred labels, and created via `gh label create` if missing in repo
+- R8: Label assignment is mode-driven via `prConfig.labels.mode` (issue #197). Three modes: `off` (default — no automatic labels), `rules` (deterministic evaluation of `prConfig.labels.rules[]`), `llm` (legacy fuzzy match against `repoLabels` using 5 signal types: branch prefix, commit subjects, changed file paths, diff size, Jira ticket type). When `prConfig.labels` is absent, mode defaults to `off`. The fuzzy-match heuristic that ran unconditionally before #197 now runs only when the user explicitly opts in via `mode: "llm"`.
+- R8a: In `rules` mode, every rule is `{ label: string, when: <one signal> }` where the signal is exactly one of `branchPrefix: string[]`, `commitType: string[]`, `pathGlob: string[]`, `jiraType: string[]`, or `diffSizeUnder: integer`. `pathGlob` matches only when **every** changed file matches at least one glob (all-changed-files semantics); `commitType` matches when any commit subject begins with `<type>:` or `<type>(scope):`. Rules whose `label` is not in `repoLabels` are stripped at validation time in `pr.js` with a warning — the skill never receives invalid rules.
+- R8b: Each suggested label carries a provenance tag in the Step 5 display: `(forced)`, `(rule)`, or `(llm)`. The Labels line is omitted entirely when the final list is empty (e.g. `mode: "off"` with no forced labels).
+- R9: Labels must exist in `repoLabels` — never fabricate labels not in the repository (defense-in-depth gate that applies after rule stripping and to `llm` output)
+- R10: Forced labels (`--label`) bypass `prConfig.labels.mode` entirely — they apply in all three modes (including `off`), are always included, dedupe against rule/llm matches with forced winning provenance, and are created via `gh label create` if missing in repo
 - R11: In update mode, existing labels are preserved; only new labels are added via `--add-label`
 - R12: When `--auto` is set, skip AskUserQuestion approval and apply labels directly; critique gates still run
 - R13: OpenSpec enrichment: when an active OpenSpec change is detected, use proposal.md for Business Context/Benefits and design.md for Technical Design

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -32,7 +32,8 @@
 - R6: Config writes go through `util/setup-init.js` which calls `lib/config.js` functions. The script deterministically creates `.sdlc/` directory, `.sdlc/.gitignore`, and config files — never use Edit/Write tools directly on config files
 - R7: Early exit when everything is configured, no migration needed, and `--force` not passed
 - R8: Ship config is developer-local (`.sdlc/local.json`, gitignored), not project-level
-- R9: Content setup sub-flows: review dimensions (`setup-dimensions.md`), PR template (`setup-pr-template.md`), plan guardrails (`setup-guardrails.md`), execution guardrails (`setup-execution-guardrails.md`)
+- R9: Content setup sub-flows: review dimensions (`setup-dimensions.md`), PR template (`setup-pr-template.md`), plan guardrails (`setup-guardrails.md`), execution guardrails (`setup-execution-guardrails.md`), PR labels (`setup-pr-labels.md`)
+- R9a: PR labels sub-flow (`setup-pr-labels.md`, [issue #197](https://github.com/rnagrodzki/sdlc-marketplace/issues/197)) — section id `pr-labels`, configFile `.claude/sdlc.json`, configPath `pr.labels`, `delegatedTo: 'setup-pr-labels'`. Writes a `pr.labels` block matching `schemas/sdlc-config.schema.json#$defs/prLabelsSection`: `mode: "off" | "rules" | "llm"`, optional `rules: { label, when }[]`. The sub-flow runs `gh label list` for the picker, presents an idempotency prompt (`keep`/`replace`/`append`) when the block already exists, and merges into the existing `pr` section without clobbering siblings (`titlePattern`, `allowedTypes`, etc.). The default state for projects that never run this sub-flow is "no `pr.labels` key" — `pr-sdlc` Step 2b interprets that as `mode = "off"`.
 - R10: Project scan phase runs before content sub-flows to collect signals (dependencies, framework, CI, DB, tests, etc.)
 - R11: Version section requires `mode` field (required by schema): `"file"` when version file detected, `"tag"` when not. Optional fields include `versionFile`, `fileType`, `tagPrefix`, `changelog`, `changelogFile`, `ticketPrefix`, and `preRelease`. The `preRelease` field, when set, is a string matching `^[a-z][a-z0-9]*$` that supplies a default pre-release label to version-sdlc when the user runs `version-sdlc` without an explicit base bump or `--pre`. Empty / skipped answers omit the field; the schema (`schemas/sdlc-config.schema.json`) does not require it.
 - R12: Prepare script output is the single authoritative source for all contracted fields (P-fields) — script-provided values take unconditional precedence over skill-generated content, and all factual context (git state, config, flags, metadata) must originate from script output to ensure deterministic behavior
@@ -95,7 +96,7 @@
 - P7: `shipFields` (array) — authoritative list of interactive ship-config fields sourced from `scripts/lib/ship-fields.js`. Each entry: `{ name, label, type, options, default, description }`. `name` is the local-config key; `options` is an array of valid values; `default` is the value applied if the user accepts the default answer.
 - P8: `openspecConfig` (object) — `{ exists: boolean, path: string, managedBlockVersion: number|null }` state of `openspec/config.yaml` and its managed block
 - P-sections: `sections` (array) — joined view of `SETUP_SECTIONS` (manifest) × `detect()` state. Drives the Step 1 selective menu and the Step 3 verbose dispatch loop. Each row has shape:
-  - `id` (string) — canonical section id (used by `--only`); one of `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`
+  - `id` (string) — canonical section id (used by `--only`); one of `version`, `ship`, `jira`, `review`, `commit`, `pr`, `pr-labels`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block`
   - `label` (string) — human-readable section name
   - `state` (string) — `'set'` (configured) | `'not-set'` (no config) | `'legacy'` (legacy file present, `localIsV1`, or managed-block-version below current)
   - `summary` (string) — one-line summary of the current configuration (empty for `not-set`)
@@ -106,7 +107,7 @@
   - `consumedBy` (string[]) — skill ids that read this section at runtime
   - `filesModified` (string[]) — workspace artifacts created or touched
   - `optional` (boolean) — `true` if the section is safe to leave unset
-  - `delegatedTo` (string|null) — sub-skill id (`setup-dimensions`, `setup-pr-template`, `setup-guardrails`, `setup-execution-guardrails`, `setup-openspec`), inline-builder id (`inline-commit-builder`, `inline-pr-builder`), or `null` for generic field-loop sections
+  - `delegatedTo` (string|null) — sub-skill id (`setup-dimensions`, `setup-pr-template`, `setup-guardrails`, `setup-execution-guardrails`, `setup-pr-labels`, `setup-openspec`), inline-builder id (`inline-commit-builder`, `inline-pr-builder`), or `null` for generic field-loop sections
   - `confirmDetected` (boolean) — `true` when the dispatcher must ask `yes` / `customize` / `skip` BEFORE iterating fields (currently only `version`)
   - `fields` (array) — entries with shape `{ name, label, type, options, default, description, validate? }` matching the `SHIP_FIELDS` shape; empty for delegated and inline-builder sections
 
@@ -158,4 +159,5 @@
 - I10: `jira-sdlc` — consumes jira config written by this skill
 - I11: `setup-openspec.md` — sub-flow for openspec config enrichment
 - I12: `util/openspec-enrich.js` — deterministic script for managed-block operations on `openspec/config.yaml`
+- I13: `setup-pr-labels.md` — sub-flow for PR label assignment policy ([issue #197](https://github.com/rnagrodzki/sdlc-marketplace/issues/197)); writes `pr.labels` (mode: off|rules|llm) into `.claude/sdlc.json`
 - I13: `lib/setup-sections.js` — single source of truth for the `SETUP_SECTIONS` manifest consumed by `skill/setup.js` to emit `prepare.sections[]` (P-sections) and by SKILL.md Step 1 / Step 3 to render menu rows and verbose headers

--- a/docs/specs/setup-sdlc.md
+++ b/docs/specs/setup-sdlc.md
@@ -160,4 +160,4 @@
 - I11: `setup-openspec.md` — sub-flow for openspec config enrichment
 - I12: `util/openspec-enrich.js` — deterministic script for managed-block operations on `openspec/config.yaml`
 - I13: `setup-pr-labels.md` — sub-flow for PR label assignment policy ([issue #197](https://github.com/rnagrodzki/sdlc-marketplace/issues/197)); writes `pr.labels` (mode: off|rules|llm) into `.claude/sdlc.json`
-- I13: `lib/setup-sections.js` — single source of truth for the `SETUP_SECTIONS` manifest consumed by `skill/setup.js` to emit `prepare.sections[]` (P-sections) and by SKILL.md Step 1 / Step 3 to render menu rows and verbose headers
+- I14: `lib/setup-sections.js` — single source of truth for the `SETUP_SECTIONS` manifest consumed by `skill/setup.js` to emit `prepare.sections[]` (P-sections) and by SKILL.md Step 1 / Step 3 to render menu rows and verbose headers

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.36",
+  "version": "0.17.37",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -553,10 +553,13 @@ function getDiffStat(base, projectRoot) {
   const insMatch   = summary.match(/(\d+) insertions?\(\+\)/);
   const delMatch   = summary.match(/(\d+) deletions?\(-\)/);
 
+  const insertions = insMatch ? parseInt(insMatch[1], 10) : 0;
+  const deletions  = delMatch ? parseInt(delMatch[1], 10) : 0;
   return {
-    filesChanged: filesMatch ? parseInt(filesMatch[1], 10) : 0,
-    insertions:   insMatch   ? parseInt(insMatch[1],   10) : 0,
-    deletions:    delMatch   ? parseInt(delMatch[1],   10) : 0,
+    filesChanged:      filesMatch ? parseInt(filesMatch[1], 10) : 0,
+    insertions,
+    deletions,
+    totalLinesChanged: insertions + deletions,
     summary,
   };
 }

--- a/plugins/sdlc-utilities/scripts/lib/setup-sections.js
+++ b/plugins/sdlc-utilities/scripts/lib/setup-sections.js
@@ -38,7 +38,7 @@
  *     consuming skill, what runtime behavior changes, and what the default
  *     produces. No bare labels.
  *   - Content sections (review-dimensions, pr-template, plan-guardrails,
- *     execution-guardrails, openspec-block) carry fields: [] and
+ *     execution-guardrails, pr-labels, openspec-block) carry fields: [] and
  *     delegatedTo: '<sub-skill-id>'. The menu still surfaces purpose,
  *     filesModified, consumedBy, and state.
  *   - Sections with conditional sub-prompts that don't fit a flat field
@@ -205,6 +205,20 @@ function summarizePr(cfg) {
   return parts.join('  ');
 }
 
+function summarizePrLabels(cfg) {
+  // cfg is the parent `pr` section; the labels block sits under cfg.labels.
+  const labels = cfg && cfg.labels;
+  if (!labels || typeof labels !== 'object') return 'not configured';
+  const mode = labels.mode;
+  if (mode === 'off') return 'off — no automatic labels';
+  if (mode === 'rules') {
+    const n = Array.isArray(labels.rules) ? labels.rules.length : 0;
+    return `rules: ${n} rule${n === 1 ? '' : 's'}`;
+  }
+  if (mode === 'llm') return 'llm — model picks labels';
+  return 'not configured';
+}
+
 function summarizeReviewDimensions(_cfg, detected) {
   if (!detected) return '';
   const count = detected?.content?.reviewDimensions?.count || 0;
@@ -331,6 +345,20 @@ const SETUP_SECTIONS = [
     confirmDetected: false,
     fields: [],
     summarize: summarizePr,
+  },
+  {
+    id: 'pr-labels',
+    label: 'pr-labels',
+    purpose: 'PR label assignment policy used by /pr-sdlc. Mode "off" (default) adds no labels except those forced via --label. Mode "rules" evaluates user-defined rules — each rule maps one signal (branch prefix, commit type, changed-path glob, JIRA issue type, or diff size) to one repo label. Mode "llm" lets the LLM suggest labels using fuzzy matching against repo labels (legacy behavior, opt-in only).',
+    configFile: '.claude/sdlc.json',
+    configPath: 'pr.labels',
+    consumedBy: ['pr-sdlc'],
+    filesModified: ['.claude/sdlc.json'],
+    optional: true,
+    delegatedTo: 'setup-pr-labels',
+    confirmDetected: false,
+    fields: [],
+    summarize: summarizePrLabels,
   },
   {
     id: 'review-dimensions',

--- a/plugins/sdlc-utilities/scripts/skill/pr.js
+++ b/plugins/sdlc-utilities/scripts/skill/pr.js
@@ -268,8 +268,23 @@ function main() {
   // mode = "off" or "llm" leaves rules untouched.
   if (prConfig && prConfig.labels && prConfig.labels.mode === 'rules' && Array.isArray(prConfig.labels.rules)) {
     const validRules = [];
+    const knownSignals = ['branchPrefix', 'commitType', 'pathGlob', 'jiraType', 'diffSizeUnder'];
     for (const rule of prConfig.labels.rules) {
       if (!rule || typeof rule !== 'object' || typeof rule.label !== 'string') {
+        continue;
+      }
+      // Validate structural correctness of rule.when (implements R-labels-2)
+      if (!rule.when || typeof rule.when !== 'object') {
+        warnings.push(`Rule for label "${rule.label}" is missing a "when" condition. Rule will be ignored.`);
+        continue;
+      }
+      const whenKeys = Object.keys(rule.when);
+      if (whenKeys.length !== 1) {
+        warnings.push(`Rule for label "${rule.label}" has ${whenKeys.length === 0 ? 'no' : 'multiple'} signal keys in "when" (expected exactly 1). Rule will be ignored.`);
+        continue;
+      }
+      if (!knownSignals.includes(whenKeys[0])) {
+        warnings.push(`Rule for label "${rule.label}" uses unknown signal "${whenKeys[0]}" in "when". Valid signals: ${knownSignals.join(', ')}. Rule will be ignored.`);
         continue;
       }
       if (!repoLabelNames.includes(rule.label)) {

--- a/plugins/sdlc-utilities/scripts/skill/pr.js
+++ b/plugins/sdlc-utilities/scripts/skill/pr.js
@@ -261,6 +261,29 @@ function main() {
     warnings.push(`Could not read PR config: ${err.message}`);
   }
 
+  // Step 10d: Validate pr.labels.rules against repoLabels (issue #197)
+  // When mode = "rules", every rule's label must exist in the repo. Unknown
+  // labels produce warnings (not errors) and are stripped from the emitted
+  // prConfig.labels.rules — same posture as forced label validation above.
+  // mode = "off" or "llm" leaves rules untouched.
+  if (prConfig && prConfig.labels && prConfig.labels.mode === 'rules' && Array.isArray(prConfig.labels.rules)) {
+    const validRules = [];
+    for (const rule of prConfig.labels.rules) {
+      if (!rule || typeof rule !== 'object' || typeof rule.label !== 'string') {
+        continue;
+      }
+      if (!repoLabelNames.includes(rule.label)) {
+        warnings.push(`Label "${rule.label}" referenced in pr.labels.rules does not exist in the repo. Rule will be ignored.`);
+        continue;
+      }
+      validRules.push(rule);
+    }
+    prConfig = {
+      ...prConfig,
+      labels: { ...prConfig.labels, rules: validRules },
+    };
+  }
+
   // Step 11: Read custom PR template
   const templatePath = path.join(projectRoot, '.claude', 'pr-template.md');
   const customTemplate = fs.existsSync(templatePath)

--- a/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -146,7 +146,7 @@ Key fields available (including `customTemplate` added for project-level PR temp
 | `existingPr` | `{ number, title, url, state, labels }` or `null` |
 | `jiraTicket` | Detected ticket reference or `null` |
 | `commits` | `[{ hash, subject, body, coAuthors }]` — all commits on this branch |
-| `diffStat` | `{ filesChanged, insertions, deletions, summary }` |
+| `diffStat` | `{ filesChanged, insertions, deletions, totalLinesChanged, summary }` |
 | `diffContent` | Full unified diff text |
 | `remoteState` | `{ pushed, remoteBranch, action }` |
 | `warnings` | Non-fatal notes already surfaced to the user by the command |

--- a/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -249,9 +249,39 @@ Teams can configure their PR title patterns in `.claude/sdlc.json`. Here are fou
 
 #### Step 2b: Infer Labels
 
-If `PR_CONTEXT_JSON.repoLabels` is empty, skip this step entirely — produce no label suggestions.
+Label assignment is **mode-dispatched** based on `PR_CONTEXT_JSON.prConfig?.labels?.mode` (issue #197). Each suggested label carries a provenance tag — `(forced)`, `(rule)`, or `(llm)` — used in the Step 5 display.
 
-Otherwise, analyze the PR context and fuzzy-match against `repoLabels` to produce `suggestedLabels: string[]`.
+**Mode resolution:**
+
+- If `PR_CONTEXT_JSON.repoLabels` is empty, skip evaluation entirely and treat the result as `suggestedLabels = []`. Forced labels still apply (see "Forced labels" below).
+- Otherwise read `mode = PR_CONTEXT_JSON.prConfig?.labels?.mode`. When absent, default to `"off"`. Dispatch:
+  - `"off"` → see [Off mode](#off-mode)
+  - `"rules"` → see [Rules mode](#rules-mode)
+  - `"llm"` → see [LLM mode](#llm-mode)
+
+The mode dispatch produces an array of `{ label, source }` entries (where `source ∈ {"rule", "llm"}`). Forced labels are merged on top with `source = "forced"`.
+
+##### Off mode
+
+Set `inferredLabels = []`. No automatic suggestions are produced. The merged `suggestedLabels` array contains only forced labels (or is empty when none are forced).
+
+##### Rules mode
+
+Iterate `PR_CONTEXT_JSON.prConfig.labels.rules` (already validated against `repoLabels` by `pr.js` — unknown labels were stripped before this step). For each rule, evaluate the single signal in `rule.when` against the PR context:
+
+| Signal | Match condition |
+| ------ | --------------- |
+| `branchPrefix: string[]` | `currentBranch` starts with any listed prefix |
+| `commitType: string[]` | Any commit subject begins with `<type>:` or `<type>(scope):` (Conventional Commits) |
+| `pathGlob: string[]` | **Every** entry in `changedFiles` matches at least one glob (all-changed-files semantics, like the legacy `*.md → documentation` rule) |
+| `jiraType: string[]` | `jiraTicket.type` (when extracted) is in the list |
+| `diffSizeUnder: number` | `diffStat.totalLinesChanged < value` |
+
+Collect every matched `rule.label` and dedupe (multiple rules may target the same label — they OR together). Tag each survivor with `source = "rule"`.
+
+##### LLM mode
+
+Run the legacy fuzzy-match heuristic. This branch is **opt-in only** — the user must have explicitly selected `mode = "llm"` during `setup-sdlc --only pr-labels`.
 
 **Signals to match:**
 
@@ -268,13 +298,21 @@ Otherwise, analyze the PR context and fuzzy-match against `repoLabels` to produc
 1. Fuzzy-match each signal against `repoLabels[].name` and `repoLabels[].description` — e.g., repo has `type:bug` and branch is `fix/...` → match
 2. Never suggest a label not in `repoLabels` — only exact names from the list are valid
 3. Keep suggestions conservative: 1–4 labels typical; deduplicate (multiple signals matching the same label count as one)
-4. **Update mode:** note `existingPr.labels` as already applied; only suggest new labels not already present in `existingPr.labels`
 
-**Output:** `suggestedLabels` — a list of label names for use in Steps 5 and 6. If no labels match, produce an empty list.
+Tag each survivor with `source = "llm"`.
+
+##### Common post-processing
+
+Regardless of branch:
+
+1. **Update mode:** when `existingPr.labels` is non-empty, drop any inferred entry already present there — they are already applied.
+2. **Validity gate (defense-in-depth):** every entry must appear in `repoLabels[].name`. Drop fabricated entries (Step 3's "Label validity" gate is the contract; this drop ensures `rules` mode stays exact and catches `llm` hallucinations).
+3. **Forced labels:** if `PR_CONTEXT_JSON.forcedLabels` is non-empty, prepend each forced label with `source = "forced"`. Forced labels are always included regardless of mode (including `off`) — they cannot be removed during interactive edit. Deduplicate by label name; if the same name was inferred and forced, keep only the forced entry (forced wins for provenance).
+4. **Output:** `suggestedLabels` — the final ordered, deduped list of `{ label, source }` entries. Forced first, then rule/llm matches in iteration order. If empty, no Labels line is shown in Step 5.
 
 **Auto mode:** When `PR_CONTEXT_JSON.isAuto` is true, apply `suggestedLabels` directly without presenting them for approval. Labels are still validated against `repoLabels` — no fabricated labels. The applied labels are shown in the Step 5 output for visibility.
 
-**Forced labels:** If `PR_CONTEXT_JSON.forcedLabels` is non-empty, merge all forced labels into `suggestedLabels`. Forced labels are always included regardless of signal matching — they cannot be removed during interactive edit. Deduplicate: if a forced label was also inferred from signals, it appears only once. In the final `suggestedLabels` list, forced labels appear first.
+**Forced labels behavior summary:** The CLI `--label <name>` flag and ship-sdlc's `skip-version-check` injection bypass `pr.labels.mode` entirely. Forced labels apply in all three modes (`off`, `rules`, `llm`).
 
 ### Step 3 (CRITIQUE): Self-review the Draft
 
@@ -325,7 +363,7 @@ before receiving explicit user approval via AskUserQuestion.**
 
 ```text
 PR Title: <title>
-Labels: <label1> (forced), <label2>
+Labels: <label1> (forced), <label2> (rule), <label3> (llm)
 
 PR Description:
 ─────────────────────────────────────────────
@@ -333,7 +371,12 @@ PR Description:
 ─────────────────────────────────────────────
 ```
 
-Labels from `forcedLabels` are marked with `(forced)` suffix to distinguish them from inferred labels.
+Each label carries its provenance suffix from the Step 2b dispatch:
+- `(forced)` — applied via CLI `--label` or ship-sdlc injection (e.g. `skip-version-check`)
+- `(rule)` — matched a deterministic rule under `pr.labels.rules` (mode = `rules`)
+- `(llm)` — fuzzy-matched by the model (mode = `llm`, opt-in)
+
+When `pr.labels.mode = "off"` and no forced labels are present, omit the Labels line entirely (existing behavior — do not show "Labels: none").
 
 **Update mode** (with existing labels and new suggestions):
 

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -22,7 +22,7 @@ delegates content creation to specialized skills.
 | `--migrate` | Force migration of legacy config files even if no legacy files are auto-detected | off |
 | `--skip <section>` | Skip a config section during setup. Valid values: `version`, `ship`, `jira`, `review`, `commit`, `pr` | none |
 | `--force` | Pre-check every menu row (reconfigure everything) instead of selecting only `not-set` rows | off |
-| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid ids match `prepare.sections[].id`: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | none |
+| `--only <ids>` | Comma-separated section ids to configure non-interactively (skips the menu). Valid ids match `prepare.sections[].id`: `version`, `ship`, `jira`, `review`, `commit`, `pr`, `pr-labels`, `review-dimensions`, `pr-template`, `plan-guardrails`, `execution-guardrails`, `openspec-block` | none |
 | `--dimensions` | Jump directly to review dimensions sub-flow (alias for `--only review-dimensions`) | off |
 | `--pr-template` | Jump directly to PR template sub-flow (skip config builder) | off |
 | `--guardrails` | Jump directly to plan guardrails sub-flow (skip config builder) | off |
@@ -237,6 +237,7 @@ For each id selected in Step 1 (call this list `selectedIds`), in `prepare.secti
    | `'inline-pr-builder'` | Inline PR-pattern builder (3.pr below) — same conditional logic as legacy Step 3f |
    | `'setup-dimensions'` | Run scan phase (Step 3.S below), then read and follow `@setup-dimensions.md` passing scan results as "Scan Input". Pass through `--add` and `--no-copilot` modifiers if present. |
    | `'setup-pr-template'` | Run scan phase (Step 3.S), then read and follow `@setup-pr-template.md` passing scan results. Pass through `--add` if present. |
+   | `'setup-pr-labels'` | Read and follow `@setup-pr-labels.md` (it runs `gh label list` itself; no scan input from parent required). |
    | `'setup-guardrails'` | Read and follow `@setup-guardrails.md` (it runs its own scan internally). Pass through `--add` if present. |
    | `'setup-execution-guardrails'` | Read and follow `@setup-execution-guardrails.md`. Pass through `--add` if present. |
    | `'setup-openspec'` | Read and follow `@setup-openspec.md`. Pass through `--remove-openspec` as `--remove` if present. |

--- a/plugins/sdlc-utilities/skills/setup-sdlc/setup-pr-labels.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/setup-pr-labels.md
@@ -1,0 +1,294 @@
+# PR Labels Sub-Flow
+
+Configure how `/pr-sdlc` chooses labels for a project (issue #197). Writes the
+`pr.labels` block in `.claude/sdlc.json`. Three modes are supported:
+
+- `off` (default) — no automatic labels; only forced labels via `--label` apply
+- `rules` — deterministic evaluation of user-defined `{ label, when }` rules
+- `llm` — legacy fuzzy matching by the model (opt-in only)
+
+This sub-flow is invoked by `setup-sdlc` via the `delegatedTo: 'setup-pr-labels'`
+section descriptor (`pr-labels` row in `setup-sections.js`).
+
+---
+
+## Scan Input
+
+This sub-flow loads everything it needs at runtime — no scan input from the
+parent is required. It calls `gh label list` itself and reads the existing
+`pr.labels` block (if any) from `.claude/sdlc.json`.
+
+---
+
+## Arguments
+
+None.
+
+---
+
+## Workflow
+
+### Step 1 — Prerequisite: Repo labels
+
+Run:
+
+```bash
+gh label list --json name,description --limit 100
+```
+
+- **Exit 0:** parse the JSON array into `repoLabels = [{ name, description }, ...]`.
+- **Auth or remote failure (any non-zero exit):** print:
+
+  > `gh label list` failed. The pr-labels sub-flow needs an authenticated `gh`
+  > and a GitHub remote. Run `gh auth login` (or `gh auth status` to check) and
+  > re-run `setup-sdlc --only pr-labels`. No changes were written.
+
+  Exit cleanly without writing anything to `.claude/sdlc.json`.
+
+If `repoLabels` is empty (repo has no custom labels yet), warn the user and
+continue — `off` is still a valid choice; `rules` will require creating labels
+in GitHub first; `llm` will produce no suggestions.
+
+### Step 2 — Idempotency check
+
+Read `.claude/sdlc.json` via `readSection(projectRoot, 'pr')`. If
+`pr.labels` already exists, present the current state and ask:
+
+```
+Current pr.labels:
+  mode:  <off|rules|llm>
+  rules: N entries (when applicable)
+```
+
+Use AskUserQuestion:
+
+> `pr.labels` is already configured. What do you want to do?
+
+Options (only show options that make sense for the current mode):
+
+- **keep** — exit without changes
+- **replace** — wipe the current block and start fresh (Step 3)
+- **append** — only when current `mode = 'rules'`: add rules to the existing
+  list (skip Step 3 mode prompt; jump to the rules loop in Step 4 with the
+  existing rules pre-loaded)
+
+If `pr.labels` is absent, skip this step and go to Step 3.
+
+### Step 3 — Mode selection
+
+Use AskUserQuestion:
+
+> How should `/pr-sdlc` choose labels?
+
+Options:
+
+- **off** — never auto-add labels (default; `--label` CLI overrides still work)
+- **rules** — apply deterministic rules I define below
+- **llm** — let the model decide using fuzzy matching against repo labels
+- **cancel** — abort without writing
+
+Branch on the choice:
+
+- `off` → Step 5 with `{ mode: 'off' }` (no rules)
+- `llm` → Step 5 with `{ mode: 'llm' }` (no rules)
+- `rules` → Step 4
+- `cancel` → exit cleanly, no write
+
+### Step 4 — Rules loop (mode = `rules` only)
+
+Maintain an in-memory `rules: []` array. If `append` was selected in Step 2,
+seed it with the existing `pr.labels.rules`.
+
+Iterate:
+
+1. **Add rule?** Use AskUserQuestion:
+
+   > Add a label rule? (current count: <N>)
+
+   Options:
+   - **add** — define another rule (continue to step 4.2)
+   - **review** — show the current rule list and stay in the loop
+   - **done** — write `{ mode: 'rules', rules: [...] }` and exit (Step 5)
+   - **cancel** — abort without writing
+
+   On `review`: print the current `rules` array in human-readable form
+   (`label → when.<signal>: [values]`) then re-ask.
+
+2. **Pick the target label.** Use AskUserQuestion with options drawn from
+   `repoLabels` (alphabetized). When `repoLabels.length > 10`, paginate the
+   options and add a **search** option that takes a substring filter and
+   re-presents the list. Reject any free-text label that is not in
+   `repoLabels[].name` — the user must pick from the list.
+
+3. **Pick the signal type.** Use AskUserQuestion:
+
+   > Which signal triggers this rule?
+
+   Options:
+   - **branchPrefix** — match if the current branch starts with one of these prefixes (e.g. `fix/`, `feat/`)
+   - **commitType** — match if any commit subject begins with `<type>:` or `<type>(scope):`
+   - **pathGlob** — match if every changed file matches one of these globs (e.g. `**/*.md`)
+   - **jiraType** — match if `jiraTicket.type` is in the list (e.g. `Bug`, `Story`)
+   - **diffSizeUnder** — match if total lines changed is below this threshold
+
+4. **Enter the value(s).** Use AskUserQuestion (free text):
+
+   - For `branchPrefix`, `commitType`, `pathGlob`, `jiraType`:
+     prompt for a comma-separated list. Trim whitespace, drop empties, dedupe.
+     Reject empty input — at least one value is required.
+   - For `diffSizeUnder`: prompt for a single positive integer. Reject
+     non-integer or zero/negative input and re-ask.
+
+5. **Append and confirm.** Build the rule object:
+
+   ```js
+   { label: <chosen>, when: { <signalKey>: <values> } }
+   ```
+
+   Append to `rules`, then loop back to step 4.1.
+
+### Step 5 — Write
+
+Build the final block:
+
+- `off` → `{ mode: 'off' }`
+- `llm` → `{ mode: 'llm' }`
+- `rules` → `{ mode: 'rules', rules: [...] }`
+
+Locate the config helper:
+
+```bash
+SCRIPT=$(find ~/.claude/plugins -name "config.js" -path "*/sdlc*/lib/config.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/lib/config.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/lib/config.js"
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate lib/config.js. Is the sdlc plugin installed?" >&2; exit 2; }
+```
+
+Then merge the labels block into the existing `pr` section without clobbering
+`titlePattern`, `allowedTypes`, or any other sibling key:
+
+```bash
+node -e "
+const { readSection, writeSection } = require('$SCRIPT');
+const root = process.cwd();
+const current = readSection(root, 'pr') || {};
+const next = { ...current, labels: <BLOCK_AS_JSON> };
+writeSection(root, 'pr', next);
+console.log('Wrote pr.labels to .claude/sdlc.json');
+"
+```
+
+Substitute `<BLOCK_AS_JSON>` with the JSON-stringified labels block.
+
+### Step 6 — Confirm
+
+Print a one-line summary:
+
+```
+Wrote pr.labels: mode=<mode>[, rules=<N>] to .claude/sdlc.json
+This block is consumed by /pr-sdlc Step 2b (Infer Labels).
+```
+
+---
+
+## Quality Gates
+
+Before marking complete, verify:
+
+- The mode chosen is exactly one of `off`, `rules`, or `llm`
+- When `mode = 'rules'`, every rule has exactly one signal key in `when` and at
+  least one value
+- Every rule's `label` exists in the scanned `repoLabels`
+- The written JSON validates against `schemas/sdlc-config.schema.json`
+- No partial writes occurred when the user cancelled or `gh` failed
+
+---
+
+## Error Recovery
+
+> **Flow**: detect → diagnose → auto-recover (retry once if transient) → invoke `error-report-sdlc` for persistent actionable failures.
+
+| Error | Recovery | Invoke error-report-sdlc? |
+|-------|----------|---------------------------|
+| `gh label list` fails (auth/remote) | Print actionable hint, exit cleanly with no write | No — actionable by user |
+| `repoLabels` is empty | Warn, allow `off`/`llm`, gate `rules` behind "create labels first" message | No |
+| `lib/config.js` not found | Show error, stop without writing | Yes |
+| User picks `cancel` at any step | Exit cleanly, do not write partial state | No |
+| `writeSection` throws | Show stderr, do not retry — preserve any prior state | Yes |
+
+When invoking `error-report-sdlc`, provide:
+- **Skill**: setup-sdlc (pr-labels sub-flow)
+- **Step**: Step 5 — Write
+- **Operation**: `lib/config.js#writeSection('pr', ...)`
+- **Error**: full stderr/stack
+- **Suggested investigation**: file permissions on `.claude/sdlc.json`; plugin install integrity
+
+---
+
+## Gotchas
+
+1. **Never clobber sibling `pr.*` keys.**
+   *Symptom:* `pr.titlePattern` (or any other `pr.*` key) is wiped after the
+   sub-flow runs.
+   *Root cause:* Calling `writeSection(root, 'pr', { labels: ... })` replaces
+   the entire `pr` section.
+   *Mitigation:* Always read the current `pr` section, spread it, and only
+   override the `labels` key (Step 5 does this explicitly).
+
+2. **Empty `repoLabels` looks like a `gh` failure but isn't.**
+   *Symptom:* User sees no labels to pick from in `rules` mode and assumes
+   their `gh auth` is broken.
+   *Root cause:* Brand-new repos may have zero custom labels (only the GitHub
+   defaults that some orgs strip).
+   *Mitigation:* Distinguish "exit non-zero" (auth/remote) from "exit 0 with
+   `[]`" (no labels). The latter is a content state, not an error.
+
+3. **`pathGlob` semantics are stricter than expected.**
+   *Symptom:* User adds rule `documentation` when `pathGlob: ["**/*.md"]` and
+   later notices the label doesn't get applied to a PR that touched `*.md` and
+   one `package.json` file.
+   *Root cause:* The evaluator uses **all-changed-files** semantics — every
+   changed file must match. This is the same posture as the legacy `*.md`
+   inference rule.
+   *Mitigation:* Note in the value-entry prompt that `pathGlob` means "every
+   changed file matches one of these globs". For "any matches" semantics,
+   point users at `commitType` instead.
+
+4. **Append mode and replace mode look similar.**
+   *Symptom:* User picks `replace` thinking they will edit the existing rules,
+   but the new rule list overwrites everything.
+   *Root cause:* Both options exit through the same Step 4 loop; only
+   `append` seeds the in-memory list with existing rules.
+   *Mitigation:* In Step 2, show the current rule count before asking, and on
+   `replace` print "Existing rules will be discarded" before entering Step 3.
+
+5. **`gh label list --limit 100` may truncate.**
+   *Symptom:* Repo has more than 100 labels; some labels never appear in the
+   pick list.
+   *Root cause:* The `--limit 100` cap is hard-coded.
+   *Mitigation:* Document the cap in the prompt; if pagination is hit, suggest
+   the user create labels with shorter names or use `llm` mode.
+
+---
+
+## DO NOT
+
+- Do NOT write `.claude/sdlc.json` on any prompt where the user picks `cancel`.
+- Do NOT replace the entire `pr` section — only set/replace the `labels` key.
+- Do NOT accept a free-text label that isn't in `repoLabels` — the rule will be
+  stripped by `pr.js` validation later, leaving the user with a silent dead rule.
+- Do NOT proceed to the rules loop if `gh label list` failed — `rules` mode
+  without a known label set produces unverifiable rules.
+- Do NOT prompt for `mode` again when the user picked `append` in Step 2 —
+  append implies `rules` mode.
+
+---
+
+## See Also
+
+- `setup-sdlc --only pr-labels` — parent skill entrypoint
+- `setup-sdlc/setup-pr-template.md` — sibling sub-flow (PR template authoring)
+- `setup-sdlc/setup-guardrails.md` — sibling sub-flow (plan guardrails)
+- `pr-sdlc/SKILL.md#step-2b-infer-labels` — consumer; reads `pr.labels` to
+  dispatch the label evaluator
+- `schemas/sdlc-config.schema.json#$defs/prLabelsSection` — schema source of truth
+- `scripts/skill/pr.js` — strips rules whose `label` is not in `repoLabels`

--- a/schemas/sdlc-config.schema.json
+++ b/schemas/sdlc-config.schema.json
@@ -110,9 +110,106 @@
       },
       "additionalProperties": false
     },
+    "prLabelsSection": {
+      "type": "object",
+      "description": "Configures how /pr-sdlc chooses labels (issue #197). Mode `off` (default) adds no labels except those forced via --label. Mode `rules` evaluates user-defined deterministic rules. Mode `llm` lets the LLM pick labels via fuzzy matching against repo labels (legacy behavior, opt-in only).",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["off", "rules", "llm"],
+          "default": "off",
+          "description": "Label selection mode. `off` = no automatic labels (forced labels still apply). `rules` = evaluate user-defined rules deterministically. `llm` = legacy LLM fuzzy match."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Label rules evaluated when mode = `rules`. Each rule names exactly one target label and one signal type in `when`. Multiple rules may target the same label (OR semantics).",
+          "items": {
+            "type": "object",
+            "required": ["label", "when"],
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Repo label to apply when this rule matches. Must exist in the repository's label list."
+              },
+              "when": {
+                "description": "Signal that triggers this rule. Exactly one signal type per rule.",
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["branchPrefix"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "branchPrefix": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Match if currentBranch starts with any listed prefix (e.g. \"fix/\", \"feat/\")."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["commitType"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "commitType": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Match if any commit subject begins with `<type>:` or `<type>(scope):` (e.g. \"feat\", \"fix\")."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["pathGlob"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "pathGlob": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Match if every changed file matches one of the listed globs (e.g. \"**/*.md\")."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["jiraType"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "jiraType": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Match if jiraTicket.type is in the list (e.g. \"Bug\", \"Story\")."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["diffSizeUnder"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "diffSizeUnder": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Match if diffStat.totalLinesChanged is strictly less than this value."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "prSection": {
       "type": "object",
-      "description": "Controls pull request title validation.",
+      "description": "Controls pull request title validation and label assignment.",
       "properties": {
         "titlePattern": {
           "type": "string",
@@ -135,6 +232,9 @@
             "type": "string"
           },
           "description": "Allowed PR title scopes."
+        },
+        "labels": {
+          "$ref": "#/$defs/prLabelsSection"
         }
       },
       "additionalProperties": false

--- a/tests/promptfoo/datasets/pr-sdlc.yaml
+++ b/tests/promptfoo/datasets/pr-sdlc.yaml
@@ -231,3 +231,162 @@
         hint and proceeds to the existing failure fallback (no retry). It does not call
         the helper twice or invoke any matching/decision logic itself — all decisions
         come from the helper.
+
+# ---------------------------------------------------------------------------
+# Issue #197 — Configurable PR labels (mode: off | rules | llm)
+# ---------------------------------------------------------------------------
+
+- description: "pr-sdlc labels: mode=off + no forced labels → no Labels line, no fabrication"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/feature-branch-with-commits.md"
+    user_request: >
+      Run /pr-sdlc on this feature branch. Assume PR_CONTEXT_JSON.prConfig.labels.mode = "off"
+      and forcedLabels is empty. Show the Step 5 approval prompt verbatim — what is the
+      Labels line, if any? Justify your answer against the Step 2b dispatch rules.
+  assert:
+    # The Labels line must NOT appear in the approval prompt
+    - type: not-icontains
+      value: "Labels:"
+    # No fabricated labels regardless of repoLabels content
+    - type: not-icontains
+      value: "(rule)"
+    - type: not-icontains
+      value: "(llm)"
+    - type: llm-rubric
+      value: >
+        The response correctly states that under mode = "off" with no forced labels, no
+        Labels line is shown in the Step 5 approval output. It cites the Step 2b "Off mode"
+        rule and the Step 5 instruction to omit the Labels line entirely when there are no
+        labels. It does NOT fabricate any label suggestions, does NOT fall back to fuzzy
+        matching, and does NOT mention "(llm)" or "(rule)" provenance tags.
+
+- description: "pr-sdlc labels: mode=rules + matching branchPrefix → only the matched label is suggested"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/pr-sdlc-labels-rules.md"
+    user_request: >
+      Run /pr-sdlc Step 2b on this branch. Walk through every rule in prConfig.labels.rules
+      against the PR context and report the final suggestedLabels list with provenance tags.
+      Use the dispatch rules from the SKILL.md exactly.
+  assert:
+    # branchPrefix rule matches "fix/" → bug
+    - type: icontains
+      value: "bug"
+    # diffSizeUnder rule matches (44 < 50) → small-change
+    - type: icontains
+      value: "small-change"
+    # commitType "feat" rule does NOT match (commits start with "fix")
+    - type: not-icontains
+      value: "feature (rule)"
+    # pathGlob "**/*.md" rule does NOT match (only .ts files)
+    - type: not-icontains
+      value: "documentation (rule)"
+    - type: llm-rubric
+      value: >
+        The response correctly evaluates each rule. It identifies that the branchPrefix
+        rule matches because the branch starts with "fix/", producing the "bug" label tagged
+        (rule). It identifies that the diffSizeUnder=50 rule matches because totalLinesChanged
+        is 44, producing "small-change" tagged (rule). It correctly REJECTS the commitType
+        "feat" rule (commits start with "fix(...)" not "feat(...)") and the pathGlob "**/*.md"
+        rule (the changed files are .ts, not all-markdown). The final suggestedLabels list
+        contains exactly two entries: bug (rule) and small-change (rule). No fabrication.
+
+- description: "pr-sdlc labels: mode=rules + forced label appears first, deduped against rule match"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/pr-sdlc-labels-rules.md"
+    user_request: >
+      Run /pr-sdlc Step 2b but assume forcedLabels = ["bug", "needs-review"]. Show the
+      final ordered, deduped suggestedLabels list with provenance tags as it would appear
+      in the Step 5 Labels line.
+  assert:
+    - type: icontains
+      value: "bug (forced)"
+    - type: icontains
+      value: "needs-review (forced)"
+    # bug must NOT also appear with (rule) — forced wins
+    - type: not-icontains
+      value: "bug (rule)"
+    # small-change still emerges from the diffSizeUnder rule
+    - type: icontains
+      value: "small-change (rule)"
+    - type: llm-rubric
+      value: >
+        The response shows forced labels first ("bug (forced)", "needs-review (forced)"),
+        followed by the rule-derived "small-change (rule)". The "bug" label appears exactly
+        once with (forced) provenance — the rule match is deduplicated since forced wins
+        for provenance. needs-review appears even though it was not in any rule, because
+        forced labels apply regardless of mode.
+
+- description: "pr-sdlc labels: mode=rules + rule references missing label → warning + rule stripped"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/pr-sdlc-labels-rules.md"
+    user_request: >
+      Run /pr-sdlc Step 2b but assume prConfig.labels.rules contains an additional rule
+      `{ label: "wontfix", when: { branchPrefix: ["fix/"] } }` and that "wontfix" is NOT
+      in repoLabels. Describe (a) where this rule is filtered, (b) what warning surfaces,
+      and (c) the final suggestedLabels list.
+  assert:
+    - type: icontains
+      value: "wontfix"
+    # Warning text from pr.js
+    - type: regex
+      value: "(does not exist|will be ignored|not in the repo|not in repoLabels)"
+    - type: not-icontains
+      value: "wontfix (rule)"
+    - type: llm-rubric
+      value: >
+        The response correctly explains that pr.js validates rules[].label against repoLabels
+        and strips any rule whose label is not present, emitting a warning ("Label \"wontfix\"
+        referenced in pr.labels.rules does not exist in the repo. Rule will be ignored." or
+        equivalent wording). The skill's Step 2b dispatch never sees the bad rule. The final
+        suggestedLabels list does NOT include "wontfix" with any provenance tag.
+
+- description: "pr-sdlc labels: mode=llm → fuzzy heuristic produces (llm)-tagged suggestions"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/feature-branch-with-commits.md"
+    user_request: >
+      Run /pr-sdlc Step 2b on this branch with PR_CONTEXT_JSON.prConfig.labels.mode = "llm"
+      and repoLabels = [{name:"feature"},{name:"enhancement"},{name:"tests"}]. Apply the
+      LLM-mode fuzzy heuristic from Step 2b and report the final suggestedLabels with
+      provenance tags as the Step 5 Labels line would render them.
+  assert:
+    - type: icontains
+      value: "(llm)"
+    # Branch starts with feat/ and commits are feat(...): fuzzy match → feature or enhancement
+    - type: regex
+      value: "(feature|enhancement)"
+    - type: llm-rubric
+      value: >
+        The response activates the LLM-mode fuzzy heuristic and produces label suggestions
+        from the branch prefix ("feat/") and conventional-commit subjects ("feat(...)",
+        "chore(...)") matched against the provided repoLabels. Each suggested label carries
+        the (llm) provenance tag in the Step 5 display. The response makes clear this
+        branch ran ONLY because mode = "llm" was explicitly selected (opt-in), and would
+        not have run under the default "off" mode.
+
+- description: "pr-sdlc labels: pr.labels absent (legacy project) → behaves as mode=off"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md"
+    project_context: "file://fixtures/feature-branch-with-commits.md"
+    user_request: >
+      Run /pr-sdlc Step 2b assuming PR_CONTEXT_JSON.prConfig is `{ "titlePattern": "..." }`
+      with NO `labels` block at all (legacy project that never ran setup-sdlc --only pr-labels).
+      What does Step 2b dispatch to, and what is the Labels line in Step 5?
+  assert:
+    - type: not-icontains
+      value: "Labels:"
+    - type: not-icontains
+      value: "(llm)"
+    - type: not-icontains
+      value: "(rule)"
+    - type: llm-rubric
+      value: >
+        The response identifies that when prConfig.labels is absent, the Step 2b mode
+        defaults to "off" (per the resolution rule "When absent, default to off"). No
+        evaluation runs, no Labels line appears in Step 5, and the LLM fuzzy heuristic is
+        NOT triggered. This is the explicit fix for issue #197 — legacy projects do not
+        get fabricated labels until they opt into rules or llm mode.

--- a/tests/promptfoo/datasets/setup-sdlc.yaml
+++ b/tests/promptfoo/datasets/setup-sdlc.yaml
@@ -165,3 +165,91 @@
         block describing the defaultProject field with at least one full sentence covering
         what runtime behavior changes when set. The header copy comes from the manifest
         (scripts/lib/setup-sections.js), not freeform LLM-generated text.
+
+# ---------------------------------------------------------------------------
+# Issue #197 — pr-labels sub-flow (setup-pr-labels.md)
+# ---------------------------------------------------------------------------
+
+- description: "setup-sdlc --only pr-labels: mode=off writes { mode: 'off' } and preserves sibling pr keys"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-clean/ with an existing
+      .claude/sdlc.json that already has `pr.titlePattern` and `pr.allowedTypes`. The user
+      runs `/setup-sdlc --only pr-labels` and at the mode prompt picks "off". `gh label list`
+      returned a non-empty list (e.g. ["bug","feature","docs"]).
+    user_request: >
+      Walk through setup-pr-labels.md Steps 1-6 for this project and pick "off" at the
+      mode prompt. Show the exact JSON written into .claude/sdlc.json `pr` section,
+      including how titlePattern and allowedTypes are preserved.
+  assert:
+    - type: icontains
+      value: '"mode": "off"'
+    - type: icontains
+      value: "titlePattern"
+    - type: icontains
+      value: "allowedTypes"
+    - type: not-icontains
+      value: '"rules":'
+    - type: llm-rubric
+      value: >
+        The response demonstrates the off-mode write path: it reads the existing pr section,
+        spreads it, and only sets/replaces the labels key with `{ mode: "off" }`. The
+        existing pr.titlePattern and pr.allowedTypes survive unchanged (sub-flow gotcha #1).
+        No `rules` array is written. The user is shown a one-line summary like
+        "Wrote pr.labels: mode=off to .claude/sdlc.json".
+
+- description: "setup-sdlc --only pr-labels: mode=llm writes { mode: 'llm' } with no rules array"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-clean/ with no existing
+      pr.labels block. `gh label list` returned ["bug","feature","docs","tests"]. The user
+      runs `/setup-sdlc --only pr-labels` and at the mode prompt explicitly picks "llm".
+    user_request: >
+      Walk through setup-pr-labels.md and pick "llm" at the mode prompt. Show the JSON
+      block written to .claude/sdlc.json `pr.labels` and explain why this is opt-in.
+  assert:
+    - type: icontains
+      value: '"mode": "llm"'
+    - type: not-icontains
+      value: '"rules":'
+    - type: llm-rubric
+      value: >
+        The response writes exactly `{ mode: "llm" }` under `pr.labels` with no `rules`
+        field. The rationale call-out makes clear that picking "llm" is the user's explicit
+        opt-in to the legacy fuzzy-match heuristic — addressing issue #197 by ensuring the
+        LLM never picks labels silently for projects that didn't choose this mode.
+
+- description: "setup-sdlc --only pr-labels: mode=rules with one branchPrefix rule writes valid block"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-clean/ with no existing
+      pr.labels block. `gh label list` returned ["bug","feature","docs"]. The user runs
+      `/setup-sdlc --only pr-labels`, picks "rules", picks the "bug" label, picks the
+      "branchPrefix" signal, and enters "fix/, bugfix/" as values, then picks "done".
+    user_request: >
+      Walk through setup-pr-labels.md Step 4 with the inputs above. Show the final JSON
+      block written to .claude/sdlc.json `pr.labels` and identify which schema keys it
+      uses (mode, rules[*].label, rules[*].when.branchPrefix).
+  assert:
+    - type: icontains
+      value: '"mode": "rules"'
+    - type: icontains
+      value: '"label": "bug"'
+    - type: icontains
+      value: "branchPrefix"
+    - type: icontains
+      value: "fix/"
+    - type: icontains
+      value: "bugfix/"
+    - type: llm-rubric
+      value: >
+        The response builds a single rule
+        `{ label: "bug", when: { branchPrefix: ["fix/", "bugfix/"] } }`,
+        appends it to an empty rules array, and writes `{ mode: "rules", rules: [...] }`
+        under `pr.labels` via `writeSection(root, "pr", ...)`. The branchPrefix value is
+        parsed from comma-separated input, trimmed, deduped, and stored as an array. The
+        chosen label "bug" comes from the gh label list (not free text). No partial write
+        occurs — the writeSection call happens once after "done".

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/.claude/sdlc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../../../schemas/sdlc-config.schema.json",
+  "pr": {
+    "titlePattern": "^(feat|fix|chore): .+$",
+    "allowedTypes": ["feat", "fix", "chore"]
+  }
+}

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/setup.sh
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Clean project for setup-sdlc --only pr-labels sub-flow tests.
+# Pre-existing pr.titlePattern is intentionally present so that writing
+# pr.labels does not clobber siblings (sub-flow gotcha #1).
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/src/index.js
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-clean/src/index.js
@@ -1,0 +1,2 @@
+// Placeholder source file so the fixture is a non-empty git repo.
+module.exports = {};

--- a/tests/promptfoo/fixtures/pr-sdlc-labels-rules.md
+++ b/tests/promptfoo/fixtures/pr-sdlc-labels-rules.md
@@ -1,0 +1,104 @@
+# Simulated Project Context: PR Labels — Rules Mode (issue #197)
+
+## Git State
+
+- **Current branch:** `fix/null-pointer-in-cart`
+- **Base branch:** `main`
+- **Remote state:** branch does not exist on origin yet (needs push)
+
+## Commit Log (2 commits since main)
+
+```
+aaa1111 fix(cart): guard against null product in line item
+bbb2222 fix(cart): add regression test for null-product crash
+```
+
+No JIRA tickets referenced in branch name or commit subjects.
+
+## Diff Summary
+
+**Files changed:** 2
+
+- `src/cart/line-item.ts` — modified (12 lines): null-check before reading product fields
+- `src/cart/__tests__/line-item.test.ts` — modified (28 lines): new regression test
+
+## Diff Stat
+
+```
+2 files changed, 40 insertions(+), 4 deletions(-)
+```
+
+## Project Config — `.claude/sdlc.json`
+
+```json
+{
+  "pr": {
+    "labels": {
+      "mode": "rules",
+      "rules": [
+        { "label": "bug", "when": { "branchPrefix": ["fix/", "bugfix/"] } },
+        { "label": "feature", "when": { "commitType": ["feat"] } },
+        { "label": "documentation", "when": { "pathGlob": ["**/*.md"] } },
+        { "label": "small-change", "when": { "diffSizeUnder": 50 } }
+      ]
+    }
+  }
+}
+```
+
+## pr-prepare.js Output (PR_CONTEXT_JSON)
+
+```json
+{
+  "mode": "create",
+  "baseBranch": "main",
+  "currentBranch": "fix/null-pointer-in-cart",
+  "isDraft": false,
+  "isAuto": false,
+  "existingPr": null,
+  "jiraTicket": null,
+  "customTemplate": null,
+  "prConfig": {
+    "labels": {
+      "mode": "rules",
+      "rules": [
+        { "label": "bug", "when": { "branchPrefix": ["fix/", "bugfix/"] } },
+        { "label": "feature", "when": { "commitType": ["feat"] } },
+        { "label": "documentation", "when": { "pathGlob": ["**/*.md"] } },
+        { "label": "small-change", "when": { "diffSizeUnder": 50 } }
+      ]
+    }
+  },
+  "commits": [
+    { "subject": "fix(cart): guard against null product in line item", "body": "" },
+    { "subject": "fix(cart): add regression test for null-product crash", "body": "" }
+  ],
+  "changedFiles": [
+    "src/cart/line-item.ts",
+    "src/cart/__tests__/line-item.test.ts"
+  ],
+  "diffStat": { "files": 2, "insertions": 40, "deletions": 4, "totalLinesChanged": 44 },
+  "repoLabels": [
+    { "name": "bug", "description": "Defect fix" },
+    { "name": "feature", "description": "New capability" },
+    { "name": "documentation", "description": "Docs only" },
+    { "name": "small-change", "description": "Tiny diff, fast review" },
+    { "name": "needs-review", "description": "Awaiting review" }
+  ],
+  "forcedLabels": [],
+  "remoteState": "no-remote",
+  "warnings": [],
+  "errors": []
+}
+```
+
+## Expected Label Evaluation
+
+Under `mode = "rules"`:
+
+- Rule 1 (`branchPrefix: ["fix/", "bugfix/"]` → `bug`): MATCHES — branch starts with `fix/`
+- Rule 2 (`commitType: ["feat"]` → `feature`): NO MATCH — both commit subjects begin with `fix(...)`
+- Rule 3 (`pathGlob: ["**/*.md"]` → `documentation`): NO MATCH — `.ts` files are not all-markdown
+- Rule 4 (`diffSizeUnder: 50` → `small-change`): MATCHES — 44 < 50
+
+Final `suggestedLabels`: `[ bug (rule), small-change (rule) ]`. No fabrication, no `feature` or `documentation`.


### PR DESCRIPTION
## Summary
This PR makes GitHub PR label assignment configurable via `.claude/sdlc.json`. Previously, label suggestions were always LLM-driven with no way to turn them off or use deterministic rules. Now teams can choose between three modes: `off` (no automatic labels), `rules` (deterministic signal-based matching), or `llm` (the legacy fuzzy model behavior, opt-in).

## Business Context
Users of the sdlc-marketplace plugin had no control over how labels were applied to pull requests. The LLM-based fuzzy matching produced inconsistent results and couldn't be disabled, making it unsuitable for teams that either want no automation or prefer predictable rule-based labeling. Issue #197 tracks this gap.

## Business Benefits
- Teams that don't use labels can turn off auto-labeling entirely with `mode: "off"`, eliminating noise
- Teams with established label conventions can define deterministic rules (branch prefix, commit type, file path glob, JIRA type, diff size) that produce consistent results without model variation
- Teams that preferred the old behavior can opt back in with `mode: "llm"` — no regression
- New `setup-sdlc --only pr-labels` sub-flow guides teams through configuration interactively

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/197

## Technical Design
The `pr.labels` configuration block in `.claude/sdlc.json` drives behavior. The `mode` field switches between three strategies:

- **`off`**: label inference is bypassed entirely; only forced labels from `--label` apply
- **`rules`**: a declarative rule array is evaluated — each rule has a single `when` signal key (`branchPrefix`, `commitType`, `pathGlob`, `jiraType`, or `diffSizeUnder`) mapped to a label name; rules are validated structurally at load time
- **`llm`**: the pre-#197 fuzzy matching path, preserved for backward compatibility

Structural validation ensures each rule has exactly one signal key from the known set; invalid rules are logged as warnings and skipped rather than causing failures. `getDiffStat()` was extended to expose `totalLinesChanged` (insertions + deletions) to support the `diffSizeUnder` signal. A new `setup-pr-labels` sub-flow in setup-sdlc walks users through mode selection and rule entry interactively.

## Technical Impact
- `schemas/sdlc-config.schema.json` extended with `pr.labels` block — backward compatible (field is optional, defaults to `off`)
- `skill/pr.js` reads the new config block and applies mode-specific label logic
- `getDiffStat()` in `scripts/lib/git.js` gains a new `totalLinesChanged` field — additive, no breakage
- SKILL.md files for `pr-sdlc` and `setup-sdlc` updated — no interface changes to existing skill invocations
- No breaking changes to plugin manifest, hook payloads, or external script APIs

## Changes Overview
- Three-mode label system (`off`/`rules`/`llm`) added to PR label assignment, replacing the always-on LLM heuristic
- Deterministic rule engine with five signal types and structural validation (warns on malformed rules, never silently applies bad config)
- `getDiffStat()` extended with `totalLinesChanged` metric to power the `diffSizeUnder` signal
- New `setup-pr-labels` interactive sub-flow in setup-sdlc for guided configuration
- Schema updated with `pr.labels` block including rule array shape
- Skill docs and specs updated for both `pr-sdlc` and `setup-sdlc` to document the new modes, signals, and provenance tags
- Comprehensive promptfoo test coverage added for all three modes and edge cases (invalid rules, forced labels, mode interactions)

## Testing
All three label modes are covered by new promptfoo test cases in the `pr-sdlc` dataset. A new filesystem fixture (`setup-pr-labels-clean`) supports exec-mode tests for the setup sub-flow. The rule structural validation is tested with malformed rule inputs. The `skip-version-check` forced-label scenario is tested to confirm it applies regardless of mode.