### PR TITLE
fix(#205): setup-sdlc - summarizePrLabels reads leaf config, not parent

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,9 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-05 — version-sdlc: patch release v0.17.41 from fix/205-pr-labels-section-menu
+Branch had no upstream; `--set-upstream` auto-heal fired correctly on first push. Changelog disabled via CLI (no `--changelog` flag despite `config.changelog: true`). Single fix commit: setup-sdlc summarizePrLabels leaf config read.
+
 ## 2026-05-05 — pr-sdlc: per-dimension model override PR (#199)
 PR created for feat(#199) on branch fix/199-per-dimension-model-override. Custom template active — title pattern required `type(#issue): scope - description` format. sdlc.json version mode was already switched to `tag` on this branch, affecting how version-sdlc behaves in future sessions. "Fixes #199" placed in Github Issue section (custom template field) to link the issue for auto-close on merge.
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
+  "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
   "version": "0.17.41",
   "author": {
     "name": "rnagrodzki"

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release management.",
-  "version": "0.17.40",
+  "version": "0.17.41",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/setup-sections.js
+++ b/plugins/sdlc-utilities/scripts/lib/setup-sections.js
@@ -206,17 +206,16 @@ function summarizePr(cfg) {
 }
 
 function summarizePrLabels(cfg) {
-  // cfg is the parent `pr` section; the labels block sits under cfg.labels.
-  const labels = cfg && cfg.labels;
-  if (!labels || typeof labels !== 'object') return 'not configured';
-  const mode = labels.mode;
+  // cfg is the `pr.labels` leaf (currentCfgFor walks the configPath dot-path).
+  if (!cfg || typeof cfg !== 'object') return '';
+  const mode = cfg.mode;
   if (mode === 'off') return 'off — no automatic labels';
   if (mode === 'rules') {
-    const n = Array.isArray(labels.rules) ? labels.rules.length : 0;
+    const n = Array.isArray(cfg.rules) ? cfg.rules.length : 0;
     return `rules: ${n} rule${n === 1 ? '' : 's'}`;
   }
   if (mode === 'llm') return 'llm — model picks labels';
-  return 'not configured';
+  return '';
 }
 
 function summarizeReviewDimensions(_cfg, detected) {

--- a/tests/promptfoo/datasets/setup-sdlc.yaml
+++ b/tests/promptfoo/datasets/setup-sdlc.yaml
@@ -253,3 +253,89 @@
         parsed from comma-separated input, trimmed, deduped, and stored as an array. The
         chosen label "bug" comes from the gh label list (not free text). No partial write
         occurs — the writeSection call happens once after "done".
+
+# ---------------------------------------------------------------------------
+# Issue #205 — pr-labels section-menu summary
+# ---------------------------------------------------------------------------
+
+- description: "setup-sdlc Step 1 menu: pr.labels mode=off renders [set] and 'off — no automatic labels'"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/ with an existing
+      .claude/sdlc.json containing `pr.labels: { mode: "off" }`. The user runs
+      `/setup-sdlc` (no flags) and reaches the Step 1 selective-section menu.
+    user_request: >
+      Render the Step 1 selective-section menu for this project. Show how the pr-labels
+      row is presented, including its state marker and the per-section summary string
+      produced by summarizePrLabels.
+  assert:
+    - type: icontains
+      value: "pr-labels"
+    - type: icontains
+      value: "[set]"
+    - type: icontains
+      value: "off — no automatic labels"
+    - type: not-icontains
+      value: "not configured"
+    - type: llm-rubric
+      value: >
+        The pr-labels row in the Step 1 menu shows the configured state: marker `[set]`
+        (not `[not set]`) and the summary `off — no automatic labels`. The summarizer
+        receives the `pr.labels` leaf object directly (currentCfgFor walks the
+        configPath dot-path), reads `cfg.mode === "off"`, and returns the off-mode
+        message. The legacy bug behavior — reading `cfg.labels.mode` from the parent
+        `pr` slice and returning `not configured` — must NOT appear (issue #205).
+
+- description: "setup-sdlc Step 1 menu: pr.labels mode=rules with 1 rule renders [set] and 'rules: 1 rule'"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/ with an existing
+      .claude/sdlc.json containing
+      `pr.labels: { mode: "rules", rules: [{ label: "bug", when: { branchPrefix: ["fix/"] } }] }`.
+      The user runs `/setup-sdlc` (no flags) and reaches the Step 1 selective-section menu.
+    user_request: >
+      Render the Step 1 selective-section menu for this project. Show how the pr-labels
+      row is presented, including its state marker and the per-section summary string
+      produced by summarizePrLabels.
+  assert:
+    - type: icontains
+      value: "pr-labels"
+    - type: icontains
+      value: "[set]"
+    - type: icontains
+      value: "rules: 1 rule"
+    - type: not-icontains
+      value: "not configured"
+    - type: llm-rubric
+      value: >
+        The pr-labels row shows marker `[set]` and summary `rules: 1 rule` (singular,
+        because the rules array has length 1). The summarizer reads `cfg.rules.length`
+        from the leaf, not `cfg.labels.rules.length` from the parent. The pluralization
+        is correct (`rule` not `rules`).
+
+- description: "setup-sdlc Step 1 menu: no pr.labels key renders [not set] without 'not configured' string"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md"
+    project_context: >
+      Project at tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/ with an existing
+      .claude/sdlc.json that has a `pr` block (titlePattern, allowedTypes) but NO
+      `pr.labels` key at all. The user runs `/setup-sdlc` (no flags) and reaches the
+      Step 1 selective-section menu.
+    user_request: >
+      Render the Step 1 selective-section menu for this project. Show how the pr-labels
+      row is presented, including its state marker and any per-section summary string.
+  assert:
+    - type: icontains
+      value: "pr-labels"
+    - type: icontains
+      value: "[not set]"
+    - type: not-icontains
+      value: "not configured"
+    - type: llm-rubric
+      value: >
+        The pr-labels row shows marker `[not set]` because `pr.labels` is undefined.
+        The per-section summary is empty (the helper returns `''` for missing config,
+        matching sibling summarizers). The literal string `not configured` does NOT
+        appear — the legacy regression must not be reintroduced (issue #205).

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/.claude/sdlc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../../../schemas/sdlc-config.schema.json",
+  "pr": {
+    "titlePattern": "^(feat|fix|chore): .+$",
+    "allowedTypes": ["feat", "fix", "chore"],
+    "labels": {
+      "mode": "off"
+    }
+  }
+}

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/setup.sh
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Project with pr.labels.mode=off — section-menu summary should render
+# `[set]` and `off — no automatic labels` (issue #205 regression guard).
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/src/index.js
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-off/src/index.js
@@ -1,0 +1,2 @@
+// Placeholder source file so the fixture project is non-empty.
+module.exports = {};

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/.claude/sdlc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../schemas/sdlc-config.schema.json",
+  "pr": {
+    "titlePattern": "^(feat|fix|chore): .+$",
+    "allowedTypes": ["feat", "fix", "chore"],
+    "labels": {
+      "mode": "rules",
+      "rules": [
+        {
+          "label": "bug",
+          "when": { "branchPrefix": ["fix/"] }
+        }
+      ]
+    }
+  }
+}

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/setup.sh
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Project with pr.labels.mode=rules and one rule — section-menu summary
+# should render `[set]` and `rules: 1 rule` (issue #205 regression guard).
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/src/index.js
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-rules/src/index.js
@@ -1,0 +1,2 @@
+// Placeholder source file so the fixture project is non-empty.
+module.exports = {};

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/.claude/sdlc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../../../schemas/sdlc-config.schema.json",
+  "pr": {
+    "titlePattern": "^(feat|fix|chore): .+$",
+    "allowedTypes": ["feat", "fix", "chore"]
+  }
+}

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/setup.sh
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Project with no pr.labels block — section-menu summary should render
+# `[not set]` (issue #205 regression guard: must NOT show "not configured").
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "init"

--- a/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/src/index.js
+++ b/tests/promptfoo/fixtures-fs/setup-pr-labels-menu-unset/src/index.js
@@ -1,0 +1,2 @@
+// Placeholder source file so the fixture project is non-empty.
+module.exports = {};


### PR DESCRIPTION
## Summary
Fixes a bug in `setup-sdlc` where the Step 1 section menu showed "not configured" for the `pr-labels` row even when `pr.labels` was explicitly configured. The `summarizePrLabels` function was receiving the `pr.labels` leaf object (via `configPath` dot-walk) but incorrectly reading `cfg.labels.mode` (one level too deep), which was always `undefined`.

## Business Context
Users who configured `pr.labels` in `sdlc.json` (with `mode: "off"`, `mode: "rules"`, or `mode: "llm"`) saw "not configured" in the setup menu, giving false negative feedback about their configuration state. This made `setup-sdlc` misleading and undermined trust in the menu's status indicators.

## Business Benefits
- The `pr-labels` section menu row now accurately reflects configured state: `[set]` with a meaningful summary (`off — no automatic labels`, `rules: N rule(s)`, or `llm — model picks labels`) when configured; `[not set]` with an empty summary when absent
- Users can reliably use the Step 1 menu to confirm their label automation settings without re-entering setup unnecessarily

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/205

## Technical Design
`summarizePrLabels` is called with the result of `currentCfgFor(cfg, section.configPath)`, which already dot-walks to the `pr.labels` leaf. The fix removes the extra `cfg.labels` dereference — now reads `cfg.mode` and `cfg.rules` directly from the passed leaf. The fallback for missing config returns `''` (empty string), matching the convention of other sibling summarizers, instead of `'not configured'`.

## Technical Impact
None. The fix is internal to `summarizePrLabels` in `scripts/lib/setup-sections.js` — no public API, skill interface, hook payload, or script API was changed.

## Changes Overview
- Fixed `summarizePrLabels` to read `mode` and `rules` from the leaf object it receives, eliminating the off-by-one config level that caused "not configured" for all configured states
- Replaced `not configured` fallback return with empty string to align with sibling summarizers convention
- Added 3 promptfoo regression test cases covering the three states: mode=off, mode=rules with 1 rule, and no pr.labels key
- Added 3 fixture directories (setup-pr-labels-menu-off, setup-pr-labels-menu-rules, setup-pr-labels-menu-unset) each with a pre-configured sdlc.json to drive the regression tests

## Testing
Three promptfoo test cases were added to `tests/promptfoo/datasets/setup-sdlc.yaml` covering all regression scenarios:
- `mode=off` → asserts `[set]` + "off — no automatic labels" appears, and "not configured" does NOT appear
- `mode=rules` with 1 rule → asserts `[set]` + "rules: 1 rule" (correct singular) appears, "not configured" does NOT appear
- No `pr.labels` key → asserts `[not set]` appears, "not configured" does NOT appear