### PR TITLE
feat(#270): guardrails - add five planning-discipline guardrails

### DIFF
--- a/.claude/learnings/log.md
+++ b/.claude/learnings/log.md
@@ -3,6 +3,12 @@
 Append-only learnings log for the `sdlc-marketplace` repository.
 Entries flow from incidents, debugging sessions, and evolution cycles.
 
+## 2026-05-07 — version-sdlc: patch bump with feat commit in history
+Explicit `patch` bump requested via pipeline with a `feat:` commit present (suggestedBump was `minor`). Auto mode accepted the override without conflict. Branch had no upstream — `--set-upstream` was auto-applied on push.
+
+## 2026-05-07 — pr-sdlc: planning-discipline guardrails PR (#280)
+PR for five new plan-only guardrails in `guardrails.js`. Title pattern `^(feat|fix|...)\(#\d+\): .+ - .+$` required a ` - ` separator; initial title draft at 82 chars was trimmed to 62 by shortening the scope segment. Custom template active from `.sdlc/pr-template.md`; all 7 sections filled from diff and commit body. Label mode=llm inferred `enhancement` from `feat/` branch prefix. Uncommitted changes warning surfaced but did not block PR creation.
+
 ## 2026-05-07 — pr-sdlc: dual-issue fix PR (#275, #276) with custom template
 PR body used custom template from `.sdlc/pr-template.md`. Both "Fixes #275" and "Fixes #276" placed in the Github Issue section per plan guardrail. Title used first issue number `fix(#275)` to satisfy the `^(fix)\(#\d+\): .+ - .+$` pattern constraint — secondary issue covered in body. Labels mode=llm inferred `bug` from `fix/` branch prefix. Uncommitted changes warning was surfaced (1 file) but did not block PR creation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.13] - 2026-05-07
+
+### Added
+- setup-sdlc: added five planning-discipline always-on guardrails for plan targets — enforcing root-problem statement, minimum viable scope identification, failure-audience naming, explicit non-goal listing, and hard gate on ambiguous patterns (#270)
+
+### Fixed
+- testbed and harvest-learnings: reliability fixes including assertions extraction, direct JSON parsing, and fixture path migration from `.claude/sdlc.json` to `.sdlc/config.json`; added error handling for invalid JSON and missing cluster guard (#251, #252, #253)
+
 ## [0.18.12] - 2026-05-07
 
 ### Fixed

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.18.12",
+  "version": "0.18.13",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/skill/guardrails.js
+++ b/plugins/sdlc-utilities/scripts/skill/guardrails.js
@@ -646,6 +646,49 @@ function buildProposals(signals, target) {
     evidence: 'Universal guardrail — always applicable.',
   });
 
+  // Planning-discipline guardrails — plan target only
+  if (isPlan) {
+    proposals.push({
+      id: 'state-premise',
+      description: 'Plan must state the underlying problem in one sentence — in Goal, Architecture, or Key Decisions. Reject plans that transcribe requirements without naming the root problem.',
+      severity: 'error',
+      category: 'planning-discipline',
+      evidence: 'Universal guardrail — always applicable to non-trivial plans.',
+    });
+
+    proposals.push({
+      id: 'smallest-viable-cut',
+      description: 'Plan must identify the smallest version of the work that still delivers value. If the plan covers more than the minimum, each extra task must be justified in Key Decisions.',
+      severity: 'warning',
+      category: 'planning-discipline',
+      evidence: 'Universal guardrail — always applicable to non-trivial plans.',
+    });
+
+    proposals.push({
+      id: 'failure-audience',
+      description: 'Plan must name who or what fails if this implementation ships incorrectly (user, system, team, downstream service). Surfaces the blast radius before decomposition.',
+      severity: 'warning',
+      category: 'planning-discipline',
+      evidence: 'Universal guardrail — always applicable to non-trivial plans.',
+    });
+
+    proposals.push({
+      id: 'explicit-non-goals',
+      description: 'Plan must list what is intentionally NOT being built. Surface adjacent improvements that were considered and excluded so reviewers and executors do not silently re-expand scope.',
+      severity: 'warning',
+      category: 'planning-discipline',
+      evidence: 'Universal guardrail — always applicable to non-trivial plans.',
+    });
+
+    proposals.push({
+      id: 'ambiguity-stops-and-asks',
+      description: 'When two or more codebase patterns are viable for the same requirement with materially different downstream implications, the plan must EITHER record the choice in Key Decisions with rationale, OR the skill must AskUserQuestion before committing. Silent selection between viable patterns is a critique failure.',
+      severity: 'error',
+      category: 'planning-discipline',
+      evidence: 'Universal guardrail — always applicable to non-trivial plans.',
+    });
+  }
+
   return proposals;
 }
 

--- a/tests/promptfoo/datasets/guardrails-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/guardrails-prepare-exec.yaml
@@ -174,3 +174,66 @@
       value: '"security-review"'
     - type: not-icontains
       value: '"reviewDimensions": []'
