### PR TITLE
chore: review-dimensions - assign per-dimension model overrides

### DIFF
--- a/.claude/review-dimensions/ci-cd-pipeline.md
+++ b/.claude/review-dimensions/ci-cd-pipeline.md
@@ -7,6 +7,7 @@ triggers:
 skip-when:
   - "**/node_modules/**"
 severity: high
+model: sonnet
 ---
 
 # CI/CD Pipeline Review

--- a/.claude/review-dimensions/code-quality.md
+++ b/.claude/review-dimensions/code-quality.md
@@ -9,6 +9,7 @@ skip-when:
   - "**/build/**"
   - "**/vendor/**"
 severity: medium
+model: sonnet
 ---
 
 # Code Quality Review

--- a/.claude/review-dimensions/dependency-management.md
+++ b/.claude/review-dimensions/dependency-management.md
@@ -7,6 +7,7 @@ triggers:
 skip-when:
   - "**/node_modules/**"
 severity: medium
+model: haiku
 max-files: 10
 ---
 

--- a/.claude/review-dimensions/docs-skill-sync.md
+++ b/.claude/review-dimensions/docs-skill-sync.md
@@ -12,6 +12,7 @@ skip-when:
   - "tests/**"
   - ".claude/skills/**"
 severity: high
+model: haiku
 requires-full-diff: true
 ---
 

--- a/.claude/review-dimensions/hook-readiness.md
+++ b/.claude/review-dimensions/hook-readiness.md
@@ -10,6 +10,7 @@ skip-when:
   - "docs/**"
   - "tests/**"
 severity: medium
+model: sonnet
 ---
 
 # Hook Readiness Review

--- a/.claude/review-dimensions/release-consistency.md
+++ b/.claude/review-dimensions/release-consistency.md
@@ -10,6 +10,7 @@ skip-when:
   - "**/node_modules/**"
   - "tests/**"
 severity: high
+model: haiku
 requires-full-diff: true
 ---
 

--- a/.claude/review-dimensions/runtime-contract.md
+++ b/.claude/review-dimensions/runtime-contract.md
@@ -9,6 +9,7 @@ skip-when:
   - "**/node_modules/**"
   - "docs/**"
 severity: high
+model: opus
 ---
 
 # Runtime Contract Review

--- a/.claude/review-dimensions/script-resolution.md
+++ b/.claude/review-dimensions/script-resolution.md
@@ -8,6 +8,7 @@ skip-when:
   - "**/node_modules/**"
   - "docs/**"
 severity: high
+model: sonnet
 ---
 
 # Script Resolution Review

--- a/.claude/review-dimensions/skill-architecture.md
+++ b/.claude/review-dimensions/skill-architecture.md
@@ -11,6 +11,7 @@ skip-when:
   - "**/node_modules/**"
   - "docs/**"
 severity: high
+model: opus
 ---
 
 # Skill Architecture Review

--- a/.claude/review-dimensions/spec-compliance.md
+++ b/.claude/review-dimensions/spec-compliance.md
@@ -9,6 +9,7 @@ skip-when:
   - "**/node_modules/**"
   - "tests/**"
 severity: high
+model: opus
 requires-full-diff: true
 ---
 

--- a/.claude/review-dimensions/test-quality.md
+++ b/.claude/review-dimensions/test-quality.md
@@ -11,6 +11,7 @@ skip-when:
   - "tests/promptfoo/.promptfoo-data/**"
   - "tests/promptfoo/.env"
 severity: medium
+model: sonnet
 ---
 
 # Test Quality Review

--- a/.claude/review-dimensions/type-safety-review.md
+++ b/.claude/review-dimensions/type-safety-review.md
@@ -9,6 +9,7 @@ skip-when:
   - "site/dist/**"
   - "site/.astro/**"
 severity: medium
+model: haiku
 max-files: 30
 ---
 

--- a/.claude/review-dimensions/ui-review.md
+++ b/.claude/review-dimensions/ui-review.md
@@ -9,6 +9,7 @@ skip-when:
   - "site/dist/**"
   - "site/.astro/**"
 severity: medium
+model: haiku
 max-files: 40
 ---
 

