### PR TITLE
feat(#230): harvest-learnings - triage learnings log into GH issues

### DIFF
--- a/.claude/commands/harvest-learnings.md
+++ b/.claude/commands/harvest-learnings.md
@@ -1,0 +1,93 @@
+---
+description: Triage .claude/learnings/log.md into GitHub issues
+allowed-tools: [Bash, Read, AskUserQuestion]
+argument-hint: "[--dry-run] [--since YYYY-MM-DD]"
+---
+
+# /harvest-learnings Command
+
+Triage `.claude/learnings/log.md` entries into discrete GitHub issues for this
+repository. Heuristic clustering + LLM-driven approve/skip/edit loop. Dedup
+keys off the `Source: learnings/log.md (lines N–M, ...)` footer, with a fuzzy
+title fallback for `possibly-tracked` candidates.
+
+`$ARGUMENTS` is forwarded verbatim to the helper (`--dry-run`, `--since
+YYYY-MM-DD` accepted).
+
+## Usage
+
+- `/harvest-learnings` — interactive triage of all clusters in the log.
+- `/harvest-learnings --dry-run` — print drafts; create no issues, mutate no log.
+- `/harvest-learnings --since 2026-04-01` — only consider clusters dated on or after.
+
+## Workflow
+
+1. **Run the helper in `--output-file` mode.** Resolve the helper path:
+   prefer `${CLAUDE_PROJECT_DIR}/.claude/scripts/harvest-learnings.js` if
+   `CLAUDE_PROJECT_DIR` is set, else fall back to
+   `.claude/scripts/harvest-learnings.js` relative to the current working
+   directory. Invoke:
+   ```bash
+   node <helper-path> --output-file $ARGUMENTS
+   ```
+   Capture stdout — it is the absolute path to the drafts JSON in `os.tmpdir()`.
+
+2. **Read drafts JSON.** If `clusters.length === 0`, print
+   `nothing to harvest` and stop. No `gh` calls, no log mutation.
+
+3. **Filter clusters.** Silently set aside clusters with `status === 'tracked'`
+   (count them and report at the end). For `status === 'possibly-tracked'`,
+   surface to the user with `existingIssue` context (number, title, state) so
+   they can confirm it's a duplicate or treat it as a fresh draft.
+
+4. **Compose draft issues.** For every `status === 'draft'` cluster (and any
+   `possibly-tracked` cluster the user marked as fresh):
+   - **Title:** `<skill>: <summary>` (from the cluster header).
+   - **Body:** the cluster `bodyLines`, followed by a blank line and the footer
+     `Source: learnings/log.md (lines <sourceStartLine>–<sourceEndLine>, harvested <harvestDate>)`.
+
+5. **Approval loop.** For each draft, present the title + body via
+   `AskUserQuestion` with options `approve` / `skip` / `edit`. On `edit`, allow
+   the user to revise the title and/or body (single-pass — no nested
+   sub-prompts). Track approved cluster ids. Loop until every cluster is
+   resolved.
+
+6. **Dry-run short-circuit.** If `--dry-run` was passed (drafts JSON has
+   `dryRun === true`), print the approved drafts and stop. **No `gh issue
+   create`. No log mutation.**
+
+7. **Create issues.** For each approved draft, run:
+   ```bash
+   gh issue create --title <T> --body <B>
+   ```
+   No `--repo` flag — `gh` resolves the target via the cwd's origin or
+   `gh repo set-default`. Capture the issue numbers returned. If any
+   `gh issue create` invocation fails, surface the failure (and any partial
+   successes) to the user and **skip Step 8** so the user can re-run after
+   resolving the failure.
+
+8. **Commit log mutation.** After all approved issues are created
+   successfully, write a temp file at `$(mktemp -t harvest-approved-XXXXXX).json`
+   with shape:
+   ```json
+   { "approvedClusterIds": ["<id1>", "<id2>", ...] }
+   ```
+   Then run:
+   ```bash
+   node <helper-path> --commit <tmpfile>
+   ```
+   The helper atomically rewrites `log.md`, removing only the line ranges of
+   the approved clusters.
+
+9. **Summary.** Print:
+   ```
+   created N issues, skipped M tracked, skipped K rejected, X remain in log
+   ```
+
+## DO NOT
+
+- Call `gh issue create` before the user explicitly approves a draft.
+- Mutate `log.md` (run `--commit`) before every approved `gh issue create`
+  has succeeded — partial-failure path skips Step 8 entirely.
+- Pass `--repo` to `gh issue create` or `gh issue list`. The helper and
+  command rely on `gh`'s cwd-resolution (`origin` / `gh repo set-default`).

--- a/.claude/commands/harvest-learnings.md
+++ b/.claude/commands/harvest-learnings.md
@@ -23,12 +23,13 @@ YYYY-MM-DD` accepted).
 ## Workflow
 
 1. **Run the helper in `--output-file` mode.** Resolve the helper path:
-   prefer `${CLAUDE_PROJECT_DIR}/.claude/scripts/harvest-learnings.js` if
-   `CLAUDE_PROJECT_DIR` is set, else fall back to
-   `.claude/scripts/harvest-learnings.js` relative to the current working
-   directory. Invoke:
    ```bash
-   node <helper-path> --output-file $ARGUMENTS
+   HELPER_PATH="$(git rev-parse --show-toplevel)/.claude/scripts/harvest-learnings.js"
+   [ -f "$HELPER_PATH" ] || { echo "ERROR: helper not found at $HELPER_PATH"; exit 2; }
+   ```
+   Invoke:
+   ```bash
+   node "$HELPER_PATH" --output-file $ARGUMENTS
    ```
    Capture stdout — it is the absolute path to the drafts JSON in `os.tmpdir()`.
 
@@ -67,7 +68,7 @@ YYYY-MM-DD` accepted).
    resolving the failure.
 
 8. **Commit log mutation.** After all approved issues are created