+
+# --- planning-discipline catalog (#270 promotion): five plan-only always-on guardrails ---
+
+- description: "guardrails-prepare planning-discipline: --target plan emits all five new IDs"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/guardrails.js"
+    script_args: "--project-root {{project_root}} --target plan"
+    project_root: "file://fixtures-fs/project-mongodb-express"
+  assert:
+    - type: icontains
+      value: '"id": "state-premise"'
+    - type: icontains
+      value: '"id": "smallest-viable-cut"'
+    - type: icontains
+      value: '"id": "failure-audience"'
+    - type: icontains
+      value: '"id": "explicit-non-goals"'
+    - type: icontains
+      value: '"id": "ambiguity-stops-and-asks"'
+
+- description: "guardrails-prepare planning-discipline: --target execute omits all five IDs"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/guardrails.js"
+    script_args: "--project-root {{project_root}} --target execute"
+    project_root: "file://fixtures-fs/project-mongodb-express"
+  assert:
+    - type: not-icontains
+      value: '"id": "state-premise"'
+    - type: not-icontains
+      value: '"id": "smallest-viable-cut"'
+    - type: not-icontains
+      value: '"id": "failure-audience"'
+    - type: not-icontains
+      value: '"id": "explicit-non-goals"'
+    - type: not-icontains
+      value: '"id": "ambiguity-stops-and-asks"'
+
+- description: "guardrails-prepare planning-discipline: state-premise and ambiguity-stops-and-asks are severity error"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/guardrails.js"
+    script_args: "--project-root {{project_root}} --target plan"
+    project_root: "file://fixtures-fs/project-mongodb-express"
+  assert:
+    - type: javascript
+      value: "(() => { const d = JSON.parse(output); const m = Object.fromEntries(d.proposals.map(p => [p.id, p])); return m['state-premise']?.severity === 'error' && m['ambiguity-stops-and-asks']?.severity === 'error'; })()"
+
+- description: "guardrails-prepare planning-discipline: failure-audience, explicit-non-goals, smallest-viable-cut are severity warning"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/guardrails.js"
+    script_args: "--project-root {{project_root}} --target plan"
+    project_root: "file://fixtures-fs/project-mongodb-express"
+  assert:
+    - type: javascript
+      value: "(() => { const d = JSON.parse(output); const m = Object.fromEntries(d.proposals.map(p => [p.id, p])); return ['failure-audience','explicit-non-goals','smallest-viable-cut'].every(id => m[id]?.severity === 'warning'); })()"
+
+- description: "guardrails-prepare planning-discipline: all five entries have category planning-discipline"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/guardrails.js"
+    script_args: "--project-root {{project_root}} --target plan"
+    project_root: "file://fixtures-fs/project-mongodb-express"
+  assert:
+    - type: javascript
+      value: "(() => { const d = JSON.parse(output); const m = Object.fromEntries(d.proposals.map(p => [p.id, p])); return ['state-premise','smallest-viable-cut','failure-audience','explicit-non-goals','ambiguity-stops-and-asks'].every(id => m[id]?.category === 'planning-discipline'); })()"


### PR DESCRIPTION
## Summary
Adds five new always-on guardrails to the `setup-sdlc --guardrails` proposal catalog under a new `planning-discipline` category. These guardrails fire only on `--target plan` runs, enforcing that plans state their root problem, identify minimum viable scope, name the failure audience, list explicit non-goals, and surface ambiguous architectural choices to the user instead of silently choosing.

## Business Context
Users of the SDLC plugin were able to generate plans that omitted critical structural discipline — plans could transcribe requirements without naming the root problem, fail to bound scope, or silently pick between viable implementation patterns without recording the rationale. Issues #270 and #271 identified these as forcing-question discipline gaps; the decision was made to encode them as default guardrail proposals so individual projects can adopt them via `setup-sdlc --guardrails`.

## Business Benefits
- Projects that run `setup-sdlc --guardrails` now receive five planning-discipline guardrails as default proposals, without any additional configuration.
- Plans validated against these guardrails will explicitly name the root problem, bound scope to the minimum viable cut, surface blast radius (failure audience), document explicit non-goals, and force a decision record or user question for ambiguous pattern choices.
- Two of the five (`state-premise`, `ambiguity-stops-and-asks`) are `error` severity — they hard-block malformed plans. Three are `warning` severity — they surface scope and audience concerns as advisory signals.

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/270

## Technical Design
Five `proposals.push(...)` entries added to `buildProposals()` inside `guardrails.js`, gated inside an `if (isPlan)` block so they are invisible to `--target execute` runs. Each entry carries `id`, `description`, `severity`, `category: 'planning-discipline'`, and a universal `evidence` string. No new dependencies, no schema changes, no hook modifications — the extension point in `buildProposals()` was already present.

## Technical Impact
None. This is an additive change: new guardrail IDs are added to the catalog only; no existing IDs, severities, or interface contracts are altered. The `--target execute` path is unaffected.

## Changes Overview
- Five new planning-discipline guardrail proposals added to the catalog, active only for plan-target runs: `state-premise` (error), `smallest-viable-cut` (warning), `failure-audience` (warning), `explicit-non-goals` (warning), `ambiguity-stops-and-asks` (error)
- Version bumped to `0.18.13` and CHANGELOG updated
- Five exec test cases added verifying: plan emits all five IDs, execute omits all five, severity classification is correct, and all five carry the `planning-discipline` category

## Testing
Five `promptfoo` exec test cases added covering the full behavioral surface: presence in plan target, absence in execute target, error/warning severity split, and category assignment. All assertions use `icontains` or `javascript` evaluators against the script's JSON output — no LLM required.