--- a/plugins/sdlc-utilities/skills/review-sdlc/EXAMPLES.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/EXAMPLES.md
@@ -28,6 +28,7 @@ skip-when:
   - "**/__fixtures__/**"
 severity: high
 max-files: 50
+model: sonnet
 ---
 
 # Security Review
@@ -61,6 +62,8 @@ Review all changes for security vulnerabilities.
 | Overly broad CORS policy | medium |
 | Missing rate limiting on auth endpoints | low |
 ```
+
+> `model:` — optional. Forces this dimension's subagent onto the named model. Omit to inherit the manifest default.
 
 ---
 

--- a/plugins/sdlc-utilities/skills/review-sdlc/REFERENCE.md
+++ b/plugins/sdlc-utilities/skills/review-sdlc/REFERENCE.md
@@ -39,6 +39,7 @@ See `EXAMPLES.md` (in this directory) for 5 copy-paste-ready example dimension f
       "description": "...",
       "severity": "high",
       "requires_full_diff": false,
+      "model": "sonnet",
       "status": "ACTIVE",
       "matched_files": ["src/auth/login.ts"],
       "matched_count": 1,
@@ -133,6 +134,7 @@ requires-full-diff: false   # OPTIONAL. Default: false. If true, subagent receiv
 | `severity` | No | string | `medium` | One of: `critical`, `high`, `medium`, `low`, `info` |
 | `max-files` | No | integer | `100` | Positive integer |
 | `requires-full-diff` | No | boolean | `false` | — |
+| `model` | No | string | `null` | One of: `haiku`, `sonnet`, `opus`. Per-dimension model override; falls back to `manifest.subagent_model` when null. Claude-Code-only — Copilot transform omits it. |
 
 ### Body content
 


### PR DESCRIPTION
## Summary
Assigns explicit `model:` fields to all review dimension configurations, routing each subagent to the appropriate Claude model (haiku, sonnet, or opus) based on the complexity of its analysis task. Updates EXAMPLES.md and REFERENCE.md to document the new field.

## Business Context
The `review-sdlc` skill runs each review dimension as an independent subagent. Before this change, all subagents inherited the same model from the manifest default, with no way to tune model selection per dimension. Operators had no mechanism to balance cost against analytical depth across dimensions with vastly different complexity requirements.

## Business Benefits
- High-complexity dimensions (runtime-contract, skill-architecture, spec-compliance) now run on Opus for deeper analysis
- Simpler dimensions (dependency-management, docs-skill-sync, release-consistency, type-safety-review, ui-review) use Haiku to reduce cost
- Mid-complexity dimensions (ci-cd-pipeline, code-quality, hook-readiness, script-resolution, test-quality) run on Sonnet
- Plugin users get better quality-cost tradeoff without modifying their manifest default

## Github Issue
Not detected

## Technical Design
Added `model: <model-name>` to the YAML frontmatter of 13 review dimension files. Model assignments are based on dimension complexity: `opus` for deep structural/behavioral analysis, `haiku` for lightweight checks with well-defined rules, `sonnet` for mid-complexity analysis. The field was already supported by the orchestrator (per REFERENCE.md schema); this PR populates it across all built-in dimensions.

## Technical Impact
None — additive change only. The `model` field is optional and falls back to `manifest.subagent_model` when absent, so existing configurations are unaffected. No breaking changes to plugin manifests, skill interfaces, or hook payloads.

## Changes Overview
- 13 review dimension files receive explicit model assignments in frontmatter: opus for runtime-contract, skill-architecture, spec-compliance; haiku for dependency-management, docs-skill-sync, release-consistency, type-safety-review, ui-review; sonnet for the remaining dimensions
- EXAMPLES.md updated with a `model:` field example in the security dimension sample and a note explaining the field's semantics
- REFERENCE.md dimension schema table updated with the `model` field entry, including type, default, valid values, and Claude Code-only caveat

## Testing
No automated tests added — the `model` field is a pass-through config value; correctness is validated at runtime by the orchestrator selecting the named model. Manual verification: run `/review-sdlc` on a branch touching files matched by multiple dimensions and confirm each subagent uses the assigned model.