### PR TITLE
fix(#202): skill subagents - move model to orchestrator for minimal payload

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -37,6 +37,9 @@ that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 - version-sdlc auto-set-upstream → #183
 - pr-sdlc post-failure gh-switch → #184
 - plan-sdlc README reminder → #185
+- version-sdlc --output-file unknown flag warning → #212
+- version-sdlc config.changelog not honored → #213
+- pr-sdlc remoteState.pushed stale → #214
 
 ## 2026-04-29 — received-review-sdlc processing of review findings for fix(#183)
 - `not-icontains` on `--set-upstream` would match the string anywhere in the response (including explanatory text), producing false negatives on regression-guard assertions; `not-regex: 'git push.*--set-upstream'` scopes the check to actual push command lines only.

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -47,3 +47,12 @@ that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 
 ## 2026-05-05 -- setup-sdlc: review-dimensions count mismatch
 setup.js reported reviewDimensions.count: 0 despite 12 valid .md files in .claude/review-dimensions/. Root cause: setup.js likely checks for .yaml extensions but this project uses .md. Validate script (validate-dimensions.js) correctly found all 12. Added type-safety-review as the one genuine gap (code-quality.md only triggers on *.js, not *.ts). GitHub Copilot instruction added for new dimension. Also added 8 execution guardrails including 3 project-specific ones derived from AGENTS.md (no-auto-eval, spec-first, skill-docs-required).
+
+## 2026-05-05 — version-sdlc: patch bump on feat commit, first push from new branch
+Patch bump (0.17.41 → 0.17.42) was explicitly requested despite conventionalSummary.suggestedBump being "minor" (one feat commit). Explicit user request takes precedence. Branch fix/skill-subagents-minimal-payload had no upstream — used --set-upstream on first push; succeeded cleanly.
+
+## 2026-05-05 — ship-sdlc: issue #202 - skill subagent minimal payload
+execute-plan-sdlc created feature branch fix/skill-subagents-minimal-payload from main. Previous in_progress state file (from 09:51) was silently bypassed by starting fresh — state was keyed to `main` but execute created a new branch, requiring state re-init. version-sdlc suggested minor bump (feat commit) but explicit patch override worked as expected. Review found call-site model:haiku inconsistency vs review-sdlc pattern (medium) — verify if agent frontmatter model: is honored without call-site override.
+
+## 2026-05-05 — received-review-sdlc: issue #202 follow-up fixes
+Review finding #2 (medium): "call-site model:haiku inconsistent with review-sdlc" — the asymmetry is intentional. review-orchestrator runs at parent model; commit/error-report orchestrators want haiku specifically. The Agent tool model: parameter takes precedence over agent frontmatter (per tool docs). The original comment "pass it explicitly so the harness honours it" was misleading — the call-site IS the correct mechanism, frontmatter is redundant. Finding accepted (improve comment clarity), not change of mechanism.

--- a/docs/skill-best-practices.md
+++ b/docs/skill-best-practices.md
@@ -411,3 +411,15 @@ The harness does not support frontmatter-driven context forking for skills. To a
 This split-phase pattern keeps the main context clean while preserving user interaction where needed.
 
 **Canonical example:** `review-sdlc` dispatches the `review-orchestrator` agent for parallel dimension review, then handles comment posting and self-fix offers in the main context.
+
+### Why frontmatter `model:` is the wrong context-isolation knob
+
+Pinning `model:` (e.g., `model: haiku`) in skill frontmatter does **not** create a fresh context. The harness routes the skill into a subagent that inherits the entire parent conversation transcript. On long sessions this overflows the smaller-window models and the skill aborts with `Context limit reached` (issue #202).
+
+Use the in-body `Agent` dispatch pattern instead: write the skill body to run in the main parent-model context, have it generate a minimal payload (typically via a prepare script using `lib/output.js writeOutput()` and `--output-file`), and dispatch a dedicated orchestrator agent with a two-line prompt — `MANIFEST_FILE: <path>` and `PROJECT_ROOT: <cwd>`. Pin `model: haiku` (or whichever cheaper model fits) on the **orchestrator agent** under `plugins/sdlc-utilities/agents/`, where the input is bounded to the manifest, not on the skill, where the input is the unbounded conversation.
+
+**Canonical pairs:**
+
+- `review-sdlc` → `review-orchestrator`
+- `commit-sdlc` → `commit-orchestrator`
+- `error-report-sdlc` → `error-report-orchestrator`

--- a/docs/specs/commit-sdlc.md
+++ b/docs/specs/commit-sdlc.md
@@ -3,7 +3,7 @@
 > Generate and execute a git commit with a message matching the project's existing style, isolating staged changes via stash lifecycle management.
 
 **User-invocable:** yes
-**Model:** haiku
+**Model:** haiku (pinned on orchestrator agent, not skill frontmatter — see issue #202)
 **Prepare script:** `skill/commit.js`
 
 ## Arguments

--- a/docs/specs/error-report-sdlc.md
+++ b/docs/specs/error-report-sdlc.md
@@ -3,7 +3,7 @@
 > Internal procedure invoked by other SDLC skills to create a GitHub issue tracking an actionable error, with full context capture and two-gate user consent.
 
 **User-invocable:** no
-**Model:** haiku
+**Model:** haiku (pinned on orchestrator agent, not skill frontmatter — see issue #202)
 
 ## Core Requirements
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.17.41",
+  "version": "0.17.42",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/commit-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/commit-orchestrator.md
@@ -1,0 +1,97 @@
+---
+name: commit-orchestrator
+description: Drafts a commit message from a prepared payload (no conversation context inherited). Reads the manifest written by commit-prepare.js, generates a single commit message that satisfies the project's commitConfig and recent-commit style, and returns ONLY the message string. Does not call git, does not write files, does not invoke gh.
+tools: Read
+model: haiku
+---
+
+# Commit Message Orchestrator
+
+You are the commit message orchestrator. You receive a manifest file path and project root.
+Your only job: read the prepared commit context and return a single commit message string.
+You inherit no conversation context — everything you need is in the manifest.
+
+## Inputs (provided in your prompt)
+
+- **MANIFEST_FILE**: Absolute path to the JSON manifest written by `commit.js --output-file`
+- **PROJECT_ROOT**: The project's working directory
+
+## Step 0 — Load Manifest
+
+Read the manifest JSON from `MANIFEST_FILE`. The manifest contains:
+
+| Field | Description |
+| --- | --- |
+| `currentBranch` | Active git branch |
+| `flags` | `{ noStash, scope, type, amend, auto }` — parsed CLI flags |
+| `staged.files` | List of staged file paths |
+| `staged.fileCount` | Number of staged files |
+| `staged.diff` | Full unified diff of staged changes |
+| `staged.diffStat` | Diff stat summary line |
+| `staged.diffTruncated` | Boolean: true when diff exceeded context budget and was truncated |
+| `staged.truncatedFiles` | File paths whose full diffs were omitted (diffstat still available) |
+| `recentCommits` | Last 15 commits (oneline format) for style detection |
+| `lastCommitMessage` | Previous commit message (only when `flags.amend` is true) |
+| `commitConfig` | Commit message validation config from `.claude/sdlc.json` (null when absent) |
+
+If the manifest's `errors` array is non-empty, return an empty string and stop. The skill body will surface the errors itself.
+
+## Step 1 — Detect Style
+
+Analyze `recentCommits` to detect the project's commit style:
+
+- Conventional commits: `type(scope): description`?
+- Plain imperative English?
+- Ticket prefix pattern (e.g., `PROJ-123: ...`)?
+- Capitalization conventions?
+
+If `recentCommits` is empty (new repo), default to conventional commits.
+
+## Step 2 — Apply Config Constraints
+
+If `commitConfig` is non-null, every constraint below is **mandatory**:
+
+- **`commitConfig.allowedTypes`** + `flags.type` not set → choose the type exclusively from `allowedTypes`. Do not infer outside the list. If `recentCommits` suggests an absent type, pick the closest allowed type.
+- **`commitConfig.allowedScopes`** + `flags.scope` not set → choose the scope exclusively from `allowedScopes` (or omit if none fits).
+- **`commitConfig.subjectPattern`** → the subject line you produce MUST match this regex.
+- **`commitConfig.requireBodyFor`** → if the selected type appears in this list, a body is mandatory.
+- **`commitConfig.requiredTrailers`** → include all listed trailer keys in the commit body, after a blank line, in `Key: Value` format. Use an empty string as the value placeholder when no value is known; do not invent values.
+
+Config constraints take precedence over `recentCommits` inference.
+
+## Step 3 — Generate Subject and Body
+
+1. Read `staged.diff` to understand what changed. When `staged.diffTruncated` is true, supplement with `staged.diffStat` and `staged.truncatedFiles`.
+2. If `flags.type` is set, use it. Else infer from the change (constrained by `allowedTypes`).
+3. If `flags.scope` is set, use it. Else infer from changed files or omit (constrained by `allowedScopes`).
+4. If `flags.amend` and `lastCommitMessage` is non-null, start from it and revise based on the staged diff.
+5. Subject ≤ 72 characters, imperative mood, no trailing period.
+6. Body only when the change is non-trivial and benefits from "why" context. Blank line between subject and body. Required trailers go after a blank line at the end.
+
+## Step 4 — Self-Critique
+
+Before returning, verify:
+
+- Subject ≤ 72 characters
+- Subject matches `commitConfig.subjectPattern` (when set)
+- Selected type is in `commitConfig.allowedTypes` (when set)
+- Selected scope is in `commitConfig.allowedScopes` (when set)
+- Required trailers all present (when `requiredTrailers` is set)
+- Body present when type is in `requireBodyFor` (when set)
+- Every claim in the message is traceable to `staged.diff` or `staged.diffStat`
+- Imperative mood ("add" not "adds" / "added")
+
+Fix any failure and re-check. Maximum 2 iterations per gate.
+
+## Step 5 — Return the Message
+
+Output the commit message string and nothing else. No preamble, no explanation, no markdown fence, no chain-of-thought. The skill's main context will display the message to the user, validate it against the link checker, run the stash/commit sequence, and clean up.
+
+## Hard Constraints
+
+- **Do not call git.** No `git log`, no `git commit`, no `git stash`, no `git diff` — every input you need is in the manifest.
+- **Do not write any file.** You have no write tools; do not attempt workarounds via Bash.
+- **Do not invoke `gh`.**
+- **Do not delete the manifest.** The skill body owns cleanup.
+- **Do not return JSON, YAML, or any wrapper.** Return the raw commit message string.
+- **Do not return chain-of-thought, alternatives, or commentary.** One message string only.

--- a/plugins/sdlc-utilities/agents/error-report-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/error-report-orchestrator.md
@@ -1,0 +1,111 @@
+---
+name: error-report-orchestrator
+description: Drafts a tooling-error GitHub issue body from a prepared payload (no conversation context inherited). Reads the manifest written by error-report-prepare.js plus the ToolingError.md template, fills every placeholder strictly from manifest fields, and returns ONLY the JSON object {title, body}. Does not call gh, does not call git, does not write any file.
+tools: Read
+model: haiku
+---
+
+# Error Report Orchestrator
+
+You are the error-report orchestrator. You receive a manifest file path and project root.
+Your only job: read the prepared error context and the ToolingError.md template, fill the
+template strictly from manifest fields, and return a single JSON object containing the issue
+title and body. You inherit no conversation context — everything you need is in the manifest
+and the template.
+
+## Inputs (provided in your prompt)
+
+- **MANIFEST_FILE**: Absolute path to the JSON manifest written by `error-report-prepare.js`
+- **PROJECT_ROOT**: The project's working directory
+
+## Step 0 — Load Manifest
+
+Read the manifest JSON from `MANIFEST_FILE`. The manifest contains:
+
+| Field | Description |
+| --- | --- |
+| `skill` | Calling skill name (e.g., `commit-sdlc`, `pr-sdlc`) |
+| `step` | Step number and name where the error occurred |
+| `operation` | What the skill was attempting |
+| `errorText` | Full error message or output |
+| `exitOrHttpCode` | Exit code or HTTP status (may be empty) |
+| `errorType` | `script crash` / `CLI failure` / `API error` / `build failure` / `escalation` (may be empty) |
+| `userIntent` | What the user was doing (may be empty) |
+| `argsString` | Arguments the skill was invoked with (may be empty) |
+| `suggestedInvestigation` | Skill-specific diagnostic hints (may be empty) |
+| `repository` | `git remote get-url origin` output |
+| `currentBranch` | Active git branch at the time of failure |
+| `timestamp` | ISO 8601 timestamp captured by the prepare script |
+| `targetRepo` | `rnagrodzki/sdlc-marketplace` (fixed) |
+| `labels` | `["tooling-error", "<skill-name>"]` |
+
+## Step 1 — Load Template
+
+Read `plugins/sdlc-utilities/skills/error-report-sdlc/templates/ToolingError.md` from `PROJECT_ROOT`. The template uses `{placeholder}` markers — see REFERENCE.md section 4 for the full placeholder-to-source mapping.
+
+## Step 2 — Fill the Template
+
+Replace every `{placeholder}` strictly with the matching manifest field:
+
+| Placeholder | Manifest field |
+| --- | --- |
+| `{what failed — one line}` | One-sentence summary of `errorText` |
+| `{skill name, e.g., pr-sdlc}` | `skill` |
+| `{step number and name where the error occurred}` | `step` |
+| `{what the skill was trying to do, e.g., "Create PR via gh CLI"}` | `operation` |
+| `{ISO timestamp}` | `timestamp` |
+| `{script crash \| CLI failure \| API error \| build failure \| escalation}` | `errorType` (omit the line if empty) |
+| `{code}` | `exitOrHttpCode` |
+| `{full error text}` | `errorText` (preserve formatting inside the code fence) |
+| `{repository name from git remote}` | `repository` |
+| `{current branch}` | `currentBranch` |
+| `{what the user was doing}` | `userIntent` |
+| `{with arguments if any}` | `argsString` (omit the parenthetical if empty) |
+| `{step that failed and why}` | `step` + brief reason from `errorText` |
+| `{what was blocked — e.g., "PR creation blocked", "Release tag not pushed"}` | One-line impact summary inferred from `operation` |
+| `{skill-specific hints about what might be wrong, provided by the calling skill}` | `suggestedInvestigation` |
+
+Rules:
+
+- If a manifest field is empty, **remove the entire section** that depends on it. Do **not** leave raw `{placeholder}` text in the output. Do **not** invent content for empty fields.
+- Preserve the surrounding markdown structure (headings, lists) intact.
+- Keep `errorText` inside the existing fenced code block.
+
+## Step 3 — Build the Title
+
+Title format: `[{skill}] {one-line error summary}` — max 72 characters total. Truncate the summary if needed.
+
+## Step 4 — Self-Critique
+
+Before returning, verify:
+
+- No raw `{placeholder}` text remains
+- Title is ≤ 72 characters and starts with `[<skill>] `
+- Body has no empty sections from omitted fields (sections were removed, not blanked)
+- `errorText` is preserved verbatim inside its code fence
+- No invented content beyond manifest fields
+
+Fix any failure and re-check.
+
+## Step 5 — Return the JSON Object
+
+Output a single JSON object and nothing else:
+
+```json
+{
+  "title": "<assembled title>",
+  "body": "<filled markdown body>"
+}
+```
+
+No preamble, no explanation, no surrounding markdown fences around the JSON, no chain-of-thought. The skill's main context will present this to the user for the second consent gate, then post via `gh issue create` itself.
+
+## Hard Constraints
+
+- **Do not call `gh`.** No `gh issue create`, no `gh api`, no `gh label`. The skill body owns posting.
+- **Do not call `git`.** Every git-derived field is already in the manifest.
+- **Do not invoke Bash.** You have no Bash tool; do not attempt workarounds.
+- **Do not write any file.** You have no write tools.
+- **Do not delete the manifest.** The skill body owns cleanup.
+- **Do not return prose around the JSON.** One JSON object only.
+- **Do not invent placeholder values.** If a manifest field is empty, remove the dependent section.

--- a/plugins/sdlc-utilities/scripts/skill/error-report-prepare.js
+++ b/plugins/sdlc-utilities/scripts/skill/error-report-prepare.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * error-report-prepare.js
+ * Pre-computes the manifest needed by the error-report-orchestrator agent.
+ * Collects all calling-skill-supplied error context plus environment fields
+ * (repository, current branch) and writes a JSON payload that the orchestrator
+ * uses to draft a tooling-error GitHub issue.
+ *
+ * Usage:
+ *   node error-report-prepare.js --skill <name> --step <step> --operation <op> \
+ *     --error-text <text> [--exit-or-http-code <code>] [--error-type <type>] \
+ *     [--user-intent <text>] [--args-string <args>] \
+ *     [--suggested-investigation <hints>] [--output-file]
+ *
+ *   Long string fields may also be supplied via stdin as JSON:
+ *     echo '{"errorText":"..."}' | node error-report-prepare.js --skill foo --step bar ...
+ *   CLI flags take precedence over stdin fields when both are present.
+ *
+ * Required fields: skill, step, operation, errorText
+ *
+ * Exit codes:
+ *   0 = success, manifest path printed to stdout (with --output-file)
+ *       or manifest JSON printed to stdout (without --output-file)
+ *   1 = fatal error (missing required fields), JSON with errors[] on stdout
+ *   2 = unexpected script crash, message on stderr
+ *
+ * Uses only Node.js built-in modules. No npm install required.
+ */
+
+'use strict';
+
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const LIB = path.join(__dirname, '..', 'lib');
+const { writeOutput } = require(path.join(LIB, 'output'));
+
+const TARGET_REPO = 'rnagrodzki/sdlc-marketplace';
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `--key value` and `--key=value` style flags. Unknown flags are kept.
+ * The `--output-file` flag is consumed downstream by lib/output.js.
+ */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    if (a === '--output-file') continue; // handled by writeOutput
+    const eq = a.indexOf('=');
+    let key;
+    let val;
+    if (eq !== -1) {
+      key = a.slice(2, eq);
+      val = a.slice(eq + 1);
+    } else {
+      key = a.slice(2);
+      val = argv[i + 1];
+      if (val !== undefined && !val.startsWith('--')) {
+        i++;
+      } else {
+        val = '';
+      }
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function camelKey(k) {
+  return k.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Read stdin synchronously when present; parse as JSON. Returns {} on absence
+ * or parse failure (silent — CLI flags remain authoritative).
+ */
+function readStdinJson() {
+  try {
+    if (process.stdin.isTTY) return {};
+    const fs = require('node:fs');
+    const buf = fs.readFileSync(0, 'utf8');
+    if (!buf.trim()) return {};
+    return JSON.parse(buf);
+  } catch (_) {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment probes
+// ---------------------------------------------------------------------------
+
+function safeExec(cmd) {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+function detectRepository() {
+  return safeExec('git remote get-url origin');
+}
+
+function detectCurrentBranch() {
+  return safeExec('git rev-parse --abbrev-ref HEAD');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const stdin = readStdinJson();
+
+  // Build input map: stdin first, CLI overrides.
+  const input = {};
+  for (const [k, v] of Object.entries(stdin)) input[k] = v;
+  for (const [k, v] of Object.entries(cli)) input[camelKey(k)] = v;
+
+  const errors = [];
+  const required = ['skill', 'step', 'operation', 'errorText'];
+  for (const key of required) {
+    if (!input[key] || String(input[key]).trim() === '') {
+      errors.push(`Missing required field: ${key}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    process.stderr.write(`error-report-prepare: ${errors.join('; ')}\n`);
+    writeOutput({ errors, warnings: [] }, 'sdlc-error-report', 1);
+    return;
+  }
+
+  const skill = String(input.skill).trim();
+  const manifest = {
+    skill,
+    step: String(input.step).trim(),
+    operation: String(input.operation).trim(),
+    errorText: String(input.errorText),
+    exitOrHttpCode: input.exitOrHttpCode != null ? String(input.exitOrHttpCode) : '',
+    errorType: input.errorType != null ? String(input.errorType).trim() : '',
+    userIntent: input.userIntent != null ? String(input.userIntent) : '',
+    argsString: input.argsString != null ? String(input.argsString) : '',
+    suggestedInvestigation: input.suggestedInvestigation != null
+      ? String(input.suggestedInvestigation)
+      : '',
+    repository: detectRepository(),
+    currentBranch: detectCurrentBranch(),
+    timestamp: new Date().toISOString(),
+    targetRepo: TARGET_REPO,
+    labels: ['tooling-error', skill],
+  };
+
+  writeOutput(manifest, 'sdlc-error-report', 0);
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`error-report-prepare.js crashed: ${err.stack || err.message}\n`);
+  process.exit(2);
+}

--- a/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
@@ -3,7 +3,6 @@ name: commit-sdlc
 description: "Use this skill when committing staged changes, creating a git commit, or generating a commit message. Analyzes staged diff and recent commit history to generate a message matching the project's style. Stashes unstaged changes to isolate the commit, commits after user confirmation, and auto-restores the stash. Arguments: [--no-stash] [--scope <scope>] [--type <type>] [--amend] [--auto]. Use --auto to skip interactive approval. Triggers on: commit changes, create commit, write commit message, git commit, smart commit, commit staged, stage and commit."
 user-invocable: true
 argument-hint: "[--no-stash] [--scope <scope>] [--type <type>] [--amend] [--auto]"
-model: haiku
 ---
 
 
@@ -65,74 +64,42 @@ rm -f "$COMMIT_CONTEXT_FILE"
 
 ---
 
-### Step 1 (CONSUME): Read the Context
+### Step 1 (CONSUME): Quick Context Read
 
-Extract these fields from `COMMIT_CONTEXT_JSON`:
+Read just enough from `COMMIT_CONTEXT_JSON` for the main-context flow (Step 5 onwards): `currentBranch`, `flags`, `staged.files`, `staged.fileCount`, `staged.diffStat`, `unstaged.hasChanges`, `commitConfig.subjectPattern`, `commitConfig.subjectPatternError`. Heavy fields — `staged.diff`, `recentCommits`, `lastCommitMessage`, full `commitConfig` — are consumed by the orchestrator agent below; do **not** read or quote them in main context.
 
-| Field | Description |
-| ----- | ----------- |
-| `currentBranch` | Active git branch |
-| `flags` | `{ noStash, scope, type, amend, auto }` — parsed CLI flags |
-| `staged.files` | List of staged file paths |
-| `staged.fileCount` | Number of staged files |
-| `staged.diff` | Full unified diff of staged changes |
-| `staged.diffStat` | Diff stat summary line |
-| `staged.diffTruncated` | Boolean: true when diff exceeded context budget and was truncated |
-| `staged.truncatedFiles` | File paths whose full diffs were omitted (diffstat still available) |
-| `unstaged.files` | Modified tracked files not staged |
-| `unstaged.hasChanges` | Whether unstaged changes exist |
-| `recentCommits` | Last 15 commits (oneline format) for style detection |
-| `lastCommitMessage` | Previous commit message (only when `flags.amend` is true) |
-| `commitConfig` | Commit message validation config from .claude/sdlc.json (null when absent) |
+### Step 2 (PLAN): Dispatch the commit-orchestrator Agent
 
-### Step 2 (PLAN): Generate Commit Message
+Issue #202: pinning `model:` in skill frontmatter routes the skill into a subagent that inherits the entire conversation transcript and overflows the smaller-window models on long sessions. To keep the main context clean and bound the orchestrator's input to the prepared payload only, dispatch the dedicated `commit-orchestrator` agent. See `docs/skill-best-practices.md` → "Why frontmatter `model:` is the wrong context-isolation knob" for the rationale.
 
-1. Analyze `staged.diff` to understand what changed. Read the full diff — do not rely on file names alone. When `staged.diffTruncated` is true, the diff includes only the largest file changes within the context budget. For files in `staged.truncatedFiles`, use `staged.diffStat` and file names to infer the nature of changes.
-2. Analyze `recentCommits` to detect project commit style:
-   - Conventional commits: `type(scope): description`?
-   - Plain imperative English?
-   - Ticket prefix pattern (e.g. `PROJ-123: ...`)?
-   - Capitalization conventions?
-**2a. Config override (run before steps 3–6 below):** If `commitConfig` is non-null:
-- If `commitConfig.allowedTypes` is set AND `flags.type` is NOT set → choose the type exclusively from `allowedTypes`. Do not infer a type outside this list.
-- If `commitConfig.allowedScopes` is set AND `flags.scope` is NOT set → choose the scope exclusively from `allowedScopes` (or omit if none fits). Do not infer a scope outside this list.
-- Config constraints take precedence over `recentCommits` inference. If `recentCommits` suggests a type not in `allowedTypes`, use the closest allowed type.
-- If `commitConfig.requireBodyFor` is set and the selected type appears in that list → a body is mandatory. Do not omit the body for these commit types.
-- If `commitConfig.requiredTrailers` is set → include all listed trailer keys in the commit body, after a blank line, in `Key: Value` format. Use an empty string as the value placeholder if no value is known; do not invent values.
+Use the `Agent` tool with:
 
-**Common `subjectPattern` examples (for reference when `commitConfig.subjectPattern` is set):**
+- `subagent_type`: `sdlc:commit-orchestrator`
+- `model`: `haiku` (the orchestrator pins `haiku` itself; pass it explicitly so the harness honours it)
+- `prompt` (exactly two lines, no other content):
 
-| Style | Pattern | Example |
-| ----- | ------- | ------- |
-| Conventional commits | `^(feat\|fix\|refactor\|chore\|docs\|test\|ci)(\([a-z-]+\))?: .+$` | `feat(auth): add OAuth2 PKCE flow` |
-| Ticket prefix | `^[A-Z]{2,10}-\d+: .+$` | `PROJ-123: fix login timeout` |
-| Ticket + conventional | `^[A-Z]{2,10}-\d+ (feat\|fix\|chore): .+$` | `PROJ-123 feat: add dark mode` |
-| Plain imperative | `^[A-Z].{10,70}$` | `Add rate limiting to API endpoints` |
+  ```text
+  MANIFEST_FILE: <COMMIT_CONTEXT_FILE>
+  PROJECT_ROOT: <cwd>
+  ```
 
-3. If `flags.type` is set, use it as the commit type. If not, infer from the nature of the change (constrained by `commitConfig.allowedTypes` per step 2a above).
-4. If `flags.scope` is set, use it as the scope. If not, infer from the changed files or omit (constrained by `commitConfig.allowedScopes` per step 2a above).
-4a. **OpenSpec scope hint (optional):** If `flags.scope` is not set, Glob for `openspec/config.yaml`. If found, Glob `openspec/changes/*/proposal.md` (exclude `archive/`). If exactly one active change exists, or one matches the current branch name, use the change directory name as a candidate scope (e.g., change `add-dark-mode` → scope `add-dark-mode`). This is a hint only — the style detected from `recentCommits` in step 2 takes precedence. If recent commits don't use scopes, do not force one.
+  Substitute `<COMMIT_CONTEXT_FILE>` with the absolute temp-file path captured in Step 0. Substitute `<cwd>` with the current working directory.
 
-    **Hook context fast-path:** If the session-start system-reminder contains an `OpenSpec active:` line, use its data (change name, branch match status) to skip the `Glob for openspec/config.yaml` and change directory scanning. If the line is absent or the user switched branches since session start, fall back to the existing Glob-based detection. The hook context is a session-start snapshot — treat it as a hint, not as authoritative.
-4b. **OpenSpec change trailer (optional):** If step 4a identified an active OpenSpec change, add an `OpenSpec-Change: <change-directory-name>` trailer to the commit message body. Trailers go after a blank line at the end of the body, in git standard `Key: Value` format. If the commit has no body (trivial change where the subject line is sufficient), skip the trailer — do not add a body solely for the trailer.
-5. If `flags.amend` and `lastCommitMessage` is non-null, use it as the starting point — revise based on staged diff.
-6. Draft subject line (max 72 chars) and optional body:
-   - Subject: imperative mood, concise, no trailing period
-   - Body: only when the change is non-trivial and benefits from "why" context; blank line between subject and body
+The orchestrator reads the manifest, applies every `commitConfig` constraint (`subjectPattern`, `allowedTypes`, `allowedScopes`, `requireBodyFor`, `requiredTrailers`), detects style from `recentCommits`, runs its own self-critique loop, and returns ONLY the final commit message string. It does not call `git`, does not write files, does not invoke `gh`.
 
-### Step 3 (CRITIQUE): Self-review the Message
+Capture the orchestrator's return value as `MESSAGE`. If `MESSAGE` is empty, the orchestrator detected an `errors[]` array in the manifest — surface those errors and stop.
 
-Review against every quality gate in the table below. Note every failing gate.
+**OpenSpec scope hint (main context, optional):** If `flags.scope` is NOT set, Glob for `openspec/config.yaml`. If found, Glob `openspec/changes/*/proposal.md` (exclude `archive/`). If exactly one active change exists, or one matches the current branch name, append an `OpenSpec-Change: <change-directory-name>` trailer to `MESSAGE` (after a blank line; only if `MESSAGE` already has a body — do not add a body solely for the trailer). If recent commits don't use scopes, the trailer is still optional. The hook context fast-path applies: if the session-start system-reminder has an `OpenSpec active:` line, use it instead of Glob.
 
-### Step 4 (IMPROVE): Revise Based on Critique
+### Step 3 (CRITIQUE) and Step 4 (IMPROVE)
 
-Fix each issue found in Step 3. Max 2 iterations per gate.
+The orchestrator agent owns Steps 3 (CRITIQUE) and 4 (IMPROVE) internally. The main context does not re-run them; the orchestrator's returned `MESSAGE` is already self-critiqued against the gate table below.
 
 ### Step 5 (DO): Present and Execute
 
-Show the full commit plan to the user. **Do not execute any git commands before receiving explicit user approval via AskUserQuestion.**
+Show the full commit plan to the user with the `MESSAGE` returned by the orchestrator and the staged-file summary read in Step 1. **Do not execute any git commands before receiving explicit user approval via AskUserQuestion.**
 
-**Auto mode:** When `flags.auto` is true, skip the AskUserQuestion prompt entirely. Still display the full commit plan for visibility, then proceed directly to execution. Treat the response as an implicit `yes`. All critique gates (Steps 3–4) still run — only the interactive approval prompt is skipped.
+**Auto mode:** When `flags.auto` is true, skip the AskUserQuestion prompt entirely. Still display the full commit plan for visibility, then proceed directly to execution. Treat the response as an implicit `yes`. The orchestrator's internal critique already ran in Step 2 — only the interactive approval prompt is skipped.
 
 ```
 Commit
@@ -209,9 +176,9 @@ Show `Amend:` instead of `Commit:` heading when `flags.amend` is true.
    git stash pop
    ```
 
-**On `edit`:** Ask what to change, revise the message, and present again. Loop until explicit `yes` or `cancel`.
+**On `edit`:** Ask what to change, revise the message, and present again. Loop until explicit `yes` or `cancel`. Re-dispatching the orchestrator is not required for small wording tweaks — apply user-supplied edits to `MESSAGE` directly and re-validate against the subject-pattern gate before re-presenting.
 
-**On `cancel`:** Abort without changes.
+**On `cancel`:** Abort without changes. Run `rm -f "$COMMIT_CONTEXT_FILE"` to remove the manifest.
 
 **Hook failure handling**: If `git commit` fails due to a pre-commit hook, the stash is still in place. Inform the user: "Pre-commit hook failed. Your unstaged changes are stashed (`git stash list` to see). Fix the hook issue, re-stage your changes, and re-run `/commit-sdlc`."
 
@@ -228,6 +195,12 @@ Show the result:
 ```
 
 Omit the `Stash:` line if no stash was used.
+
+After verification, remove the manifest temp file:
+
+```bash
+rm -f "$COMMIT_CONTEXT_FILE"
+```
 
 ---
 

--- a/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
@@ -64,18 +64,18 @@ rm -f "$COMMIT_CONTEXT_FILE"
 
 ---
 
-### Step 1 (CONSUME): Quick Context Read
+### Step 1 (CONSUME): Quick Context Read <!-- implements R1, R2 -->
 
 Read just enough from `COMMIT_CONTEXT_JSON` for the main-context flow (Step 5 onwards): `currentBranch`, `flags`, `staged.files`, `staged.fileCount`, `staged.diffStat`, `unstaged.hasChanges`, `commitConfig.subjectPattern`, `commitConfig.subjectPatternError`. Heavy fields — `staged.diff`, `recentCommits`, `lastCommitMessage`, full `commitConfig` — are consumed by the orchestrator agent below; do **not** read or quote them in main context.
 
-### Step 2 (PLAN): Dispatch the commit-orchestrator Agent
+### Step 2 (PLAN): Dispatch the commit-orchestrator Agent <!-- implements R3, R4, R5, R6 -->
 
 Issue #202: pinning `model:` in skill frontmatter routes the skill into a subagent that inherits the entire conversation transcript and overflows the smaller-window models on long sessions. To keep the main context clean and bound the orchestrator's input to the prepared payload only, dispatch the dedicated `commit-orchestrator` agent. See `docs/skill-best-practices.md` → "Why frontmatter `model:` is the wrong context-isolation knob" for the rationale.
 
 Use the `Agent` tool with:
 
 - `subagent_type`: `sdlc:commit-orchestrator`
-- `model`: `haiku` (the orchestrator pins `haiku` itself; pass it explicitly so the harness honours it)
+- `model`: `haiku` (the Agent tool `model:` parameter takes precedence over agent frontmatter; passing `haiku` here keeps this bounded task on a lightweight model regardless of the parent context's model)
 - `prompt` (exactly two lines, no other content):
 
   ```text

--- a/plugins/sdlc-utilities/skills/error-report-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/error-report-sdlc/REFERENCE.md
@@ -76,6 +76,12 @@ This error may be worth tracking as a GitHub issue. Create one? (yes / no)
 
 ## Section 4: Assemble Issue Content
 
+> **As of issue #202:** Template assembly (reading this template, filling placeholders,
+> building the title) is delegated to the `error-report-orchestrator` agent (SKILL.md
+> Step 4). This section documents the template structure and placeholder sources for
+> reference. The orchestrator receives the manifest from `error-report-prepare.js` and
+> applies the rules below internally.
+
 Read `./templates/ToolingError.md` (locate via Glob: `**/error-report-sdlc/templates/ToolingError.md` under `~/.claude/plugins`, then cwd fallback).
 
 Fill all `{placeholder}` markers using the context provided by the calling skill:

--- a/plugins/sdlc-utilities/skills/error-report-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/error-report-sdlc/SKILL.md
@@ -3,14 +3,19 @@ name: error-report-sdlc
 description: "Internal skill invoked by other SDLC skills when they encounter an actionable error (script crash, CLI failure, persistent API error, build failure after retries). Proposes creating a GitHub issue in rnagrodzki/sdlc-marketplace to track the error with full context capture, two-gate user consent, and pre-flight verification. NOT user-invocable — only dispatched from within another skill's error handling path. When dispatched, follow ./REFERENCE.md for the full procedure."
 user-invocable: false
 disable-model-invocation: true
-model: haiku
 ---
 
 # Error-to-GitHub Issue Proposal
 
 Internal procedure invoked by SDLC skills when an actionable error occurs.
 Captures error context, verifies gh CLI availability, gets user consent, and
-creates a tracking issue in rnagrodzki/sdlc-marketplace using the gh CLI.
+creates a tracking issue in `rnagrodzki/sdlc-marketplace` using the gh CLI.
+
+The skill body runs in the main parent-model context. The heavy work — assembling
+the issue title and body from the error context and the `templates/ToolingError.md`
+template — is dispatched to the dedicated `error-report-orchestrator` agent so the
+main conversation transcript is never inherited (issue #202). Both consent gates
+and the `gh issue create` call stay in the main context.
 
 ## When This Skill Is Invoked
 
@@ -25,17 +30,159 @@ error. The calling skill provides:
 
 ## Procedure
 
-Follow `./REFERENCE.md` for the complete step-by-step procedure, including:
+The full procedural narrative — error classification (issue-worthy vs not),
+pre-flight verification, two-gate consent flow, template, and the `gh issue create`
+sequence — lives in `./REFERENCE.md`. The implementation flow below resolves
+sections from REFERENCE.md and dispatches the orchestrator.
 
-- Error classification (issue-worthy vs. not)
-- Pre-flight verification (gh CLI availability, GitHub remote)
-- Two-gate consent flow
-- Issue assembly from the `./templates/ToolingError.md` template
-- GitHub issue creation using `gh issue create`
+### Step 1 — Classify and Pre-flight (main context)
+
+Follow REFERENCE.md sections 1 (Error Classification) and 2 (Pre-flight Verification)
+in the main context. If the error is NOT issue-worthy, or any required pre-flight
+check fails, return to the calling skill's normal error handling immediately. Do
+not run the prepare script, do not dispatch the orchestrator.
+
+### Step 2 — Consent Gate 1: Offer (main context)
+
+Follow REFERENCE.md section 3 verbatim. Use `AskUserQuestion`. The prompt MUST run
+in the main context (not inside the orchestrator agent) — the user's consent is
+required before any further work, including running the prepare script.
+
+**On `no`:** Return to the calling skill's normal error handling. Do not proceed.
+
+**On `yes`:** Continue to Step 3.
+
+### Step 3 — Run the Prepare Script (main context)
+
+> **VERBATIM** — Run this bash block exactly as written. Do not modify, rephrase, or simplify the commands.
+
+```bash
+SCRIPT=$(find ~/.claude/plugins -name "error-report-prepare.js" -path "*/sdlc*/scripts/skill/error-report-prepare.js" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && [ -f "plugins/sdlc-utilities/scripts/skill/error-report-prepare.js" ] && SCRIPT="plugins/sdlc-utilities/scripts/skill/error-report-prepare.js"
+[ -z "$SCRIPT" ] && { echo "ERROR: Could not locate skill/error-report-prepare.js. Is the sdlc plugin installed?" >&2; exit 2; }
+
+ERROR_CONTEXT_FILE=$(node "$SCRIPT" \
+  --skill "$SKILL_NAME" \
+  --step "$STEP_NAME" \
+  --operation "$OPERATION" \
+  --error-text "$ERROR_TEXT" \
+  --exit-or-http-code "$EXIT_OR_HTTP_CODE" \
+  --error-type "$ERROR_TYPE" \
+  --user-intent "$USER_INTENT" \
+  --args-string "$ARGS_STRING" \
+  --suggested-investigation "$SUGGESTED_INVESTIGATION" \
+  --output-file)
+EXIT_CODE=$?
+```
+
+Substitute the shell variables with the values supplied by the calling skill. Optional
+fields (`exitOrHttpCode`, `errorType`, `userIntent`, `argsString`,
+`suggestedInvestigation`) may be empty; the script tolerates empty values and the
+orchestrator will omit dependent template sections.
+
+**On `EXIT_CODE != 0`:**
+
+- Exit code 1: required field missing — show the script's stderr message and stop.
+- Exit code 2: prepare script crashed — show the stderr and stop. Do **not** recursively dispatch this skill on its own crash.
+
+### Step 4 — Dispatch the error-report-orchestrator Agent
+
+Issue #202: pinning `model:` in skill frontmatter routes the skill into a subagent
+that inherits the entire conversation transcript and overflows smaller-window
+models on long sessions. To keep the main context clean and bound the
+orchestrator's input to the prepared payload only, dispatch the dedicated
+`error-report-orchestrator` agent. See
+`docs/skill-best-practices.md` → "Why frontmatter `model:` is the wrong
+context-isolation knob" for the rationale.
+
+Use the `Agent` tool with:
+
+- `subagent_type`: `sdlc:error-report-orchestrator`
+- `model`: `haiku` (the orchestrator pins `haiku` itself; pass it explicitly so the harness honours it)
+- `prompt` (exactly two lines, no other content):
+
+  ```text
+  MANIFEST_FILE: <ERROR_CONTEXT_FILE>
+  PROJECT_ROOT: <cwd>
+  ```
+
+  Substitute `<ERROR_CONTEXT_FILE>` with the absolute temp-file path captured in
+  Step 3. Substitute `<cwd>` with the current working directory.
+
+The orchestrator reads the manifest, reads
+`plugins/sdlc-utilities/skills/error-report-sdlc/templates/ToolingError.md`, fills
+every `{placeholder}` strictly from manifest fields, removes sections whose
+manifest fields are empty, and returns ONLY a JSON object:
+
+```json
+{
+  "title": "<assembled title>",
+  "body": "<filled markdown body>"
+}
+```
+
+The orchestrator does not call `gh`, does not call `git`, does not write any file.
+
+Capture the returned object as `PROPOSAL = { title, body }`. If the parse fails,
+clean up the manifest (`rm -f "$ERROR_CONTEXT_FILE"`) and stop.
+
+### Step 5 — Consent Gate 2: Review (main context)
+
+Follow REFERENCE.md section 5 verbatim. Display `PROPOSAL.title` and
+`PROPOSAL.body` to the user along with the labels (`tooling-error` plus the
+calling skill's name) and the priority. Use `AskUserQuestion` for the
+`yes / edit / cancel` choice.
+
+**On `edit`:** Apply the requested changes to `PROPOSAL.title` and / or
+`PROPOSAL.body` in the main context (do not re-dispatch the orchestrator for
+small edits) and re-present.
+
+**On `cancel`:** Run `rm -f "$ERROR_CONTEXT_FILE"` and return to the calling
+skill's normal error handling. Do not create anything.
+
+**On `yes`:** Continue to Step 6.
+
+### Step 6 — Create the GitHub Issue (main context)
+
+Follow REFERENCE.md section 6 verbatim. The `gh issue create` call MUST run in the
+main context — the orchestrator agent has no `Bash` tool and is forbidden from
+invoking `gh`.
+
+```bash
+gh issue create \
+  --repo "rnagrodzki/sdlc-marketplace" \
+  --title "$PROPOSAL_TITLE" \
+  --body "$PROPOSAL_BODY" \
+  --label "tooling-error" \
+  --label "$SKILL_NAME"
+```
+
+Apply the missing-label fallback (`gh label create … || true`) and retry per
+REFERENCE.md section 6a. On success, report the issue number and URL per 6b. On
+failure after the retry, report the error per 6c.
+
+### Step 7 — Cleanup and Return (main context)
+
+```bash
+rm -f "$ERROR_CONTEXT_FILE"
+```
+
+Then return to the calling skill's normal error handling per REFERENCE.md
+section 7. The cleanup runs on every exit path (success, failure, cancel, edit
+loop exit).
 
 ## DO NOT
 
-- Invoke this skill directly in response to user requests — it is internal only
-- Create a GitHub issue without both consent gates passing
-- Block or replace the calling skill's normal error handling
-- Create issues in a repository other than rnagrodzki/sdlc-marketplace
+- Invoke this skill directly in response to user requests — it is internal only.
+- Pin `model:` in this skill's frontmatter — the harness will route the skill into a
+  subagent that inherits the full conversation transcript (issue #202). The
+  orchestrator agent (Step 4) is the correct place to pin `model: haiku`.
+- Run consent gates inside the orchestrator agent. Both gates (Section 3 and
+  Section 5) MUST execute in the main context.
+- Run `gh issue create` inside the orchestrator agent. The agent has no `Bash`
+  tool. Posting MUST run in the main context.
+- Create a GitHub issue without both consent gates passing.
+- Block or replace the calling skill's normal error handling.
+- Create issues in a repository other than `rnagrodzki/sdlc-marketplace`.
+- Recursively dispatch this skill on its own prepare-script or orchestrator
+  crash — log the failure to stderr and stop.

--- a/plugins/sdlc-utilities/skills/error-report-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/error-report-sdlc/SKILL.md
@@ -7,6 +7,11 @@ disable-model-invocation: true
 
 # Error-to-GitHub Issue Proposal
 
+<!-- disable-model-invocation: true prevents the harness from auto-triggering this skill
+     when conversation content matches the description. It does NOT prevent explicit
+     dispatch from another skill's error-handling path — that is the only intended
+     activation route. user-invocable: false hides the skill from the / menu. -->
+
 Internal procedure invoked by SDLC skills when an actionable error occurs.
 Captures error context, verifies gh CLI availability, gets user consent, and
 creates a tracking issue in `rnagrodzki/sdlc-marketplace` using the gh CLI.
@@ -98,7 +103,7 @@ context-isolation knob" for the rationale.
 Use the `Agent` tool with:
 
 - `subagent_type`: `sdlc:error-report-orchestrator`
-- `model`: `haiku` (the orchestrator pins `haiku` itself; pass it explicitly so the harness honours it)
+- `model`: `haiku` (the Agent tool `model:` parameter takes precedence over agent frontmatter; passing `haiku` here keeps this bounded task on a lightweight model regardless of the parent context's model)
 - `prompt` (exactly two lines, no other content):
 
   ```text

--- a/tests/promptfoo/datasets/commit-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/commit-prepare-exec.yaml
@@ -163,3 +163,29 @@
       value: '"diffTruncated": false'
     - type: icontains
       value: '"truncatedFiles": []'
+
+- description: "commit-prepare: --output-file writes payload to temp file and prints absolute path"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/commit.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-commit-no-config"
+  assert:
+    # stdout is an absolute path, not the JSON payload
+    - type: regex
+      value: '^/.+/sdlc-commit-context-[0-9a-f]+\.json\s*$'
+    # The payload should NOT be on stdout when --output-file is set
+    - type: not-icontains
+      value: '"flags":'
+
+- description: "commit-prepare: without --output-file, JSON payload is printed inline (backward compatible)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/commit.js"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-commit-no-config"
+  assert:
+    # JSON payload is printed inline, not a temp path
+    - type: icontains
+      value: '"flags":'
+    - type: not-regex
+      value: '^/.+/sdlc-commit-context-[0-9a-f]+\.json\s*$'

--- a/tests/promptfoo/datasets/error-report-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/error-report-prepare-exec.yaml
@@ -1,0 +1,61 @@
+# Script execution tests for error-report-prepare.js.
+# These tests run error-report-prepare.js directly (no LLM).
+# They validate manifest assembly, --output-file mode, and required-field
+# validation for the prepare script consumed by error-report-orchestrator.
+
+- description: "error-report-prepare: assembles manifest with all required fields and writes JSON inline (no --output-file)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/error-report-prepare.js"
+    script_args: "--skill commit-sdlc --step Step-0 --operation skill/commit.js --error-text exit-2-crash"
+  assert:
+    - type: icontains
+      value: '"skill": "commit-sdlc"'
+    - type: icontains
+      value: '"step": "Step-0"'
+    - type: icontains
+      value: '"operation": "skill/commit.js"'
+    - type: icontains
+      value: '"errorText": "exit-2-crash"'
+    - type: icontains
+      value: '"targetRepo": "rnagrodzki/sdlc-marketplace"'
+    # labels include both tooling-error and the skill name
+    - type: icontains
+      value: '"tooling-error"'
+
+- description: "error-report-prepare: --output-file writes manifest to temp file and prints absolute path"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/error-report-prepare.js"
+    script_args: "--skill pr-sdlc --step Step-2 --operation gh-pr-create --error-text 401-Bad-credentials --output-file"
+  assert:
+    # stdout is an absolute path, not the JSON manifest
+    - type: regex
+      value: '^/.+/sdlc-error-report-[0-9a-f]+\.json\s*$'
+    # The manifest payload should NOT be on stdout when --output-file is set
+    - type: not-icontains
+      value: '"targetRepo":'
+
+- description: "error-report-prepare: missing required field exits non-zero with errors[] in payload"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/error-report-prepare.js"
+    script_args: "--skill commit-sdlc"
+  assert:
+    - type: icontains
+      value: '"errors":'
+    - type: icontains
+      value: 'Missing required field: step'
+    - type: icontains
+      value: 'Missing required field: operation'
+    - type: icontains
+      value: 'Missing required field: errorText'
+
+- description: "error-report-prepare: target repo and labels are produced by the script (not the agent)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/error-report-prepare.js"
+    script_args: "--skill version-sdlc --step Step-3 --operation git-push --error-text remote-rejected"
+  assert:
+    - type: icontains
+      value: '"targetRepo": "rnagrodzki/sdlc-marketplace"'
+    - type: icontains
+      value: '"tooling-error"'
+    - type: icontains
+      value: '"version-sdlc"'


### PR DESCRIPTION
## Summary
Fixes a context overflow bug in commit-sdlc and error-report-sdlc by moving `model: haiku` from skill frontmatter to dedicated orchestrator agents that receive only a minimal manifest payload, not the full conversation transcript.

## Business Context
Users running `/commit-sdlc` or `/error-report-sdlc` on long sessions hit `Context limit reached` because pinning `model: haiku` in skill frontmatter routes the entire conversation history into a smaller-window model, which overflows. This makes both skills unreliable on any session that has accumulated significant context.

## Business Benefits
- commit-sdlc and error-report-sdlc work reliably regardless of conversation length
- Orchestrator agents receive only the bounded manifest (file path + working directory), eliminating context overflow
- Pattern is documented in best-practices so future skills avoid the same mistake

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/202

## Technical Design
Introduces two dedicated orchestrator agents (`commit-orchestrator` and `error-report-orchestrator`) under `plugins/sdlc-utilities/agents/`. Each agent pins `model: haiku` and accepts only `MANIFEST_FILE` + `PROJECT_ROOT` as input — no conversation context inherited. The skill bodies dispatch these agents via the `Agent` tool instead of doing heavy message/issue assembly in the main context. A new `error-report-prepare.js` script mirrors the existing `commit.js --output-file` pattern to pre-compute the error context manifest before dispatch. Skills updated to read only lightweight fields from the manifest in main context; heavy fields (full diff, recent commits, template rendering) are consumed exclusively by the orchestrator.

## Technical Impact
- `model: haiku` removed from `commit-sdlc` and `error-report-sdlc` frontmatter — no breaking change to skill interface
- Callers of `error-report-sdlc` must now supply fields via `error-report-prepare.js` before dispatch; the calling convention in REFERENCE.md is unchanged (Step 3 now runs the prepare script)
- No changes to plugin manifest public API, hook payloads, or script output contracts

## Changes Overview
- New `commit-orchestrator` agent: reads commit manifest, applies commitConfig constraints, generates and self-critiques the commit message, returns the message string only
- New `error-report-orchestrator` agent: reads error manifest, fills ToolingError.md template, returns JSON `{title, body}` only
- New `error-report-prepare.js` prepare script: collects error context fields and environment probes (repository, current branch), writes bounded manifest for the orchestrator
- `commit-sdlc` refactored to dispatch `commit-orchestrator` via Agent tool with two-line prompt; main context reads only lightweight fields
- `error-report-sdlc` refactored to run prepare script in Step 3, dispatch `error-report-orchestrator` in Step 4, keep both consent gates and `gh issue create` in main context
- `docs/skill-best-practices.md` updated with new section explaining why frontmatter `model:` is the wrong context-isolation knob and documenting the canonical orchestrator pattern
- Promptfoo exec tests added for `commit-prepare --output-file` mode and all `error-report-prepare.js` scenarios

## Testing
Manual verification of the orchestrator dispatch pattern against the existing fixture-based promptfoo exec suite. New promptfoo test cases cover: `commit-prepare --output-file` writes path (not JSON) to stdout; inline JSON mode remains backward-compatible; `error-report-prepare` assembles manifest with all required fields; `--output-file` mode; missing-field validation exits non-zero with `errors[]`; `targetRepo` and `labels` are pre-computed by the script.