-   successfully, write a temp file at `$(mktemp -t harvest-approved-XXXXXX).json`
+   successfully, write a temp file at `/tmp/harvest-approved-$$.json`
    with shape:
    ```json
    { "approvedClusterIds": ["<id1>", "<id2>", ...] }

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -77,6 +77,9 @@ First push from untracked branch; `git push --set-upstream origin <branch>` requ
 ## 2026-05-06 — execute-plan-sdlc: 4-task plan executed inline (no Agent dispatch tool)
 Agent tool was not surfaced in this environment so all four waves of the harvest-learnings plan executed inline in the main context (consistent with the existing 2026-05-05 entry on the same situation). Plan AC for the exec test "byte-identical mutation" required tmp-copying the fixture before `--commit` so the canonical fixture under `fixtures-fs/` stays pristine across promptfoo's parallel concurrency=8 — the AC was honored by spinning up an isolated tmp tree inside the JS assertion. Behavioral fixtures `fixtures/*.md` describe the helper's drafts JSON output rather than copying the filesystem fixture; this is the existing harness pattern (exec tests own filesystem trees, behavioral tests own simulated context), so "no fixture duplication" was satisfied in spirit even though the two test surfaces don't literally share files.
 
+## 2026-05-06 — pr-sdlc: custom template sections require matching gh issue link format
+This repo uses a custom PR template (`.claude/pr-template.md`) with a `## Github Issue` section (not `## JIRA Ticket`). The `Fixes #N` reference goes in that section, not in a JIRA field. When a custom template is active, all section headings come from the template — do not inject default 8-section headings alongside it.
+
 Active bugs are tracked in GitHub issues. This log retains only entries < 30 days old
 that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 

--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -74,6 +74,9 @@ Single chore commit (plan-sdlc skill-docs-required guardrail & test fixture). Br
 ## 2026-04-29 — version-sdlc: patch release v0.17.31 on fix/184-sequential-meteor
 First push from untracked branch; `git push --set-upstream origin <branch>` required before `git push --tags`. Both commits were `fix` type (null-check guard + gh-account-switch retry), cleanly mapping to a patch bump.
 
+## 2026-05-06 — execute-plan-sdlc: 4-task plan executed inline (no Agent dispatch tool)
+Agent tool was not surfaced in this environment so all four waves of the harvest-learnings plan executed inline in the main context (consistent with the existing 2026-05-05 entry on the same situation). Plan AC for the exec test "byte-identical mutation" required tmp-copying the fixture before `--commit` so the canonical fixture under `fixtures-fs/` stays pristine across promptfoo's parallel concurrency=8 — the AC was honored by spinning up an isolated tmp tree inside the JS assertion. Behavioral fixtures `fixtures/*.md` describe the helper's drafts JSON output rather than copying the filesystem fixture; this is the existing harness pattern (exec tests own filesystem trees, behavioral tests own simulated context), so "no fixture duplication" was satisfied in spirit even though the two test surfaces don't literally share files.
+
 Active bugs are tracked in GitHub issues. This log retains only entries < 30 days old
 that capture non-obvious gotchas not yet reflected in code, docs, or skills.
 

--- a/.claude/scripts/harvest-learnings.js
+++ b/.claude/scripts/harvest-learnings.js
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * harvest-learnings.js — repo-local helper for /harvest-learnings.
+ *
+ * Self-contained: Node built-ins + `gh` subprocess only. No imports from
+ * plugins/sdlc-utilities or other plugin code.
+ *
+ * Modes:
+ *   --output-file [--dry-run] [--since YYYY-MM-DD]
+ *     Parses <cwd>/.claude/learnings/log.md, calls
+ *       gh issue list --state all --limit 200 \
+ *         --search "Source: learnings/log.md" \
+ *         --json number,title,body,state,closedAt
+ *     (no --repo flag — relies on cwd's resolved repo via origin or
+ *     `gh repo set-default`), performs dedup, writes the drafts JSON to a
+ *     temp file in os.tmpdir(). Stdout = absolute path to that temp file.
+ *
+ *   --commit <approved-clusters.json>
+ *     Input file shape: { approvedClusterIds: [string] }. Atomically rewrites
+ *     log.md removing only the [sourceStartLine..sourceEndLine] ranges for
+ *     those cluster ids. Headings, trailer ("## Tracked in GH Issues") and
+ *     unaffected entries are preserved. Empty approved list → no-op.
+ *
+ * Output JSON shape (--output-file mode):
+ *   {
+ *     logPath,            // absolute path to log.md
+ *     harvestDate,        // YYYY-MM-DD (UTC) of this run
+ *     totalEntries,       // count of parsed clusters before filters
+ *     dryRun,             // boolean
+ *     clusters: [{
+ *       id,               // 12-hex stable hash of (dateISO, skill, sourceStartLine)
+ *       dateISO,          // YYYY-MM-DD
+ *       skill,            // skill name from header
+ *       summary,          // header summary text
+ *       bodyLines,        // body content (joined with \n, no header)
+ *       sourceStartLine,  // 1-indexed line number of `## ` header in log.md
+ *       sourceEndLine,    // 1-indexed last body line of cluster
+ *       status,           // 'draft' | 'tracked' | 'possibly-tracked'
+ *       dedupReason?,     // 'source-range-overlap' | 'fuzzy-title-match'
+ *       existingIssue?    // { number, title, state }
+ *     }],
+ *     skippedTrivial: [{ dateISO, skill, summary, sourceStartLine, sourceEndLine }],
+ *     gh: { listError? }  // populated if gh invocation failed
+ *   }
+ *
+ * Env vars:
+ *   GH_HARVEST_FAKE_LIST  Path to a JSON file matching `gh issue list --json
+ *                         number,title,body,state,closedAt` shape. When set,
+ *                         the helper reads this file instead of invoking gh.
+ *                         Used for tests.
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — user-facing error (log missing, malformed approved-json)
+ *   2 — internal error (filesystem failure during commit, etc.)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function writeOutput(jsonValue) {
+  const dir = os.tmpdir();
+  const name = `harvest-learnings-${Date.now()}-${process.pid}.json`;
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, JSON.stringify(jsonValue, null, 2), 'utf8');
+  process.stdout.write(p + '\n');
+}
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function clusterId(dateISO, skill, sourceStartLine) {
+  return crypto
+    .createHash('sha1')
+    .update(`${dateISO}|${skill}|${sourceStartLine}`)
+    .digest('hex')
+    .slice(0, 12);
+}
+
+const HEADER_RE = /^## (\d{4}-\d{2}-\d{2}) [—-]{1,2} ([^:]+): (.+)$/;
+const TRAILER_RE = /^## Tracked in GH Issues\b/;
+
+function parseLog(logPath) {
+  const raw = fs.readFileSync(logPath, 'utf8');
+  const lines = raw.split('\n');
+
+  // Find trailer (terminates harvestable region). Trailer line index is exclusive.
+  let trailerIdx = lines.length;
+  for (let i = 0; i < lines.length; i++) {
+    if (TRAILER_RE.test(lines[i])) {
+      trailerIdx = i;
+      break;
+    }
+  }
+
+  // Collect cluster header positions (1-indexed) within harvestable region.
+  const headers = [];
+  for (let i = 0; i < trailerIdx; i++) {
+    const m = lines[i].match(HEADER_RE);
+    if (m) {
+      headers.push({
+        idx: i, // 0-indexed
+        dateISO: m[1],
+        skill: m[2].trim(),
+        summary: m[3].trim(),
+      });
+    }
+  }
+
+  const clusters = [];
+  const skippedTrivial = [];
+
+  for (let h = 0; h < headers.length; h++) {
+    const cur = headers[h];
+    const next = headers[h + 1];
+    const endIdx = next ? next.idx - 1 : trailerIdx - 1;
+
+    // Body = lines (cur.idx+1) .. endIdx, trim trailing blank lines off the end
+    let bodyEnd = endIdx;
+    while (bodyEnd > cur.idx && lines[bodyEnd].trim() === '') bodyEnd--;
+    const bodyArr = lines.slice(cur.idx + 1, bodyEnd + 1);
+    const body = bodyArr.join('\n');
+
+    const sourceStartLine = cur.idx + 1; // 1-indexed
+    const sourceEndLine = bodyEnd + 1; // 1-indexed (== sourceStartLine if body empty)
+
+    if (body.trim() === '') {
+      skippedTrivial.push({
+        dateISO: cur.dateISO,
+        skill: cur.skill,
+        summary: cur.summary,
+        sourceStartLine,
+        sourceEndLine,
+      });
+      continue;
+    }
+
+    clusters.push({
+      id: clusterId(cur.dateISO, cur.skill, sourceStartLine),
+      dateISO: cur.dateISO,
+      skill: cur.skill,
+      summary: cur.summary,
+      bodyLines: body,
+      sourceStartLine,
+      sourceEndLine,
+      status: 'draft',
+    });
+  }
+
+  return { clusters, skippedTrivial };
+}
+
+function fetchExistingIssues() {
+  const fake = process.env.GH_HARVEST_FAKE_LIST;
+  if (fake) {
+    try {
+      const txt = fs.readFileSync(fake, 'utf8');
+      const arr = JSON.parse(txt);
+      if (!Array.isArray(arr)) {
+        return { issues: [], listError: 'GH_HARVEST_FAKE_LIST: expected JSON array' };
+      }
+      return { issues: arr };
+    } catch (e) {
+      return { issues: [], listError: `GH_HARVEST_FAKE_LIST: ${e.message}` };
+    }
+  }
+
+  const res = spawnSync(
+    'gh',
+    [
+      'issue',
+      'list',
+      '--state',
+      'all',
+      '--limit',
+      '200',
+      '--search',
+      'Source: learnings/log.md',
+      '--json',
+      'number,title,body,state,closedAt',
+    ],
+    { encoding: 'utf8' }
+  );
+
+  if (res.error) {
+    return { issues: [], listError: `gh: ${res.error.message}` };
+  }
+  if (res.status !== 0) {
+    const msg = (res.stderr || '').trim() || `exit ${res.status}`;
+    return { issues: [], listError: `gh: ${msg}` };
+  }
+  try {
+    const arr = JSON.parse(res.stdout || '[]');
+    return { issues: Array.isArray(arr) ? arr : [] };
+  } catch (e) {
+    return { issues: [], listError: `gh: parse error: ${e.message}` };
+  }
+}
+
+const SOURCE_RANGE_RE = /Source: learnings\/log\.md \(lines (\d+)[–-](\d+)/;
+
+function parseSourceRange(body) {
+  if (typeof body !== 'string') return null;
+  const m = body.match(SOURCE_RANGE_RE);
+  if (!m) return null;
+  return { start: parseInt(m[1], 10), end: parseInt(m[2], 10) };
+}
+
+function rangesOverlap(a, b) {
+  return a.start <= b.end && b.start <= a.end;
+}
+
+const STOPWORDS = new Set(
+  'the,a,an,and,or,for,to,of,in,on,is,was'.split(',')
+);
+
+function tokenize(s) {
+  if (typeof s !== 'string') return new Set();
+  const toks = s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((t) => !STOPWORDS.has(t));
+  return new Set(toks);
+}
+
+function jaccard(setA, setB) {
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let inter = 0;
+  for (const t of setA) if (setB.has(t)) inter++;
+  const union = setA.size + setB.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+function classifyCluster(cluster, issues) {
+  // 1) Source-range overlap → tracked
+  for (const issue of issues) {
+    const range = parseSourceRange(issue.body);
+    if (!range) continue;
+    if (
+      rangesOverlap(
+        { start: cluster.sourceStartLine, end: cluster.sourceEndLine },
+        range
+      )
+    ) {
+      return {
+        status: 'tracked',
+        dedupReason: 'source-range-overlap',
+        existingIssue: {
+          number: issue.number,
+          title: issue.title,
+          state: issue.state,
+        },
+      };
+    }
+  }
+  // 2) Fuzzy title match against open issues → possibly-tracked
+  const summaryTokens = tokenize(cluster.summary);
+  let best = null;
+  for (const issue of issues) {
+    if (issue.state && String(issue.state).toUpperCase() !== 'OPEN') continue;
+    const issueTokens = tokenize(issue.title);
+    const score = jaccard(summaryTokens, issueTokens);
+    if (score >= 0.6 && (!best || score > best.score)) {
+      best = { score, issue };
+    }
+  }
+  if (best) {
+    return {
+      status: 'possibly-tracked',
+      dedupReason: 'fuzzy-title-match',
+      existingIssue: {
+        number: best.issue.number,
+        title: best.issue.title,
+        state: best.issue.state,
+      },
+    };
+  }
+  return { status: 'draft' };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Modes
+// ─────────────────────────────────────────────────────────────────────────
+
+function modeOutputFile(args) {
+  const dryRun = args.includes('--dry-run');
+  let since = null;
+  const sinceIdx = args.indexOf('--since');
+  if (sinceIdx !== -1) {
+    since = args[sinceIdx + 1];
+    if (!since || !/^\d{4}-\d{2}-\d{2}$/.test(since)) {
+      process.stderr.write(`harvest-learnings: --since requires YYYY-MM-DD\n`);
+      process.exit(1);
+    }
+  }
+
+  const cwd = process.cwd();
+  const logPath = path.join(cwd, '.claude', 'learnings', 'log.md');
+  if (!fs.existsSync(logPath)) {
+    process.stderr.write(`harvest-learnings: log not found at ${logPath}\n`);
+    process.exit(1);
+  }
+
+  const { clusters: rawClusters, skippedTrivial } = parseLog(logPath);
+  const totalEntries = rawClusters.length;
+
+  const filtered = since
+    ? rawClusters.filter((c) => c.dateISO >= since)
+    : rawClusters;
+
+  const { issues, listError } = fetchExistingIssues();
+
+  const clusters = filtered.map((c) => {
+    const verdict = classifyCluster(c, issues);
+    return Object.assign({}, c, verdict);
+  });
+
+  const out = {
+    logPath,
+    harvestDate: todayISO(),
+    totalEntries,
+    dryRun,
+    clusters,
+    skippedTrivial,
+    gh: listError ? { listError } : {},
+  };
+
+  writeOutput(out);
+  process.exit(0);
+}
+
+function modeCommit(args) {
+  const approvedPath = args[args.indexOf('--commit') + 1];
+  if (!approvedPath) {
+    process.stderr.write(`harvest-learnings: --commit requires a file path\n`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(approvedPath)) {
+    process.stderr.write(`harvest-learnings: approved-json not found at ${approvedPath}\n`);
+    process.exit(1);
+  }
+
+  let approvedDoc;
+  try {
+    approvedDoc = JSON.parse(fs.readFileSync(approvedPath, 'utf8'));
+  } catch (e) {
+    process.stderr.write(`harvest-learnings: malformed approved-json: ${e.message}\n`);
+    process.exit(1);
+  }
+
+  const approvedClusterIds = Array.isArray(approvedDoc.approvedClusterIds)
+    ? approvedDoc.approvedClusterIds
+    : null;
+  if (!approvedClusterIds) {
+    process.stderr.write(`harvest-learnings: approved-json missing approvedClusterIds[]\n`);
+    process.exit(1);
+  }
+
+  if (approvedClusterIds.length === 0) {
+    // No-op
+    process.exit(0);
+  }
+
+  const cwd = process.cwd();
+  const logPath = path.join(cwd, '.claude', 'learnings', 'log.md');
+  if (!fs.existsSync(logPath)) {
+    process.stderr.write(`harvest-learnings: log not found at ${logPath}\n`);
+    process.exit(1);
+  }
+
+  // Re-parse the log to map approved ids to current line ranges (round-trip
+  // via the same id mint). Anything not found is silently ignored — caller
+  // already got their issues, so we just skip the line-range removal.
+  const { clusters } = parseLog(logPath);
+  const idToCluster = new Map(clusters.map((c) => [c.id, c]));
+  const ranges = [];
+  for (const id of approvedClusterIds) {
+    const c = idToCluster.get(id);
+    if (c) ranges.push({ start: c.sourceStartLine, end: c.sourceEndLine });
+  }
+
+  if (ranges.length === 0) {
+    // Nothing matched → no mutation
+    process.exit(0);
+  }
+
+  // Sort by start asc and remove [start..end] inclusive line ranges.
+  ranges.sort((a, b) => a.start - b.start);
+  const raw = fs.readFileSync(logPath, 'utf8');
+  const lines = raw.split('\n');
+  const remove = new Array(lines.length).fill(false);
+  for (const r of ranges) {
+    for (let i = r.start - 1; i <= r.end - 1 && i < lines.length; i++) {
+      remove[i] = true;
+    }
+  }
+  const kept = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!remove[i]) kept.push(lines[i]);
+  }
+  // Atomic write via tmp + rename
+  const tmp = logPath + '.harvest-tmp-' + process.pid;
+  try {
+    fs.writeFileSync(tmp, kept.join('\n'), 'utf8');
+    fs.renameSync(tmp, logPath);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch (_) {}
+    process.stderr.write(`harvest-learnings: commit failed: ${e.message}\n`);
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Entrypoint
+// ─────────────────────────────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--commit')) {
+    return modeCommit(args);
+  }
+  if (args.includes('--output-file')) {
+    return modeOutputFile(args);
+  }
+
+  process.stderr.write(
+    'Usage: harvest-learnings.js --output-file [--dry-run] [--since YYYY-MM-DD]\n' +
+      '       harvest-learnings.js --commit <approved-clusters.json>\n'
+  );
+  process.exit(1);
+}
+
+main();

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "rnagrodzki"
   }

--- a/tests/promptfoo/datasets/harvest-learnings-exec.yaml
+++ b/tests/promptfoo/datasets/harvest-learnings-exec.yaml
@@ -1,0 +1,144 @@
+# Script execution tests for .claude/scripts/harvest-learnings.js
+# Runs the helper directly against fixture trees (no LLM, no real `gh`).
+# Real `gh issue list` is bypassed via the GH_HARVEST_FAKE_LIST env var.
+# Covers: empty log, draft clusters, source-range dedup, --since filter,
+# --dry-run flag, and --commit log mutation.
+
+# AC1 — Empty log → totalEntries 0, no clusters.
+- description: "harvest-learnings: empty log returns totalEntries=0 and clusters=[]"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-empty"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const path = output.trim();
+        const j = JSON.parse(fs.readFileSync(path, 'utf8'));
+        return j.totalEntries === 0 && Array.isArray(j.clusters) && j.clusters.length === 0;
+
+# AC2 — Log with 3 distinct entries → 3 draft clusters.
+- description: "harvest-learnings: 3-entry log produces 3 draft clusters"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-with-entries"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const j = JSON.parse(fs.readFileSync(output.trim(), 'utf8'));
+        return j.totalEntries === 3
+          && j.clusters.length === 3
+          && j.clusters.every(c => c.status === 'draft')
+          && j.clusters.every(c => typeof c.id === 'string' && c.id.length === 12);
+
+# AC3 — Source-range overlap → cluster classified as 'tracked'.
+- description: "harvest-learnings: source-range overlap classifies cluster as tracked"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-already-tracked"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"{{project_root}}/fake-gh-issues.json"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const j = JSON.parse(fs.readFileSync(output.trim(), 'utf8'));
+        const tracked = j.clusters.find(c => c.status === 'tracked');
+        const draft = j.clusters.find(c => c.status === 'draft');
+        return j.totalEntries === 2
+          && tracked && tracked.dedupReason === 'source-range-overlap'
+          && tracked.existingIssue && tracked.existingIssue.number === 999
+          && draft && draft.skill === 'skill-beta';
+
+# AC4 — --since filters older clusters out.
+- description: "harvest-learnings: --since YYYY-MM-DD filters older clusters"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file --since 2026-05-01"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-with-entries"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const j = JSON.parse(fs.readFileSync(output.trim(), 'utf8'));
+        // totalEntries reflects parse count (3); clusters reflects post-filter (2 of 3).
+        return j.totalEntries === 3
+          && j.clusters.length === 2
+          && j.clusters.every(c => c.dateISO >= '2026-05-01');
+
+# AC5 — --dry-run hint flows into JSON without changing parsing.
+- description: "harvest-learnings: --dry-run sets dryRun=true on output"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file --dry-run"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-with-entries"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const j = JSON.parse(fs.readFileSync(output.trim(), 'utf8'));
+        return j.dryRun === true && j.clusters.length === 3;
+
+# AC6 — --commit removes only approved clusters; rest of file preserved.
+# Performed against a tmp-copy of the fixture so the source stays pristine.
+# The first script invocation seeds drafts JSON; the JS assertion then runs
+# a second invocation against an isolated tmp copy and checks the line delta.
+- description: "harvest-learnings: --commit removes only approved cluster line ranges"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-with-entries"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+  assert:
+    - type: javascript
+      value: |
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+        const { execFileSync } = require('child_process');
+        const drafts = JSON.parse(fs.readFileSync(output.trim(), 'utf8'));
+        // Locate repo root and helper from the fixture path.
+        const fixtureDir = path.dirname(path.dirname(path.dirname(drafts.logPath)));
+        const repoRoot = fixtureDir.replace(/\/tests\/promptfoo\/fixtures-fs\/[^/]+$/, '');
+        const helper = repoRoot + '/.claude/scripts/harvest-learnings.js';
+        // Set up an isolated tmp project tree (copy of fixture log).
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harvest-commit-'));
+        fs.mkdirSync(path.join(tmp, '.claude', 'learnings'), { recursive: true });
+        const srcLog = drafts.logPath;
+        const dstLog = path.join(tmp, '.claude', 'learnings', 'log.md');
+        fs.copyFileSync(srcLog, dstLog);
+        const beforeLines = fs.readFileSync(dstLog, 'utf8').split('\n').length;
+        // Re-run --output-file inside the tmp tree to mint matching cluster ids.
+        const env = Object.assign({}, process.env, { GH_HARVEST_FAKE_LIST: '/dev/null' });
+        const draftsTmpPath = execFileSync('node', [helper, '--output-file'],
+          { cwd: tmp, env, encoding: 'utf8' }).trim();
+        const draftsTmp = JSON.parse(fs.readFileSync(draftsTmpPath, 'utf8'));
+        // Approve only the middle cluster (skill-beta).
+        const target = draftsTmp.clusters.find(c => c.skill === 'skill-beta');
+        const approvedFile = path.join(tmp, 'approved.json');
+        fs.writeFileSync(approvedFile, JSON.stringify({ approvedClusterIds: [target.id] }));
+        execFileSync('node', [helper, '--commit', approvedFile],
+          { cwd: tmp, env, encoding: 'utf8' });
+        const afterRaw = fs.readFileSync(dstLog, 'utf8');
+        const afterLines = afterRaw.split('\n').length;
+        const removed = beforeLines - afterLines;
+        // skill-beta header occupies 2 lines (header + body) in the fixture.
+        const trailerStillPresent = /^## Tracked in GH Issues/m.test(afterRaw);
+        const alphaStillPresent = /skill-alpha: first lesson/.test(afterRaw);
+        const gammaStillPresent = /skill-gamma: older lesson/.test(afterRaw);
+        const betaGone = !/skill-beta: second lesson/.test(afterRaw);
+        return removed === 2 && trailerStillPresent && alphaStillPresent
+          && gammaStillPresent && betaGone;

--- a/tests/promptfoo/datasets/harvest-learnings.yaml
+++ b/tests/promptfoo/datasets/harvest-learnings.yaml
@@ -1,0 +1,122 @@
+# Behavioral tests for /harvest-learnings command (.claude/commands/harvest-learnings.md).
+# Six cases mapped 1:1 to acceptance criteria from issue #230.
+# The simulated project context describes the drafts JSON the helper returned —
+# the canonical filesystem fixtures live under tests/promptfoo/fixtures-fs/
+# (exercised by datasets/harvest-learnings-exec.yaml).
+
+# AC1 — Empty log → command short-circuits with "nothing to harvest", no `gh` calls.
+- description: "harvest-learnings: empty log short-circuits with 'nothing to harvest'"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-empty.md"
+    user_request: >
+      Run /harvest-learnings. The drafts JSON returned by the helper indicates
+      zero clusters. Show what the command does next.
+  assert:
+    - type: icontains
+      value: "nothing to harvest"
+    - type: llm-rubric
+      value: >
+        The response detects that there are no clusters to harvest, prints a
+        short "nothing to harvest" message, and stops. It does NOT call
+        `gh issue create`. It does NOT invoke the helper with `--commit`.
+        It does NOT prompt the user for approval — there is nothing to approve.
+
+# AC2 — All drafts approved → one `gh issue create` per draft, then helper --commit.
+- description: "harvest-learnings: all approved → one gh issue create per draft, then --commit"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-three-drafts.md"
+    user_request: >
+      Run /harvest-learnings. The drafts JSON has 3 draft clusters. Assume the
+      user approves every draft via AskUserQuestion. Show what the command
+      does — what `gh issue create` invocations it produces and what helper
+      command it runs to mutate the log.
+  assert:
+    - type: icontains
+      value: "gh issue create"
+    - type: icontains
+      value: "--commit"
+    - type: llm-rubric
+      value: >
+        The response calls `gh issue create --title <T> --body <B>` once per
+        approved draft (3 invocations total), with no `--repo` flag. The body
+        of each issue ends with a `Source: learnings/log.md (lines N–M,
+        harvested YYYY-MM-DD)` footer. After all `gh issue create` calls
+        succeed, the response writes the approved cluster ids to a temp file
+        and runs `node .claude/scripts/harvest-learnings.js --commit <tmpfile>`
+        to atomically remove the harvested entries from log.md.
+
+# AC3 — Tracked clusters silently skipped, count reported in summary.
+- description: "harvest-learnings: tracked cluster silently skipped, counted in summary"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-already-tracked.md"
+    user_request: >
+      Run /harvest-learnings. The drafts JSON has 1 cluster with status
+      "tracked" (existing issue #999) and 1 with status "draft". Assume the
+      user approves the draft. Show what the command does.
+  assert:
+    - type: llm-rubric
+      value: >
+        The response silently skips the tracked cluster — it does NOT prompt
+        the user about it and does NOT call `gh issue create` for it. The
+        response only presents the single draft cluster (skill-beta) to the
+        user for approval. After approval, exactly one `gh issue create` is
+        invoked (for skill-beta only), and the final summary reports
+        `skipped 1 tracked` (or equivalent — the count of tracked clusters
+        is acknowledged in the summary output).
+
+# AC4 — Partial approval → only approved clusters removed; skipped entries remain.
+- description: "harvest-learnings: partial approval — only approved clusters committed"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-three-drafts.md"
+    user_request: >
+      Run /harvest-learnings. The drafts JSON has 3 draft clusters. Assume the
+      user approves the first cluster (skill-alpha), skips the second
+      (skill-beta), and approves the third (skill-gamma). Show what `gh issue
+      create` invocations are produced and what cluster ids end up in the
+      `--commit` payload.
+  assert:
+    - type: llm-rubric
+      value: >
+        The response makes exactly 2 `gh issue create` invocations (for
+        skill-alpha and skill-gamma). The skipped cluster (skill-beta) gets
+        NO `gh issue create` and is NOT included in the approvedClusterIds
+        passed to `--commit`. The `--commit` payload's approvedClusterIds
+        array contains exactly 2 ids (alpha and gamma) — never the skipped
+        beta. The skipped entry remains in log.md after the commit step.
+
+# AC5 — Full rejection → no `gh issue create`, no log mutation.
+- description: "harvest-learnings: full rejection — no gh create, no log mutation"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-three-drafts.md"
+    user_request: >
+      Run /harvest-learnings. The drafts JSON has 3 draft clusters. Assume the
+      user skips every draft (rejects all approvals). Show what the command
+      does.
+  assert:
+    - type: llm-rubric
+      value: >
+        With every draft rejected, the response makes ZERO `gh issue create`
+        invocations and does NOT invoke the helper with `--commit`. log.md is
+        unchanged. The summary indicates that no issues were created and the
+        rejected count is reported.
+
+# AC6 — --dry-run → drafts printed, no `gh issue create`, no log mutation.
+- description: "harvest-learnings: --dry-run prints drafts, no side effects"
+  vars:
+    skill_path: ".claude/commands/harvest-learnings.md"
+    project_context: "file://fixtures/harvest-learnings-dry-run.md"
+    user_request: >
+      Run /harvest-learnings --dry-run. The drafts JSON has dryRun=true and
+      3 draft clusters. Show what the command does.
+  assert:
+    - type: llm-rubric
+      value: >
+        The response prints the draft titles and bodies (or otherwise displays
+        the drafts) and stops. It does NOT call `gh issue create` for any
+        draft. It does NOT invoke the helper with `--commit`. log.md is
+        unchanged. The dry-run nature of the run is explicit in the output.

--- a/tests/promptfoo/fixtures-fs/project-learnings-already-tracked/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-already-tracked/.claude/learnings/log.md
@@ -1,0 +1,12 @@
+# Learnings Log
+
+Append-only learnings log.
+
+## 2026-05-01 — skill-alpha: tracked lesson about alpha behavior
+This entry already has a corresponding GitHub issue.
+Source-line range will overlap with the fake gh issue body footer.
+
+## 2026-05-02 — skill-beta: untracked lesson about beta behavior
+This entry has no corresponding GitHub issue yet.
+
+## Tracked in GH Issues

--- a/tests/promptfoo/fixtures-fs/project-learnings-already-tracked/fake-gh-issues.json
+++ b/tests/promptfoo/fixtures-fs/project-learnings-already-tracked/fake-gh-issues.json
@@ -1,0 +1,9 @@
+[
+  {
+    "number": 999,
+    "title": "skill-alpha: tracked lesson about alpha behavior",
+    "state": "OPEN",
+    "closedAt": null,
+    "body": "Some preamble text.\n\nSource: learnings/log.md (lines 5–7, harvested 2026-05-01)\n"
+  }
+]

--- a/tests/promptfoo/fixtures-fs/project-learnings-empty/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-empty/.claude/learnings/log.md
@@ -1,0 +1,5 @@
+# Learnings Log
+
+Append-only learnings log.
+
+## Tracked in GH Issues

--- a/tests/promptfoo/fixtures-fs/project-learnings-with-entries/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-with-entries/.claude/learnings/log.md
@@ -1,0 +1,15 @@
+# Learnings Log
+
+Append-only learnings log.
+
+## 2026-05-01 — skill-alpha: first lesson about alpha behavior
+First-entry body line one.
+First-entry body line two.
+
+## 2026-05-02 — skill-beta: second lesson about beta behavior
+Second-entry body content.
+
+## 2026-04-15 — skill-gamma: older lesson about gamma behavior
+Third-entry body content covers an older event.
+
+## Tracked in GH Issues

--- a/tests/promptfoo/fixtures/harvest-learnings-already-tracked.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-already-tracked.md
@@ -1,0 +1,36 @@
+# Harvest Learnings — Already-Tracked Cluster
+
+## Project state
+- Repo: rnagrodzki/sdlc-marketplace
+- `.claude/learnings/log.md` contains two harvestable entries:
+  - `## 2026-05-01 — skill-alpha: tracked lesson about alpha behavior` (lines 5–7)
+  - `## 2026-05-02 — skill-beta: untracked lesson about beta behavior` (lines 9–10)
+
+## Helper invocation simulation
+The helper invoked `gh issue list --state all --limit 200 --search "Source: learnings/log.md" --json number,title,body,state,closedAt`. One open issue was returned whose body contains `Source: learnings/log.md (lines 5–7, harvested 2026-05-01)`.
+
+Drafts JSON (simulated):
+```json
+{
+  "totalEntries": 2,
+  "dryRun": false,
+  "clusters": [
+    { "id": "abc123", "dateISO": "2026-05-01", "skill": "skill-alpha",
+      "summary": "tracked lesson about alpha behavior",
+      "sourceStartLine": 5, "sourceEndLine": 7,
+      "status": "tracked",
+      "dedupReason": "source-range-overlap",
+      "existingIssue": { "number": 999, "title": "skill-alpha: tracked lesson about alpha behavior", "state": "OPEN" } },
+    { "id": "def456", "dateISO": "2026-05-02", "skill": "skill-beta",
+      "summary": "untracked lesson about beta behavior",
+      "sourceStartLine": 9, "sourceEndLine": 10, "status": "draft" }
+  ],
+  "skippedTrivial": [],
+  "gh": {}
+}
+```
+
+## Tooling availability
+`gh` CLI authenticated. The tracked cluster must be silently skipped (counted
+in the final summary). Only the draft cluster should be presented to the user
+for approval.

--- a/tests/promptfoo/fixtures/harvest-learnings-dry-run.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-dry-run.md
@@ -1,0 +1,39 @@
+# Harvest Learnings — Dry Run
+
+## Project state
+- Repo: rnagrodzki/sdlc-marketplace
+- `.claude/learnings/log.md` contains three harvestable draft entries (same shape
+  as `harvest-learnings-three-drafts.md`).
+
+## Helper invocation simulation
+The user invoked `/harvest-learnings --dry-run`. The helper was called with
+`--output-file --dry-run`.
+
+Drafts JSON (simulated):
+```json
+{
+  "totalEntries": 3,
+  "dryRun": true,
+  "clusters": [
+    { "id": "abc123", "dateISO": "2026-05-01", "skill": "skill-alpha",
+      "summary": "first lesson",
+      "bodyLines": "Body content for alpha.",
+      "sourceStartLine": 5, "sourceEndLine": 6, "status": "draft" },
+    { "id": "def456", "dateISO": "2026-05-02", "skill": "skill-beta",
+      "summary": "second lesson",
+      "bodyLines": "Body content for beta.",
+      "sourceStartLine": 8, "sourceEndLine": 9, "status": "draft" },
+    { "id": "ghi789", "dateISO": "2026-04-15", "skill": "skill-gamma",
+      "summary": "older lesson",
+      "bodyLines": "Body content for gamma.",
+      "sourceStartLine": 11, "sourceEndLine": 12, "status": "draft" }
+  ],
+  "skippedTrivial": [],
+  "gh": {}
+}
+```
+
+## Expected behavior
+Per the workflow, `--dry-run` short-circuits before issue creation. No
+`gh issue create` calls. No `--commit` invocation. Drafts are printed for
+the user to inspect.

--- a/tests/promptfoo/fixtures/harvest-learnings-empty.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-empty.md
@@ -1,0 +1,29 @@
+# Harvest Learnings — Empty Log
+
+## Project state
+- Repo: rnagrodzki/sdlc-marketplace
+- `.claude/learnings/log.md` exists but contains only the header and the
+  `## Tracked in GH Issues` trailer.
+- No harvestable entries above the trailer.
+
+## Helper invocation simulation
+The user runs `/harvest-learnings`. The command resolves the helper to
+`.claude/scripts/harvest-learnings.js` and invokes it with `--output-file`.
+
+Helper stdout (simulated): `/tmp/harvest-learnings-XXXXX.json`
+
+Drafts JSON contents (simulated):
+```json
+{
+  "logPath": "<repo>/.claude/learnings/log.md",
+  "harvestDate": "2026-05-06",
+  "totalEntries": 0,
+  "dryRun": false,
+  "clusters": [],
+  "skippedTrivial": [],
+  "gh": {}
+}
+```
+
+## Tooling availability
+`gh` CLI is authenticated. No issues exist with the source-footer search query.

--- a/tests/promptfoo/fixtures/harvest-learnings-three-drafts.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-three-drafts.md
@@ -1,0 +1,43 @@
+# Harvest Learnings — Three Draft Clusters
+
+## Project state
+- Repo: rnagrodzki/sdlc-marketplace
+- `.claude/learnings/log.md` contains three harvestable entries above the trailer:
+  - `## 2026-05-01 — skill-alpha: first lesson about alpha behavior`
+  - `## 2026-05-02 — skill-beta: second lesson about beta behavior`
+  - `## 2026-04-15 — skill-gamma: older lesson about gamma behavior`
+
+## Helper invocation simulation
+The user runs `/harvest-learnings`. The helper at
+`.claude/scripts/harvest-learnings.js` is invoked with `--output-file`.
+
+Drafts JSON contents (simulated):
+```json
+{
+  "logPath": "<repo>/.claude/learnings/log.md",
+  "harvestDate": "2026-05-06",
+  "totalEntries": 3,
+  "dryRun": false,
+  "clusters": [
+    { "id": "abc123", "dateISO": "2026-05-01", "skill": "skill-alpha",
+      "summary": "first lesson about alpha behavior",
+      "bodyLines": "First-entry body line one.\nFirst-entry body line two.",
+      "sourceStartLine": 5, "sourceEndLine": 7, "status": "draft" },
+    { "id": "def456", "dateISO": "2026-05-02", "skill": "skill-beta",
+      "summary": "second lesson about beta behavior",
+      "bodyLines": "Second-entry body content.",
+      "sourceStartLine": 9, "sourceEndLine": 10, "status": "draft" },
+    { "id": "ghi789", "dateISO": "2026-04-15", "skill": "skill-gamma",
+      "summary": "older lesson about gamma behavior",
+      "bodyLines": "Third-entry body content covers an older event.",
+      "sourceStartLine": 12, "sourceEndLine": 13, "status": "draft" }
+  ],
+  "skippedTrivial": [],
+  "gh": {}
+}
+```
+
+## Tooling availability
+`gh` CLI is authenticated. `gh issue list` returned no overlapping issues.
+The user is expected to approve drafts interactively before any
+`gh issue create` runs.

--- a/tests/promptfoo/promptfooconfig-exec.yaml
+++ b/tests/promptfoo/promptfooconfig-exec.yaml
@@ -39,3 +39,4 @@ tests:
   - file://datasets/state-gc-migrate-exec.yaml
   - file://datasets/links-lib-exec.yaml
   - file://datasets/version-prepare-exec.yaml
+  - file://datasets/harvest-learnings-exec.yaml

--- a/tests/promptfoo/promptfooconfig.yaml
+++ b/tests/promptfoo/promptfooconfig.yaml
@@ -29,3 +29,4 @@ tests:
   - file://datasets/error-report-sdlc.yaml
   - file://datasets/ship-sdlc.yaml
   - file://datasets/harden-sdlc.yaml
+  - file://datasets/harvest-learnings.yaml


### PR DESCRIPTION
## Summary
Adds `/harvest-learnings`, a repo-local command and Node.js helper that reads `.claude/learnings/log.md`, groups entries into clusters, deduplicates against existing GitHub issues, and creates new issues from approved clusters via an interactive triage loop.

## Business Context
The learnings log accumulates non-obvious gotchas and process discoveries, but those entries have no direct path to actionable GitHub issues. Without a structured harvest step, learnings stay buried in a flat log and do not get triaged, tracked, or resolved.

## Business Benefits
- Converts raw learnings log entries into tracked GitHub issues with a single command, ensuring discoveries drive actual improvements.
- Deduplication via source-range overlap and fuzzy title matching prevents duplicate issues from being created on repeated runs.
- `--dry-run` and `--since` flags give users safe, scoped control over the harvest process.

## Github Issue
Fixes #230

## Technical Design
The command is split into two parts: a SKILL.md-style workflow in `.claude/commands/harvest-learnings.md` (orchestrates the approval loop, `gh issue create`, and log mutation) and a self-contained Node.js helper at `.claude/scripts/harvest-learnings.js` (parsing, deduplication, commit). The helper uses two dedup strategies: exact source-range overlap against the GitHub issue body footer, and Jaccard similarity (>=0.6 threshold) against open issue titles as a fuzzy fallback. Log mutation is atomic via tmp-file rename. The helper is invoked in `--output-file` mode to write a temp JSON, then in `--commit` mode after all approved issues are successfully created, ensuring no log mutation on partial failure.

## Technical Impact
None. The command and helper are repo-local artifacts (`.claude/` directory) that do not modify any plugin skill, hook, or manifest interface. Plugin version bumped from 0.18.0 to 0.18.1 to reflect the new capability.

## Changes Overview
- New `/harvest-learnings` command that parses the learnings log, presents draft clusters for interactive approval, creates GitHub issues for approved entries, and atomically removes harvested entries from the log
- New `harvest-learnings.js` helper supporting `--output-file` (parse + dedup + classify) and `--commit` (atomic log mutation) modes; deduplication uses source-range overlap as primary strategy and fuzzy Jaccard title matching as fallback
- `GH_HARVEST_FAKE_LIST` environment variable bypass for test isolation, enabling exec tests without real `gh` calls
- Six promptfoo exec test cases covering: empty log, 3-draft log, source-range dedup, `--since` filter, `--dry-run` flag, and `--commit` mutation with isolation via tmp-copy
- Six promptfoo behavioral test cases covering: empty short-circuit, full approval flow, tracked cluster skipping, partial approval, full rejection, and dry-run output
- Plugin manifest version bumped 0.18.0 to 0.18.1

## Testing
Covered by two promptfoo test datasets registered in `promptfooconfig-exec.yaml` and `promptfooconfig.yaml`. Exec tests run the helper directly against filesystem fixtures with `GH_HARVEST_FAKE_LIST` bypassing real `gh` calls, no LLM involved. Behavioral tests validate command workflow decisions against simulated drafts JSON fixtures. Review findings (mktemp replacement, CLAUDE_PROJECT_DIR removal, file existence guard) addressed in a follow-up commit.