### PR TITLE
fix(#211): version-sdlc - plugin.json, --output-file, and config.changelog fixes

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,11 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-05 — received-review-sdlc: three HIGH fixes on fix/version-sdlc-bugs-211-212-213
+HIGH-1: `--output-file` handler had a conditional `i++` that ate the next positional arg (e.g. `patch`), causing `requestedBump` to stay null. `output.js` only checks `process.argv.includes('--output-file')` — no value consumption — so the handler must be a pure no-op. Rule: boolean flags that delegate value-reading to another module must not advance the parse index.
+HIGH-2: Exec test for #212 used `--output-file` in `script_args`, which made the script write JSON to a temp file and print only the path to stdout. The `not-icontains "Unknown flag: --output-file"` assertion against a file path was a guaranteed false positive. Fix: remove `--output-file` from args so full JSON hits stdout; replace the file-path regex with a `requestedBump` content assertion.
+HIGH-3: `docs/skills/version-sdlc.md` was never updated after #211 (git diff hard-gate) and #213 (unified flags.changelog). Rule: when SKILL.md gains a new hard gate or behavior change, update the user-facing reference doc in the same PR.
+
 ## 2026-05-05 — version-sdlc: plugin.json corruption during release v0.17.41 (#211)
 Root cause: SKILL.md Step 8.1 only mandated targeted Edit for TOML/YAML version files; JSON formats (package.json, plugin.json) were left to LLM discretion. The agent rewrote plugin.json from memory during the release commit, truncating the `description` field. Mitigation: Step 8.1 now mandates a single targeted Edit-tool call for ALL version-file formats (JSON included) plus a post-edit `git diff` HARD GATE — exactly one line must differ; otherwise abort and `git checkout -- <versionFile>`. Spec R8 generalized; gotcha bullet rewritten. Behavioral test added (multi-field plugin.json fixture).
 

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,9 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-05 — version-sdlc: plugin.json corruption during release v0.17.41 (#211)
+Root cause: SKILL.md Step 8.1 only mandated targeted Edit for TOML/YAML version files; JSON formats (package.json, plugin.json) were left to LLM discretion. The agent rewrote plugin.json from memory during the release commit, truncating the `description` field. Mitigation: Step 8.1 now mandates a single targeted Edit-tool call for ALL version-file formats (JSON included) plus a post-edit `git diff` HARD GATE — exactly one line must differ; otherwise abort and `git checkout -- <versionFile>`. Spec R8 generalized; gotcha bullet rewritten. Behavioral test added (multi-field plugin.json fixture).
+
 ## 2026-05-05 — version-sdlc: patch release v0.17.41 from fix/205-pr-labels-section-menu
 Branch had no upstream; `--set-upstream` auto-heal fired correctly on first push. Changelog disabled via CLI (no `--changelog` flag despite `config.changelog: true`). Single fix commit: setup-sdlc summarizePrLabels leaf config read.
 
@@ -37,8 +40,8 @@ that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 - version-sdlc auto-set-upstream → #183
 - pr-sdlc post-failure gh-switch → #184
 - plan-sdlc README reminder → #185
-- version-sdlc --output-file unknown flag warning → #212
-- version-sdlc config.changelog not honored → #213
+- version-sdlc --output-file unknown flag warning → #212 (RESOLVED — declared in version.js parser; see fix/version-sdlc-bugs-211-212-213)
+- version-sdlc config.changelog not honored → #213 (RESOLVED — flags.changelog now emits resolved value config OR --changelog; spec R18; see fix/version-sdlc-bugs-211-212-213)
 - pr-sdlc remoteState.pushed stale → #214
 
 ## 2026-04-29 — received-review-sdlc processing of review findings for fix(#183)

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,12 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-05 — pr-sdlc: gh account auto-switch on CreatePullRequest permission error
+The active gh account (rnagrodzkicl) lacked CreatePullRequest permissions on the rnagrodzki/sdlc-marketplace repo. pr-recover-gh-account.js returned `recovered: false` with hint `gh auth login --hostname github-rn` because the remote URL uses a custom SSH host alias. The correct account (rnagrodzki) was already configured locally as an inactive account — manual `gh auth switch --user rnagrodzki` resolved it before the retry. Rule: when the recovery helper returns `recovered: false`, check `gh auth status` for inactive matching accounts and switch manually before the retry.
+
+## 2026-05-05 — version-sdlc: patch release v0.17.43 on fix branch
+Released v0.17.43 on `fix/version-sdlc-bugs-211-212-213` — first push required `--set-upstream`; auto-healed correctly. The `--output-file` "Unknown flag" warning was expected (the very bug being fixed in this release) and is non-blocking. `config.changelog = true` drove CHANGELOG generation without an explicit `--changelog` flag, confirming #213 fix works correctly during its own release.
+
 ## 2026-05-05 — received-review-sdlc: three HIGH fixes on fix/version-sdlc-bugs-211-212-213
 HIGH-1: `--output-file` handler had a conditional `i++` that ate the next positional arg (e.g. `patch`), causing `requestedBump` to stay null. `output.js` only checks `process.argv.includes('--output-file')` — no value consumption — so the handler must be a pure no-op. Rule: boolean flags that delegate value-reading to another module must not advance the parse index.
 HIGH-2: Exec test for #212 used `--output-file` in `script_args`, which made the script write JSON to a temp file and print only the path to stdout. The `not-icontains "Unknown flag: --output-file"` assertion against a file path was a guaranteed false positive. Fix: remove `--output-file` from args so full JSON hits stdout; replace the file-path regex with a `requestedBump` content assertion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.43] - 2026-05-05
+
+### Fixed
+- version-sdlc: fixed plugin.json corruption during version bump by switching to targeted field replacement with a post-edit diff gate (#211)
+- version-sdlc: fixed `--output-file` flag parser consuming the following positional argument (e.g. `patch`), causing incorrect bump resolution (#212)
+- version-sdlc: `config.changelog` is now respected without requiring an explicit `--changelog` flag; unified changelog gate reads from both flags and config (#213)
+
 ## [0.17.40] - 2026-05-05
 
 ### Fixed

--- a/docs/skills/version-sdlc.md
+++ b/docs/skills/version-sdlc.md
@@ -22,7 +22,7 @@ Manages the full semantic release workflow: detects the version source, bumps th
 | `--init` | Run the setup wizard and write `.claude/version.json`. Safe to re-run. | — |
 | `--pre <label>` | Create a pre-release version (e.g. `beta`, `rc`). Label must match `^[a-z][a-z0-9]*$`. Auto-increments the counter on repeated runs. | — |
 | `--no-push` | Commit and tag locally, skip `git push`. | — |
-| `--changelog` | With a bump type: generate a CHANGELOG entry as part of the release. Without a bump type: update the changelog for the already-tagged current version (no new tag created). | off |
+| `--changelog` | With a bump type: generate a CHANGELOG entry as part of the release. Without a bump type: update the changelog for the already-tagged current version (no new tag created). Can also be enabled permanently by setting `"changelog": true` in `.claude/version.json` — the CLI flag and config value are OR'd together as `flags.changelog`. | off |
 | `--hotfix` | Mark this release as a hotfix for DORA metrics tracking. Annotates the commit message with `[hotfix]` and the tag message body with `Type: hotfix`. | off |
 | `--auto` | Skip interactive approval prompts. Release plan is still displayed for visibility; critique gates and pre-condition checks still run. | off |
 
@@ -282,6 +282,14 @@ git tag -l --format='%(refname:short)%09%(contents:subject)%09%(contents:body)'
 | `package.json` / version file | Version field bumped in-place |
 | git tag | Annotated tag (e.g. `v1.3.0`) pushed to origin. With `--hotfix`, tag body includes `Type: hotfix`. |
 | `CHANGELOG.md` | New entry prepended (only with `--changelog`) |
+
+---
+
+## Version-File Edit Hard Gate
+
+After bumping the version string in the version file, the skill runs `git diff <versionFile>` and enforces that **exactly one line changed**. If more than one line differs, the release is aborted immediately: the file is restored with `git checkout -- <versionFile>` and the diff is surfaced verbatim to the user.
+
+This gate applies to all supported file formats (JSON, TOML, YAML — `package.json`, `plugin.json`, `Cargo.toml`, `pyproject.toml`, etc.). The Edit tool is used with a single targeted string replacement; the Write tool is never used to rewrite the file, because LLMs can silently truncate or paraphrase fields like `description`.
 
 ---
 

--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -25,7 +25,7 @@
 - R5: CHANGELOG entry uses Keep a Changelog format with today's date, mapping commit types to sections (feat→Added, fix→Fixed, refactor/perf→Changed)
 - R6: Skip non-user-facing commit types in CHANGELOG (chore, docs, test, ci, build, style) unless clearly user-facing
 - R7: When `config.ticketPrefix` is set, append extracted ticket IDs to changelog entries
-- R8: Version file update uses targeted Edit (not full rewrite) for TOML/YAML files
+- R8: Version file update uses targeted Edit (single-string replacement, NOT full rewrite) for ALL supported formats (package.json, plugin.json, Cargo.toml, pyproject.toml, TOML/YAML, etc.). Skill must verify post-edit that exactly one line of `<versionFile>` differs in `git diff`; if not, abort the release and restore the file with `git checkout -- <versionFile>`.
 - R9: Annotated tag includes hotfix type annotation when `flags.hotfix` is true
 - R10: Release commit message includes `[hotfix]` suffix when `flags.hotfix` is true
 - R11: Push requires both `git push` and `git push --tags` (two separate commands)
@@ -35,6 +35,7 @@
 - R15: When `remoteState.hasUpstream === false`, the push step uses `git push --set-upstream origin <currentBranch>` instead of bare `git push`; the subsequent `git push --tags` is unchanged. This avoids first-push failures on fresh feature branches.
 - R16: Pre-release source precedence (top wins): (1) explicit base bump `major|minor|patch` (with optional `--pre <label>`); (2) explicit label-form `--bump <label>` OR explicit `--pre <label>`; (3) `config.preRelease` from `.claude/sdlc.json`; (4) auto-detection from conventional commits. When `config.preRelease` is set and the user passes neither an explicit base bump nor `--pre` nor a label-form `--bump`, the resolved bump is `patch + --pre <config.preRelease>`. An explicit base bump always graduates the release out of the pre-release train regardless of `config.preRelease`. Label values from any source must match `^[a-z][a-z0-9]*$`.
 - R17: Link verification (issue #198) — every URL embedded in changelog or release-notes body MUST be validated by `plugins/sdlc-utilities/scripts/lib/links.js` (CLI: `node scripts/lib/links.js --json`) before any commit/tag operation that publishes the body. Three URL classes are checked: (1) `github.com/<owner>/<repo>/(issues|pull)/<n>` — owner/repo identity must match the current remote, and the issue/PR number must exist on that repo; (2) `*.atlassian.net/browse/<KEY-N>` — host must match the configured Jira site; (3) any other `http(s)://` URL — generic reachability via HEAD (fall back to GET on 405), 5s timeout. Hosts in the built-in skip list (`linkedin.com`, `x.com`, `twitter.com`, `medium.com`) and any `ctx.skipHosts` entries are reported as `skipped`, not violations. `SDLC_LINKS_OFFLINE=1` skips network checks but keeps structural context-aware checks (GitHub identity match, Atlassian host match). Any violation aborts publication with non-zero exit and a structured violation list — no soft-warning mode.
+- R18: `flags.changelog` in `skill/version.js` output reflects the resolved value (`config.changelog === true` OR `--changelog` CLI flag passed). Skill consumes `flags.changelog` directly without re-OR-ing against `config.changelog`.
 
 ## Workflow Phases
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.17.42",
+  "version": "0.17.43",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/skill/version.js
+++ b/plugins/sdlc-utilities/scripts/skill/version.js
@@ -120,9 +120,7 @@ function parseArgs(argv) {
     } else if (a === '--file' && args[i + 1]) {
       fileOverride = args[++i];
     } else if (a === '--output-file') {
-      // Value (when present) is consumed by writeOutput in scripts/lib/output.js.
-      // Skip the next token only if it does not look like another flag.
-      if (args[i + 1] && !args[i + 1].startsWith('-')) i++;
+      // boolean flag; consumed by writeOutput in scripts/lib/output.js
     } else if (a.startsWith('-')) {
       warnings.push(`Unknown flag: ${a}`);
     } else if (PRE_RELEASE_LABEL_RE.test(a)) {

--- a/plugins/sdlc-utilities/scripts/skill/version.js
+++ b/plugins/sdlc-utilities/scripts/skill/version.js
@@ -119,6 +119,10 @@ function parseArgs(argv) {
       auto = true;
     } else if (a === '--file' && args[i + 1]) {
       fileOverride = args[++i];
+    } else if (a === '--output-file') {
+      // Value (when present) is consumed by writeOutput in scripts/lib/output.js.
+      // Skip the next token only if it does not look like another flag.
+      if (args[i + 1] && !args[i + 1].startsWith('-')) i++;
     } else if (a.startsWith('-')) {
       warnings.push(`Unknown flag: ${a}`);
     } else if (PRE_RELEASE_LABEL_RE.test(a)) {
@@ -717,7 +721,7 @@ async function main() {
     requestedBump: args.requestedBump,
     flags: {
       noPush:             args.noPush,
-      changelog:          args.changelog,
+      changelog:          changelogEnabled, // resolved: config.changelog OR --changelog CLI flag
       preLabel:           args.preLabel,
       hotfix:             args.hotfix,
       auto:               args.auto,

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -137,7 +137,7 @@ Decision table:
 
 **Implements R3 (breaking-change gate, reworded):** if `conventionalSummary.hasBreakingChanges` is `true` AND the chosen bump is not `major`, suggest `major` UNLESS the resolved bump is a pre-release from any source. Detect "is a pre-release" by checking that `flags.preLabel` is non-null (covers all three pre-release sources: explicit `--pre`, label-form positional, and `config.preRelease`). Pre-release trains skip this warning to avoid nagging on every RC iteration.
 
-**Draft CHANGELOG entry** (only if `flags.changelog === true` OR `config.changelog === true`):
+**Draft CHANGELOG entry** (only if `flags.changelog === true`) — `flags.changelog` is the resolved value (`config.changelog` OR `--changelog`) emitted by `skill/version.js`:
 
 - Use Keep a Changelog format with today's date: `## [x.y.z] - YYYY-MM-DD`
 - Map commit types to sections:
@@ -247,7 +247,10 @@ The release proceeds regardless of the user's answer. This is informational, not
 
 **Only execute after explicit `yes` from Step 5, or when `flags.auto` is true (implicit approval).**
 
-1. **Update version file** (only if `config.mode === "file"`): Use the Edit tool to replace the old version string with the new version in the version file. For TOML/YAML files, use targeted string replacement rather than a full file rewrite.
+1. **Update version file** (only if `config.mode === "file"`):
+   - **For all version-file formats (JSON, TOML, YAML — package.json, plugin.json, Cargo.toml, pyproject.toml, etc.):** use the Edit tool with a single targeted string replacement. The `old_string` must contain the current version string in its on-disk form (e.g. `"version": "<currentVersion>"` for JSON, `version = "<currentVersion>"` for TOML). The `new_string` substitutes the new version only.
+   - **DO NOT use the Write tool. DO NOT rewrite the file. DO NOT touch any other field.**
+   - **Verify after edit (HARD GATE):** run `git diff <versionFile>`. Exactly one line must differ — the version line. If more than one line differs, abort the release immediately, restore with `git checkout -- <versionFile>`, and surface the diff to the user.
 2. **Update CHANGELOG** (only if changelog is enabled): Use the Edit or Write tool to prepend the new entry after the `## [Unreleased]` section if present, or after the file header if not. Create `CHANGELOG.md` if it does not exist.
 3. **Stage changed files**: `git add <versionFile> CHANGELOG.md` — include only files that were actually changed.
 3b. **Link verification (R17, issue #198) — HARD GATE.** Before `git commit`, validate every URL embedded in the staged CHANGELOG entry (and any release-notes body) via the shared link validator. The script reads the body via `--file` and auto-derives `expectedRepo` from `parseRemoteOwner(cwd)` and `jiraSite` from `~/.sdlc-cache/jira/` — the skill MUST NOT construct ctx JSON. Skip this sub-step entirely when changelog is disabled and no release-notes body was generated.
@@ -367,7 +370,7 @@ When invoking `error-report-sdlc`, provide:
 
 - **Squash merge orphans tags**: When using GitHub's "squash and merge" strategy, the annotated tag created on the feature branch points to the pre-merge commit, which becomes unreachable from main after merge. The `retag-release.yml` workflow (scaffolded during init) automatically moves the tag to the squash commit on main whenever a push lands on main. Without this workflow, tags are orphaned and `git describe` / `git log --decorate` on main will not show them.
 - `bumpOptions.preRelease` is pre-computed in the JSON only when `--pre` was passed at script time. If the user requests a different pre-label during `edit`, re-run the script — the `preRelease` field reflects the label passed at script invocation, not a label added mid-session.
-- For TOML/YAML version files, use the Edit tool with targeted string replacement (old version string → new version string), not full file rewrites, to avoid corrupting file structure.
+- **Version-file edit hard gate:** for ALL version-file formats (JSON, TOML, YAML — package.json, plugin.json, Cargo.toml, pyproject.toml, etc.) use the Edit tool with a single targeted string replacement and verify with `git diff <versionFile>` that exactly one line changed. If more than one line differs, abort and `git checkout -- <versionFile>`. Never use the Write tool or rewrite the file from memory — LLMs reliably truncate or paraphrase fields like `description` (see #211).
 - `git push && git push --tags` are two separate pushes. `git push --tags` alone does NOT push the release commit — both commands are required.
 - **Auto-`--set-upstream` on first push (R15):** When `remoteState.hasUpstream === false`, Step 8 emits `git push --set-upstream origin <currentBranch>` instead of bare `git push`. This eliminates the `fatal: The current branch has no upstream` error on releases cut from a fresh feature branch. The branch comes from `currentBranch` in the `version-context` JSON — never hardcode it. The subsequent `git push --tags` is unchanged.
 - If the working tree has uncommitted changes at execution time, the release commit will include only the staged version file and changelog changes. Warn the user so they are not surprised by files missing from the commit.

--- a/tests/promptfoo/datasets/version-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/version-prepare-exec.yaml
@@ -1,0 +1,56 @@
+# Script execution tests for plugins/sdlc-utilities/scripts/skill/version.js.
+# Covers: --output-file flag declaration (#212) and resolved flags.changelog (#213).
+# These tests run version.js directly against fixture directories (no LLM).
+
+- description: "version-prepare: --output-file does NOT produce 'Unknown flag' warning (#212)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/version.js"
+    script_args: "--output-file patch"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/version-sdlc-config-changelog"
+  assert:
+    # stdout is the path to the temp output file (not the JSON payload)
+    - type: regex
+      value: '^/.+/version-context-[0-9a-f]+\.json\s*$'
+    # The "Unknown flag: --output-file" warning must not appear in stdout
+    - type: not-icontains
+      value: "Unknown flag: --output-file"
+
+- description: "version-prepare: config.changelog=true with no --changelog flag emits flags.changelog=true (#213)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/version.js"
+    script_args: "patch"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/version-sdlc-config-changelog"
+  assert:
+    # The script emits flags.changelog as the resolved value (true here, sourced from config.changelog)
+    - type: icontains
+      value: '"changelog": true'
+    # A non-null changelog block must be present (R18 — skill consumes flags.changelog directly)
+    - type: icontains
+      value: '"changelog":'
+    # No "Unknown flag" warnings should appear regardless
+    - type: not-icontains
+      value: "Unknown flag"
+
+- description: "version-prepare: config.changelog=false with --changelog flag still emits flags.changelog=true (#213)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/version.js"
+    script_args: "patch --changelog"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/version-sdlc-plugin-json-multifield"
+  assert:
+    # Even though fixture has config.changelog=false, --changelog CLI flag flips it on
+    - type: icontains
+      value: '"changelog": true'
+
+- description: "version-prepare: neither config.changelog nor --changelog emits flags.changelog=false (#213)"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/version.js"
+    script_args: "patch"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/version-sdlc-plugin-json-multifield"
+  assert:
+    # Fixture has config.changelog=false and no --changelog flag — resolved value must be false
+    - type: icontains
+      value: '"changelog": false'

--- a/tests/promptfoo/datasets/version-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/version-prepare-exec.yaml
@@ -2,19 +2,19 @@
 # Covers: --output-file flag declaration (#212) and resolved flags.changelog (#213).
 # These tests run version.js directly against fixture directories (no LLM).
 
-- description: "version-prepare: --output-file does NOT produce 'Unknown flag' warning (#212)"
+- description: "version-prepare: patch bump produces no 'Unknown flag' warnings (#212)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/scripts/skill/version.js"
-    script_args: "--output-file patch"
+    script_args: "patch"
     script_cwd: "{{project_root}}"
     project_root: "file://fixtures-fs/version-sdlc-config-changelog"
   assert:
-    # stdout is the path to the temp output file (not the JSON payload)
-    - type: regex
-      value: '^/.+/version-context-[0-9a-f]+\.json\s*$'
-    # The "Unknown flag: --output-file" warning must not appear in stdout
+    # stdout is JSON payload; requestedBump must be patch
+    - type: icontains
+      value: '"requestedBump": "patch"'
+    # No unknown-flag warnings in the JSON output
     - type: not-icontains
-      value: "Unknown flag: --output-file"
+      value: "Unknown flag"
 
 - description: "version-prepare: config.changelog=true with no --changelog flag emits flags.changelog=true (#213)"
   vars:

--- a/tests/promptfoo/datasets/version-sdlc.yaml
+++ b/tests/promptfoo/datasets/version-sdlc.yaml
@@ -485,6 +485,99 @@
         from the output (script did not compute one). The user has graduated out of
         the rc train.
 
+# ---------------------------------------------------------------------------
+# Version-file integrity (#211) and resolved flags.changelog (#213)
+# ---------------------------------------------------------------------------
+
+- description: "version-sdlc: plugin.json edit uses targeted Edit + post-edit diff hard gate (#211)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user is releasing a Claude Code plugin. Running version-prepare.js with `patch --auto`
+      produces this version-context JSON (excerpt):
+      {"flow": "release", "config": {"mode": "file", "versionFile": "plugin.json",
+      "tagPrefix": "v", "changelog": false},
+      "versionSource": {"currentVersion": "0.1.0"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "0.1.1", "minor": "0.2.0",
+      "major": "1.0.0"}, "tags": {"latest": "v0.1.0"},
+      "commits": [{"type": "fix", "subject": "tighten input validation"}],
+      "flags": {"noPush": false, "auto": true, "hotfix": false, "changelog": false},
+      "conflictsWithNext": {"patch": false}, "currentBranch": "main",
+      "remoteState": {"hasUpstream": true}, "errors": [], "warnings": []}
+      The on-disk plugin.json has a long "description" field, an "author" object, a "keywords"
+      array, a "homepage", and a "repository" object — many fields beyond version that the LLM
+      must NOT touch.
+    user_request: >
+      Run /version-sdlc patch --auto. Walk through Step 8.1 — show how you update plugin.json
+      and what verification you perform after the edit. Show the exact Edit-tool call (old_string
+      and new_string) and the post-edit verification command.
+  assert:
+    # Must use the Edit tool (not Write, not bash sed)
+    - type: icontains
+      value: "Edit"
+    # Must NOT propose Write tool or full file rewrite
+    - type: not-icontains
+      value: "Write tool"
+    # Must verify with git diff
+    - type: regex
+      value: 'git diff (--?[a-z]+ )*plugin\.json'
+    # Must NOT touch description, author, keywords (no mention of changing these in the response)
+    - type: not-regex
+      value: '(?i)(rewrite|regenerate|update).*(description|author|keywords)'
+    - type: llm-rubric
+      value: >
+        The response describes Step 8.1 by performing a single targeted Edit-tool call against
+        plugin.json with old_string="\"version\": \"0.1.0\"" and new_string="\"version\": \"0.1.1\"".
+        It explicitly states that Write tool and full-file rewrites are forbidden. After the edit
+        it runs `git diff plugin.json` (or `git diff -- plugin.json`) and asserts that EXACTLY ONE
+        line changed — the version line. It says that if more than one line differs (e.g. the
+        description was truncated or fields were reordered), the release is aborted and the file
+        is restored with `git checkout -- plugin.json`. It does NOT propose touching the
+        description, author, keywords, homepage, or repository fields.
+
+- description: "version-sdlc: config.changelog=true with no --changelog flag still drafts CHANGELOG (#213)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"
+    project_context: >
+      The user has `version.changelog: true` in .claude/sdlc.json but did NOT pass --changelog
+      on the CLI. Running version-prepare.js with `patch` produces this version-context JSON
+      (excerpt):
+      {"flow": "release", "config": {"mode": "file", "versionFile": "package.json",
+      "tagPrefix": "v", "changelog": true},
+      "versionSource": {"currentVersion": "1.0.0"},
+      "requestedBump": "patch", "conventionalSummary": {"suggestedBump": "patch",
+      "hasBreakingChanges": false}, "bumpOptions": {"patch": "1.0.1", "minor": "1.1.0",
+      "major": "2.0.0"}, "tags": {"latest": "v1.0.0"},
+      "commits": [{"type": "feat", "subject": "add new capability"}],
+      "flags": {"noPush": false, "auto": false, "hotfix": false, "changelog": true},
+      "changelog": {"exists": false, "filePath": "CHANGELOG.md", "currentContent": null},
+      "conflictsWithNext": {"patch": false}, "currentBranch": "main",
+      "remoteState": {"hasUpstream": true}, "errors": [], "warnings": []}
+      Note: the script (after the #213 fix) emits flags.changelog=true as the RESOLVED value
+      (config.changelog OR --changelog). The skill must consume flags.changelog directly.
+    user_request: >
+      Run /version-sdlc patch. Show the release plan including the drafted CHANGELOG entry.
+  assert:
+    # Must show new version
+    - type: regex
+      value: '1\.0\.1'
+    # Must draft a Keep-a-Changelog heading
+    - type: regex
+      value: '## \[1\.0\.1\]'
+    # Must include the feat commit in the Added section
+    - type: icontains
+      value: "Added"
+    - type: icontains
+      value: "new capability"
+    - type: llm-rubric
+      value: >
+        The response reads version-context flags.changelog=true (the resolved value emitted by
+        skill/version.js, sourced from config.changelog=true) and treats it as a single
+        authoritative gate — it does NOT re-check config.changelog. It drafts a Keep-a-Changelog
+        entry under `## [1.0.1] - YYYY-MM-DD` with the feat commit listed under the Added
+        section. The release plan presents the drafted changelog and asks for confirmation.
+
 - description: "version-sdlc: link verification (R17, #198) — invokes script gate at Step 8.3b before git commit"
   vars:
     skill_path: "plugins/sdlc-utilities/skills/version-sdlc/SKILL.md"

--- a/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/.claude/sdlc.json
@@ -1,0 +1,9 @@
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "package.json",
+    "fileType": "package.json",
+    "tagPrefix": "v",
+    "changelog": true
+  }
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/package.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-config-changelog",
+  "version": "1.0.0"
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/setup.sh
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "chore: init"
+git tag v1.0.0
+# Add a feat commit so the next bump produces a changelog
+echo "// added" >> src/index.js
+git add -A
+git commit -q -m "feat: add new capability"

--- a/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/src/index.js
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-config-changelog/src/index.js
@@ -1,0 +1,2 @@
+// fixture entry point
+module.exports = {};

--- a/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/.claude/sdlc.json
@@ -1,0 +1,9 @@
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "plugin.json",
+    "fileType": "plugin.json",
+    "tagPrefix": "v",
+    "changelog": false
+  }
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/plugin.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "fixture-multifield-plugin",
+  "version": "0.1.0",
+  "description": "A long description that the LLM must not truncate or paraphrase. It exists specifically to surface the failure mode reported in #211 — when the agent rewrites plugin.json from memory, multi-line description text gets shortened, fields get reordered, or trailing fields disappear entirely. The post-edit git diff hard gate catches this by requiring exactly one changed line.",
+  "author": {
+    "name": "Test Author",
+    "email": "test@example.com",
+    "url": "https://example.com/test-author"
+  },
+  "keywords": [
+    "fixture",
+    "version-sdlc",
+    "regression-test",
+    "plugin-json",
+    "issue-211"
+  ],
+  "homepage": "https://example.com/fixture-multifield-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://example.com/fixture-multifield-plugin.git"
+  }
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/setup.sh
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "chore: init plugin manifest fixture"
+git tag v0.1.0
+echo "// noop" >> src/main.js
+git add -A
+git commit -q -m "fix: tighten input validation"

--- a/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/src/main.js
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-plugin-json-multifield/src/main.js
@@ -1,0 +1,2 @@
+// fixture entry point
+module.exports = {};

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -37,3 +37,4 @@ tests:
   - file://datasets/jira-sdlc-guardrail-exec.yaml
   - file://datasets/context-advisory-exec.yaml
   - file://datasets/links-lib-exec.yaml
+  - file://datasets/version-prepare-exec.yaml


### PR DESCRIPTION
## Summary
Three bugs in the version-sdlc release workflow are fixed: plugin.json corruption during version bumps (#211), a flag parser consuming the positional bump argument when --output-file was used (#212), and config.changelog being silently ignored unless the --changelog CLI flag was explicitly passed (#213).

## Business Context
Users of the sdlc plugin who release Claude Code plugins or Node packages via version-sdlc were hitting three distinct failures: their plugin.json got corrupted (description field truncated), the bump type was silently dropped when using --output-file, and the changelog automation did nothing even when configured on in sdlc.json. All three issues produced silent incorrect behavior with no clear error message.

## Business Benefits
- Plugin.json corruption eliminated: the targeted Edit + post-edit diff hard gate prevents LLM-driven file rewrites from truncating fields like `description` (issue #211)
- Bump type now always reaches the skill: the --output-file boolean flag no longer consumes the next positional argument (issue #212)
- Changelog automation respects config: `config.changelog: true` in sdlc.json now enables changelog generation without requiring a redundant --changelog CLI flag on every invocation (issue #213)

## Github Issue
- https://github.com/rnagrodzki/sdlc-marketplace/issues/211
- https://github.com/rnagrodzki/sdlc-marketplace/issues/212
- https://github.com/rnagrodzki/sdlc-marketplace/issues/213

## Technical Design
Three targeted fixes in `scripts/skill/version.js` and `skills/version-sdlc/SKILL.md`:

1. **#211 — plugin.json hard gate:** SKILL.md Step 8.1 now mandates a single targeted Edit-tool call for ALL version-file formats (JSON, TOML, YAML). After the edit, a `git diff <versionFile>` hard gate asserts exactly one line changed — the version line. On failure, the release is aborted and the file is restored with `git checkout -- <versionFile>`. This prevents the LLM from rewriting the file from memory.

2. **#212 — --output-file flag parser:** The `parseArgs` function in version.js previously had no handler for `--output-file`. The fall-through to the `startsWith('-')` branch emitted an "Unknown flag" warning, and a mistakenly-placed conditional `i++` was consuming the next positional argument. A dedicated `else if (a === '--output-file')` no-op handler now declares the flag without advancing the parse index.

3. **#213 — resolved flags.changelog:** `flags.changelog` in the version.js output is now the resolved value of `config.changelog OR --changelog`, so the SKILL.md condition `flags.changelog === true` is a single authoritative gate. Spec R18 was added to document this contract.

## Technical Impact
- SKILL.md behavior change: Step 8.1 now enforces a hard abort gate for all version-file formats, not just TOML/YAML
- version.js output contract change: `flags.changelog` is now always the resolved boolean (was previously only `true` when `--changelog` was explicitly passed)
- Skills consuming the version-context JSON should read `flags.changelog` only — re-checking `config.changelog` is now redundant and incorrect
- No breaking changes to the external skill interface (flags, invocation syntax, config file format)

## Changes Overview
- Version-file edit protection: SKILL.md Step 8.1 now uses a single targeted Edit call for all formats with a mandatory post-edit diff verification gate that aborts the release if more than one line changed
- Flag parser fix: --output-file declared as a no-op boolean flag in version.js, eliminating the Unknown flag warning and the argument-consumption bug
- Unified changelog resolution: flags.changelog now reflects the OR of config.changelog and --changelog; SKILL.md condition simplified to a single flags.changelog check
- Spec updated: R8 generalized to cover all version-file formats with the hard gate contract; R18 added for the flags.changelog resolution contract
- Documentation updated: version-sdlc.md reference doc adds the Version-File Edit Hard Gate section and clarifies --changelog flag config precedence
- Test coverage added: exec dataset for --output-file warning (#212) and flags.changelog resolution (#213); behavioral test for plugin.json targeted Edit + hard gate (#211); two new fixture directories

## Testing
- New exec test dataset (`version-prepare-exec.yaml`) verifies: patch bump produces no Unknown flag warning, config.changelog=true emits flags.changelog=true, --changelog CLI flag overrides config.changelog=false, and neither source emits false
- New behavioral test case in `version-sdlc.yaml` verifies Step 8.1 uses targeted Edit with exact old_string/new_string and rejects any diff showing more than one changed line
- Two new fixture directories (`version-sdlc-config-changelog`, `version-sdlc-plugin-json-multifield`) provide isolated test environments for each scenario
- Manual verification: version bump on the current repo used the fixed version.js; plugin.json shows clean single-line diff