### PR TITLE
fix(#203): setup-sdlc - count .md review-dimension files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.40] - 2026-05-05
+
+### Fixed
+- setup-sdlc: corrected review dimension file count to look for `.md` files instead of `.yaml`/`.yml`, fixing dimensions always reporting a count of 0 (#203)
+
 ## [0.17.39] - 2026-05-05
 
 ### Added

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.39",
+  "version": "0.17.40",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/skill/setup.js
+++ b/plugins/sdlc-utilities/scripts/skill/setup.js
@@ -160,7 +160,7 @@ function detect(projectRoot) {
     },
     content: {
       reviewDimensions: {
-        count: countFiles(reviewDimensionsDir, '.yaml') + countFiles(reviewDimensionsDir, '.yml'),
+        count: countFiles(reviewDimensionsDir, '.md'),
         path: path.join('.claude', 'review-dimensions') + path.sep,
       },
       prTemplate: {

--- a/tests/promptfoo/datasets/setup-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/setup-prepare-exec.yaml
@@ -88,3 +88,12 @@
       value: |
         const out = JSON.parse(output);
         return out.needsMigration === true && out.localIsV1 === true
+
+- description: "setup-prepare: counts .md review-dimension files (regression #203)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/setup.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-with-dimensions"
+  assert:
+    - type: javascript
+      value: "JSON.parse(output).content.reviewDimensions.count === 3"


### PR DESCRIPTION
## Summary
Fixes a bug in `setup-sdlc` where the review dimensions count always reported 0. The script was counting `.yaml`/`.yml` files, but dimension files are stored as `.md`. This patch corrects the extension and adds a regression test.

## Business Context
Users who configure custom review dimensions saw the setup health check always report 0 dimensions configured, even when dimension files existed. This gave false confidence that the feature was absent or broken, making it impossible to rely on setup output for onboarding guidance or CI validation.

## Business Benefits
- Setup output now correctly reflects the number of configured review dimensions
- Onboarding and validation scripts that read setup output will no longer be misled by a zero count
- Regression test prevents this from silently breaking again

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/203

## Technical Design
Single-line fix in `setup.js`: changed `countFiles(reviewDimensionsDir, '.yaml') + countFiles(reviewDimensionsDir, '.yml')` to `countFiles(reviewDimensionsDir, '.md')`. Dimension files were always `.md` (matching the review-dimension skill format); the YAML counting was a copy-paste error from a different detection block. Regression test added using the `project-with-dimensions` fixture, asserting the count equals 3.

## Technical Impact
None. This is an internal detection fix — no changes to plugin manifests, skill interfaces, hook payloads, or script APIs.

## Changes Overview
- Fixed review dimension file counter to use `.md` extension instead of `.yaml`/`.yml`
- Added regression test case asserting correct count with a fixture project that contains 3 dimension files
- Bumped plugin version to 0.17.40 and updated CHANGELOG

## Testing
Regression test added to `setup-prepare-exec.yaml` dataset using the `project-with-dimensions` fixture, asserting `reviewDimensions.count === 3`. The fix was verified manually by running setup.js against the fixture before and after the change.