### PR TITLE
fix(#356): learnings log path - align to .sdlc canonical path

### DIFF
--- a/.claude/commands/harvest-learnings.md
+++ b/.claude/commands/harvest-learnings.md
@@ -1,12 +1,12 @@
 ---
-description: Triage .claude/learnings/log.md into GitHub issues
+description: Triage .sdlc/learnings/log.md into GitHub issues
 allowed-tools: [Bash, Read, AskUserQuestion]
 argument-hint: "[--dry-run] [--since YYYY-MM-DD]"
 ---
 
 # /harvest-learnings Command
 
-Triage `.claude/learnings/log.md` entries into discrete GitHub issues for this
+Triage `.sdlc/learnings/log.md` entries into discrete GitHub issues for this
 repository. Heuristic clustering + LLM-driven approve/skip/edit loop. Dedup
 keys off the `Source: learnings/log.md (lines N–M, ...)` footer, with a fuzzy
 title fallback for `possibly-tracked` candidates.

--- a/.claude/scripts/harvest-learnings.js
+++ b/.claude/scripts/harvest-learnings.js
@@ -9,7 +9,7 @@
  *
  * Modes:
  *   --output-file [--dry-run] [--since YYYY-MM-DD]
- *     Parses <cwd>/.claude/learnings/log.md, calls
+ *     Parses <cwd>/.sdlc/learnings/log.md, calls
  *       gh issue list --state all --limit 200 \
  *         --search "Source: learnings/log.md" \
  *         --json number,title,body,state,closedAt
@@ -91,6 +91,37 @@ const { spawnSync } = require('child_process');
 // ─────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves the path to learnings/log.md with a legacy-read fallback.
+ *
+ * Priority:
+ *   1. <cwd>/.sdlc/learnings/log.md   (canonical; returned when it exists)
+ *   2. <cwd>/.claude/learnings/log.md (legacy; emits one stderr deprecation
+ *      warning and is returned when the canonical path does not exist but this
+ *      one does)
+ *   3. <cwd>/.sdlc/learnings/log.md   (canonical; returned when neither
+ *      exists so that downstream missing-file handling fires on the new path)
+ *
+ * NOTE: This function governs the READ path only. Write targets are handled
+ * separately and always use the canonical .sdlc path.
+ */
+function resolveLogPath(cwd) {
+  const newPath = path.join(cwd, '.sdlc', 'learnings', 'log.md');
+  if (fs.existsSync(newPath)) {
+    return newPath;
+  }
+  const legacyPath = path.join(cwd, '.claude', 'learnings', 'log.md');
+  if (fs.existsSync(legacyPath)) {
+    process.stderr.write(
+      '[harvest-learnings] DEPRECATED: reading legacy .claude/learnings/log.md;' +
+        ' run `node plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js`' +
+        ' to migrate. This fallback will be removed in the next minor release.\n'
+    );
+    return legacyPath;
+  }
+  return newPath;
+}
 
 function writeOutput(jsonValue) {
   const dir = os.tmpdir();
@@ -472,7 +503,7 @@ function modeOutputFile(args) {
   }
 
   const cwd = process.cwd();
-  const logPath = path.join(cwd, '.claude', 'learnings', 'log.md');
+  const logPath = resolveLogPath(cwd);
   if (!fs.existsSync(logPath)) {
     process.stderr.write(`harvest-learnings: log not found at ${logPath}\n`);
     process.exit(1);
@@ -548,7 +579,7 @@ function modeCommit(args) {
   }
 
   const cwd = process.cwd();
-  const logPath = path.join(cwd, '.claude', 'learnings', 'log.md');
+  const logPath = resolveLogPath(cwd);
   if (!fs.existsSync(logPath)) {
     process.stderr.write(`harvest-learnings: log not found at ${logPath}\n`);
     process.exit(1);

--- a/.claude/skills/promptfoo-results/SKILL.md
+++ b/.claude/skills/promptfoo-results/SKILL.md
@@ -235,4 +235,4 @@ Before presenting results to the user:
 
 If analysis reveals patterns (e.g. "llm-rubric assertions flaky on skill X",
 "latency spikes correlate with fixture size"), append entries to
-`.claude/learnings/log.md`.
+`.sdlc/learnings/log.md`.

--- a/.claude/skills/test-report/SKILL.md
+++ b/.claude/skills/test-report/SKILL.md
@@ -317,4 +317,4 @@ When invoking `error-report-sdlc`, provide:
 
 If analysis reveals patterns (e.g., "Cat-A failures correlate with concurrency > N",
 "specific skill consistently produces false-positive assertion failures"), append
-entries to `.claude/learnings/log.md`.
+entries to `.sdlc/learnings/log.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
 ## [0.19.14] - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.20.0] - 2026-05-13
+
+### Added
+- harvest-learnings: canonical learnings log path resolution with `resolveLogPath()` and one-shot migration script from legacy `.claude/learnings/log.md` to `.sdlc/learnings/log.md` (#356)
+
+### Changed
+- harden-sdlc: updated documentation to reference learnings log migration (#356)
+
 ## [0.19.14] - 2026-05-12
 
 ### Added

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.19.14",
+  "version": "0.20.0",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js
+++ b/plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * migrate-learnings-log — migrate-learnings-log in plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js
+ *
+ * Migrates the learnings log from the legacy path <project>/.claude/learnings/log.md
+ * to the canonical path <project>/.sdlc/learnings/log.md.
+ *
+ * Behavior by case:
+ *   - Both absent    → print "migrate-learnings-log: nothing to migrate", exit 0
+ *   - Target exists, legacy absent → print "migrate-learnings-log: already migrated", exit 0
+ *   - Target absent, legacy exists → mkdir -p target dir, fs.renameSync(legacy, target),
+ *                                    print "migrate-learnings-log: moved <legacy> → <target>", exit 0
+ *   - Both exist     → print warning to stderr:
+ *                      "migrate-learnings-log: both paths present; keeping <target>, leaving <legacy> in place — please review and delete legacy manually"
+ *                      exit 0 (non-fatal, idempotent)
+ *   - Filesystem error → print error to stderr, exit 1
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const cwd = process.cwd();
+const legacy = path.join(cwd, '.claude', 'learnings', 'log.md');
+const target = path.join(cwd, '.sdlc', 'learnings', 'log.md');
+
+try {
+  const legacyExists = fs.existsSync(legacy);
+  const targetExists = fs.existsSync(target);
+
+  if (!legacyExists && !targetExists) {
+    console.log('migrate-learnings-log: nothing to migrate');
+    process.exit(0);
+  }
+  if (targetExists && !legacyExists) {
+    console.log('migrate-learnings-log: already migrated');
+    process.exit(0);
+  }
+  if (targetExists && legacyExists) {
+    process.stderr.write('migrate-learnings-log: both paths present; keeping ' + target + ', leaving ' + legacy + ' in place — please review and delete legacy manually\n');
+    process.exit(0);
+  }
+  // legacy exists, target absent
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.renameSync(legacy, target);
+  console.log('migrate-learnings-log: moved ' + legacy + ' → ' + target);
+  process.exit(0);
+} catch (err) {
+  process.stderr.write('migrate-learnings-log: error — ' + err.message + '\n');
+  process.exit(1);
+}

--- a/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/commit-sdlc/SKILL.md
@@ -272,7 +272,7 @@ When invoking `error-report-sdlc`, provide:
 
 ## Learning Capture
 
-After completing a commit, if the project's detected commit style was non-conventional or unusual, append to `.claude/learnings/log.md`:
+After completing a commit, if the project's detected commit style was non-conventional or unusual, append to `.sdlc/learnings/log.md`:
 
 ```
 ## YYYY-MM-DD — commit-sdlc: <brief summary>

--- a/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/execute-plan-sdlc/SKILL.md
@@ -486,7 +486,7 @@ The reviewer's focus in this final check is **cross-wave coverage**:
 
 **8-ter. Learning Capture (runs before Step 9 returns control):**
 
-Append to `.claude/learnings/log.md`:
+Append to `.sdlc/learnings/log.md`:
 
 - Tasks classified trivial that needed agent dispatch (or vice versa)
 - Wave structures that caused unexpected file conflicts
@@ -627,7 +627,7 @@ On failure or interruption (not all tasks completed), preserve the state file. P
 
 **Empty guardrails are the happy path for existing projects.** If `activeGuardrails` is empty (no guardrails configured in `.sdlc/config.json` under `execute`), all guardrail steps are skipped. This is backward compatible — no existing behavior changes. Execution guardrails (`execute.guardrails`) and plan guardrails (`plan.guardrails`) are independent — configuring one does not affect the other.
 
-**Learning Capture runs before the final report.** See Step 8-ter. The append to `.claude/learnings/log.md` must happen before Step 9 returns control so ship-sdlc's staging window (`git add -A -- ':!.sdlc/'`) picks up the change and the log entry lands inside the feature commit. A standalone `## Learning Capture` section after Step 9 would leave the working tree dirty post-pipeline.
+**Learning Capture runs before the final report.** See Step 8-ter. The append to `.sdlc/learnings/log.md` must happen before Step 9 returns control so ship-sdlc's staging window (`git add -A -- ':!.sdlc/'`) picks up the change and the log entry lands inside the feature commit. A standalone `## Learning Capture` section after Step 9 would leave the working tree dirty post-pipeline.
 
 ## What's Next
 

--- a/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
@@ -287,7 +287,7 @@ The `AmbiguousOffer` line records the Step 5c outcome:
   `skip`.
 
 Mirror the append pattern used by `commit-sdlc` and `execute-plan-sdlc`. Create
-the `.claude/learnings/` directory and `log.md` file if they don't exist.
+the `.sdlc/learnings/` directory and `log.md` file if they don't exist.
 
 ---
 

--- a/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
@@ -267,7 +267,7 @@ The trap from Step 1 cleans up the manifest on every exit path.
 
 ## Step 7 — Learning Capture
 
-Append a single line to `.claude/learnings/log.md` summarizing the hardening
+Append a single line to `.sdlc/learnings/log.md` summarizing the hardening
 action:
 
 ```

--- a/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md
@@ -535,7 +535,7 @@ When invoking `error-report-sdlc` for a persistent Jira API failure, provide:
 
 ## Learning Capture
 
-When executing Jira operations, capture discoveries by appending to `.claude/learnings/log.md`.
+When executing Jira operations, capture discoveries by appending to `.sdlc/learnings/log.md`.
 Record entries for: field formats that differ from the defaults documented here, workflow
 quirks discovered in specific projects, issue type names that aren't standard (e.g., custom
 subtask type names), user lookup disambiguation patterns, and transition required fields not

--- a/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
@@ -445,7 +445,7 @@ Then call ExitPlanMode. Do NOT invoke execute-plan-sdlc or ship-sdlc in this tur
 
 ## Learning Capture
 
-After writing the plan, append to `.claude/learnings/log.md`:
+After writing the plan, append to `.sdlc/learnings/log.md`:
 
 - Requirements that needed significant clarification before decomposition
 - Scope decisions (what was included/excluded and why)

--- a/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/pr-sdlc/SKILL.md
@@ -611,7 +611,7 @@ When invoking `error-report-sdlc`, provide:
 
 ## Learning Capture
 
-When creating pull requests, capture discoveries by appending to `.claude/learnings/log.md`.
+When creating pull requests, capture discoveries by appending to `.sdlc/learnings/log.md`.
 Record entries for: repository PR conventions not covered by this skill, branch naming
 patterns, CI requirements that affect PR descriptions, team-specific template preferences,
 JIRA project key patterns, or review process quirks encountered while generating PR content.

--- a/plugins/sdlc-utilities/skills/received-review-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/received-review-sdlc/SKILL.md
@@ -573,7 +573,7 @@ When invoking `error-report-sdlc`, provide:
 
 ## Learning Capture
 
-After processing review feedback, append discoveries to `.claude/learnings/log.md`. Record
+After processing review feedback, append discoveries to `.sdlc/learnings/log.md`. Record
 entries for: reviewer patterns worth knowing (e.g., they always flag X style), pushback
 outcomes (accepted or rejected — to calibrate future responses), unclear feedback patterns
 that revealed communication gaps, YAGNI findings that removed unnecessary work, or codebase

--- a/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/setup-sdlc/SKILL.md
@@ -682,7 +682,7 @@ This skill is safe to re-run. Already-configured sections are skipped unless `--
 
 ## Learning Capture
 
-After completing setup or encountering unexpected behavior, append to `.claude/learnings/log.md`:
+After completing setup or encountering unexpected behavior, append to `.sdlc/learnings/log.md`:
 
 ```
 ## YYYY-MM-DD -- setup-sdlc: <brief summary>

--- a/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/ship-sdlc/SKILL.md
@@ -570,15 +570,15 @@ Pipeline-level learnings cannot land in the feature commit (issue #208) — revi
 
 If the `learnings-commit` step has `status: "will_run"`, execute it inline (no Agent dispatch — deterministic shell):
 
-1. Run the ship-level Learning Capture (see the `## Learning Capture` section below) — append any new entries to `.claude/learnings/log.md`.
+1. Run the ship-level Learning Capture (see the `## Learning Capture` section below) — append any new entries to `.sdlc/learnings/log.md`.
 2. Check whether anything actually changed:
    ```bash
-   git diff --quiet -- .claude/learnings/log.md
+   git diff --quiet -- .sdlc/learnings/log.md
    ```
    - Exit `0` (no diff) → skip the commit and report `learnings-commit: no-op (no new learnings)`.
 3. If there is a diff:
    ```bash
-   git add .claude/learnings/log.md
+   git add .sdlc/learnings/log.md
    git commit -m "chore(ship-sdlc): capture pipeline learnings"
    git push
    ```
@@ -865,7 +865,7 @@ Each sub-skill has its own error recovery. ship-sdlc does not duplicate their re
 
 ## Learning Capture
 
-After completing the pipeline, append to `.claude/learnings/log.md`:
+After completing the pipeline, append to `.sdlc/learnings/log.md`:
 
 - Review verdicts that surprised (threshold too aggressive or too lenient)
 - Sub-skills that failed in unexpected ways during chaining

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -401,7 +401,7 @@ The automated changelog is a **draft, not a source of truth**. Correctness is th
 
 ## Learning Capture
 
-After completing a release or encountering unexpected behavior, append to `.claude/learnings/log.md`:
+After completing a release or encountering unexpected behavior, append to `.sdlc/learnings/log.md`:
 
 ```
 ## YYYY-MM-DD — version-sdlc: <brief summary>

--- a/tests/promptfoo/.gitignore
+++ b/tests/promptfoo/.gitignore
@@ -1,0 +1,5 @@
+# >>> sdlc-utilities managed v3 (do not edit) — transient skill artifacts
+*-context-*.json
+*-manifest-*.json
+*-prepare-*.json
+# <<< sdlc-utilities managed

--- a/tests/promptfoo/.sdlc/.gitignore
+++ b/tests/promptfoo/.sdlc/.gitignore
@@ -1,0 +1,7 @@
+# >>> sdlc-utilities managed (do not edit) — selective ignores
+*
+!.gitignore
+!config.json
+!review-dimensions/
+!review-dimensions/**
+# <<< sdlc-utilities managed

--- a/tests/promptfoo/datasets/execute-plan-sdlc.yaml
+++ b/tests/promptfoo/datasets/execute-plan-sdlc.yaml
@@ -176,7 +176,7 @@
       A 2-task plan has just finished executing. A guardrail was overridden by the
       user during Wave 1 (so a learning entry should be appended). Walk through
       Step 8-ter (Learning Capture) and Step 9 (REPORT) in order, narrating exactly
-      what gets written to `.claude/learnings/log.md` and confirming the working
+      what gets written to `.sdlc/learnings/log.md` and confirming the working
       tree contains that change BEFORE the final summary is emitted.
   assert:
     - type: icontains

--- a/tests/promptfoo/datasets/harvest-learnings-exec.yaml
+++ b/tests/promptfoo/datasets/harvest-learnings-exec.yaml
@@ -385,3 +385,117 @@
   assert:
     - type: javascript
       value: file://assertions/harvest-learnings-commit-processed.js
+
+# ── resolveLogPath resolution cases (issue #356) ────────────────────────────
+
+# AC-RP1 — new path only: resolveLogPath reads .sdlc/learnings/log.md, no deprecation on stderr.
+- description: "harvest-learnings: resolveLogPath reads .sdlc/learnings/log.md when present (no deprecation)"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-new-only"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+    script_capture_stderr: true
+  assert:
+    - type: javascript
+      value: |
+        const lines = output.split('\n');
+        const hasDeprecation = lines.some(l => l.includes('DEPRECATED'));
+        let parsed = null;
+        try { parsed = JSON.parse(output); } catch (_) {}
+        if (!parsed) {
+          // output is stderr + stdout; try to find JSON portion
+          const jsonLine = lines.find(l => l.trim().startsWith('{'));
+          if (jsonLine) try { parsed = JSON.parse(jsonLine); } catch (_) {}
+        }
+        return !hasDeprecation && parsed !== null && typeof parsed.totalEntries === 'number';
+
+# AC-RP2 — legacy only: resolveLogPath falls back to .claude/learnings/log.md with stderr deprecation.
+- description: "harvest-learnings: resolveLogPath falls back to .claude/learnings/log.md with DEPRECATED warning"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-legacy-only"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+    script_capture_stderr: true
+  assert:
+    - type: javascript
+      value: |
+        const hasDeprecation = output.includes('DEPRECATED');
+        const hasLegacyPath = output.includes('.claude/learnings/log.md');
+        return hasDeprecation && hasLegacyPath;
+
+# AC-RP3 — both exist: new path wins, no deprecation on stderr.
+- description: "harvest-learnings: resolveLogPath uses .sdlc path when both exist (no deprecation)"
+  vars:
+    script_path: "repo://.claude/scripts/harvest-learnings.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-both-exist"
+    script_env: '{"GH_HARVEST_FAKE_LIST":"/dev/null"}'
+    script_capture_stderr: true
+  assert:
+    - type: javascript
+      value: |
+        const noDeprecation = !output.includes('DEPRECATED');
+        return noDeprecation;
+
+# ── migrate-learnings-log.js cases (issue #356) ─────────────────────────────
+
+# AC-ML1 — already migrated: target exists, no legacy → stdout "already migrated".
+- description: "migrate-learnings-log: target present, no legacy → 'already migrated'"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-migrate-new-only"
+  assert:
+    - type: javascript
+      value: |
+        const trimmedML1 = output.trim();
+        return trimmedML1.includes('already migrated');
+
+# AC-ML2 — legacy to new: legacy exists, no target → file moved, stdout "moved".
+- description: "migrate-learnings-log: legacy present, no target → moves file and prints 'moved'"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-migrate-legacy-only"
+  assert:
+    - type: javascript
+      value: |
+        // Script only prints "moved X → Y" after fs.renameSync succeeds;
+        // an error would produce stderr + exit 1, not this stdout message.
+        const hasMoved = output.trim().includes('moved');
+        const hasArrow = output.includes(' → ');
+        return hasMoved && hasArrow;
+
+# AC-ML3 — both exist: stderr contains "both paths present".
+- description: "migrate-learnings-log: both paths present → stderr warning 'both paths present'"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-migrate-both-exist"
+    script_capture_stderr: true
+  assert:
+    - type: javascript
+      value: |
+        const hasBothPaths = output.includes('both paths present');
+        return hasBothPaths;
+
+# AC-ML4 — nothing to migrate: neither path exists → stdout "nothing to migrate".
+- description: "migrate-learnings-log: neither path present → 'nothing to migrate'"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/migrate-learnings-log.js"
+    script_args: ""
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/project-learnings-migrate-nothing"
+  assert:
+    - type: javascript
+      value: |
+        const trimmedML4 = output.trim();
+        return trimmedML4.includes('nothing to migrate');

--- a/tests/promptfoo/datasets/ship-sdlc.yaml
+++ b/tests/promptfoo/datasets/ship-sdlc.yaml
@@ -538,7 +538,7 @@
         The pipeline table shows `learnings-commit` as the final step, ordered AFTER
         `pr-sdlc`. The step is described as an inline shell operation (no Agent
         dispatched, no sub-skill invoked) that appends Learning Capture entries to
-        `.claude/learnings/log.md` and creates a trailing
+        `.sdlc/learnings/log.md` and creates a trailing
         `chore(ship-sdlc): capture pipeline learnings` commit if the diff is
         non-empty. The response notes the step is a no-op when no learnings were
         captured this run. The response makes clear that post-pipeline `git status`

--- a/tests/promptfoo/fixtures-fs/project-learnings-both-exist/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-both-exist/.claude/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: legacy path in both-exist fixture
+This entry should NOT be read when new path exists.

--- a/tests/promptfoo/fixtures-fs/project-learnings-both-exist/.sdlc/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-both-exist/.sdlc/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: new path in both-exist fixture
+Stub entry — new path wins when both exist.

--- a/tests/promptfoo/fixtures-fs/project-learnings-legacy-only/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-legacy-only/.claude/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: legacy-only test fixture
+Stub entry for testing that resolveLogPath falls back to .claude/learnings/log.md with deprecation.

--- a/tests/promptfoo/fixtures-fs/project-learnings-migrate-both-exist/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-migrate-both-exist/.claude/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: both-exist legacy path
+Stub entry — legacy path in both-exist migration fixture; migrate should warn on stderr.

--- a/tests/promptfoo/fixtures-fs/project-learnings-migrate-both-exist/.sdlc/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-migrate-both-exist/.sdlc/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: both-exist new path
+Stub entry — new path in both-exist migration fixture.

--- a/tests/promptfoo/fixtures-fs/project-learnings-migrate-legacy-only/.claude/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-migrate-legacy-only/.claude/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: needs-migration fixture
+Stub entry — legacy exists, no target; migrate should move and say "moved".

--- a/tests/promptfoo/fixtures-fs/project-learnings-migrate-new-only/.sdlc/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-migrate-new-only/.sdlc/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: already-migrated fixture
+Stub entry — target exists, no legacy; migrate should say "already migrated".

--- a/tests/promptfoo/fixtures-fs/project-learnings-new-only/.sdlc/learnings/log.md
+++ b/tests/promptfoo/fixtures-fs/project-learnings-new-only/.sdlc/learnings/log.md
@@ -1,0 +1,2 @@
+## 2026-05-13 — stub: new-path-only test fixture
+Stub entry for testing that resolveLogPath reads from .sdlc/learnings/log.md when present.

--- a/tests/promptfoo/fixtures/harvest-learnings-already-tracked.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-already-tracked.md
@@ -2,7 +2,7 @@
 
 ## Project state
 - Repo: rnagrodzki/sdlc-marketplace
-- `.claude/learnings/log.md` contains two harvestable entries:
+- `.sdlc/learnings/log.md` contains two harvestable entries:
   - `## 2026-05-01 — skill-alpha: tracked lesson about alpha behavior` (lines 5–7)
   - `## 2026-05-02 — skill-beta: untracked lesson about beta behavior` (lines 9–10)
 

--- a/tests/promptfoo/fixtures/harvest-learnings-classifier-cases.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-classifier-cases.md
@@ -5,7 +5,7 @@ and returned the following JSON (path captured from stdout, content read):
 
 ```json
 {
-  "logPath": "/project/.claude/learnings/log.md",
+  "logPath": "/project/.sdlc/learnings/log.md",
   "harvestDate": "2026-05-09",
   "totalEntries": 5,
   "dryRun": false,

--- a/tests/promptfoo/fixtures/harvest-learnings-dry-run.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-dry-run.md
@@ -2,7 +2,7 @@
 
 ## Project state
 - Repo: rnagrodzki/sdlc-marketplace
-- `.claude/learnings/log.md` contains three harvestable draft entries (same shape
+- `.sdlc/learnings/log.md` contains three harvestable draft entries (same shape
   as `harvest-learnings-three-drafts.md`).
 
 ## Helper invocation simulation

--- a/tests/promptfoo/fixtures/harvest-learnings-empty.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-empty.md
@@ -2,7 +2,7 @@
 
 ## Project state
 - Repo: rnagrodzki/sdlc-marketplace
-- `.claude/learnings/log.md` exists but contains only the header and the
+- `.sdlc/learnings/log.md` exists but contains only the header and the
   `## Tracked in GH Issues` trailer.
 - No harvestable entries above the trailer.
 
@@ -15,7 +15,7 @@ Helper stdout (simulated): `/tmp/harvest-learnings-XXXXX.json`
 Drafts JSON contents (simulated):
 ```json
 {
-  "logPath": "<repo>/.claude/learnings/log.md",
+  "logPath": "<repo>/.sdlc/learnings/log.md",
   "harvestDate": "2026-05-06",
   "totalEntries": 0,
   "dryRun": false,

--- a/tests/promptfoo/fixtures/harvest-learnings-three-drafts.md
+++ b/tests/promptfoo/fixtures/harvest-learnings-three-drafts.md
@@ -2,7 +2,7 @@
 
 ## Project state
 - Repo: rnagrodzki/sdlc-marketplace
-- `.claude/learnings/log.md` contains three harvestable entries above the trailer:
+- `.sdlc/learnings/log.md` contains three harvestable entries above the trailer:
   - `## 2026-05-01 — skill-alpha: first lesson about alpha behavior`
   - `## 2026-05-02 — skill-beta: second lesson about beta behavior`
   - `## 2026-04-15 — skill-gamma: older lesson about gamma behavior`
@@ -14,7 +14,7 @@ The user runs `/harvest-learnings`. The helper at
 Drafts JSON contents (simulated):
 ```json
 {
-  "logPath": "<repo>/.claude/learnings/log.md",
+  "logPath": "<repo>/.sdlc/learnings/log.md",
   "harvestDate": "2026-05-06",
   "totalEntries": 3,
   "dryRun": false,


### PR DESCRIPTION
## Summary
Aligns the learnings log path across all skills, scripts, and test fixtures from the legacy `.claude/learnings/log.md` to the canonical `.sdlc/learnings/log.md`. Adds `resolveLogPath()` with a one-version deprecation fallback for backward compatibility and a one-shot migration script for existing projects.

## Business Context
The sdlc plugin's learnings capture mechanism was split across two paths — the legacy `.claude/` location and the newer `.sdlc/` canonical location introduced in the sdlc config migration (#231). Users installing the plugin on existing projects would silently lose learnings capture if they had already moved to `.sdlc/` config, because scripts still pointed to the old location.

## Business Benefits
- Users upgrading to the canonical `.sdlc/` layout no longer lose learnings entries silently.
- A migration script allows one-shot conversion from the legacy path to the canonical path with a clear outcome message.
- A one-version deprecation stderr warning gives teams on the old path an actionable prompt to migrate without immediately breaking their workflow.

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/356

## Technical Design
Introduced `resolveLogPath(cwd)` in `harvest-learnings.js` — a priority-ordered resolver that checks `.sdlc/learnings/log.md` first, falls back to `.claude/learnings/log.md` with a stderr deprecation warning, and defaults to the canonical path when neither exists. A standalone `migrate-learnings-log.js` script handles the one-shot file rename with four distinct outcomes (nothing-to-migrate, already-migrated, moved, both-present warning). All SKILL.md references across nine skills were updated to reference the canonical path.

## Technical Impact
No breaking changes — the fallback ensures existing projects on the legacy path continue to work for one release. The deprecation warning is stderr-only and does not affect script exit codes. Any skill or script that writes to the learnings log should target `.sdlc/learnings/log.md` directly; reads go through `resolveLogPath`.

## Changes Overview
- `resolveLogPath()` added to `harvest-learnings.js` to resolve the learnings log path with legacy fallback and deprecation warning
- `migrate-learnings-log.js` added as a one-shot migration script covering all four path-existence cases
- All skill `Learning Capture` sections updated to reference `.sdlc/learnings/log.md`
- Test fixtures added for `resolveLogPath` resolution (new-only, legacy-only, both-exist) and migration script (new-only, legacy-only, both-exist, nothing-to-migrate)
- Promptfoo exec test cases added for all `resolveLogPath` and migration scenarios
- harden-sdlc documentation updated to reference the new canonical path

## Testing
Seven new promptfoo exec test cases cover `resolveLogPath` resolution (AC-RP1–3) and migration script behavior (AC-ML1–4). Fixtures are isolated per scenario. The commit subjects for the implementation (`feat(#356)`) and docs update (`chore(#356)`) are traceable to this issue.