### PR TITLE
fix(#364): review-sdlc - route all scope through three-dot diff

### DIFF
--- a/.claude/scripts/block-isolation-worktree.js
+++ b/.claude/scripts/block-isolation-worktree.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook — blocks Agent dispatch with isolation: "worktree".
+ *
+ * SDLC manages its own worktrees via util/worktree-create.js (git CLI).
+ * The Claude Code SDK's isolation: "worktree" creates ephemeral worktrees
+ * at .claude/worktrees/agent-<id> — these are never the intended SDLC
+ * worktree and cause changes to land in the wrong location.
+ *
+ * See issues #370, #371, #372.
+ */
+'use strict';
+
+const chunks = [];
+process.stdin.on('data', c => chunks.push(c));
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(Buffer.concat(chunks).toString());
+    if (input.tool_input && input.tool_input.isolation === 'worktree') {
+      process.stderr.write(
+        'BLOCKED: isolation: "worktree" is forbidden in this repo.\n' +
+        'SDLC manages worktrees via util/worktree-create.js (git CLI).\n' +
+        'The Agent SDK\'s isolation: "worktree" creates .claude/worktrees/agent-<id>\n' +
+        'which is never the intended SDLC worktree.\n' +
+        'Remove the isolation parameter from this Agent dispatch.\n' +
+        'See: https://github.com/rnagrodzki/sdlc-marketplace/issues/370\n'
+      );
+      process.exit(1);
+    }
+  } catch (_) {
+    // Unparseable input — don't block
+  }
+  process.exit(0);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/scripts/block-isolation-worktree.js",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -168,10 +168,13 @@ function fetchBaseRef(base, projectRoot) {
  *   'stat'      — `git diff --stat <base>...HEAD`      (used by getDiffStat)
  *   'content'   — `git diff <base>...HEAD`             (used by getDiffContent)
  *
- * Other scopes (staged, working, worktree, all) intentionally do NOT use 3-dot:
+ * Other scopes (staged, working, worktree) intentionally do NOT use 3-dot:
  *   - 'staged'/'working': do not involve a base ref
  *   - 'worktree': symmetric (full working tree vs. base) by design
- *   - 'all'    : `--cached` does not accept a commit range, so stays two-arg
+ *
+ * The 'all' scope (default) now also routes through this helper via
+ * buildBranchContribDiffCmd('committed'|'content', base) — issue #364
+ * completes #239 by removing the two-dot leak in the default review path.
  *
  * @param {'committed'|'stat'|'content'} scope
  * @param {string} base
@@ -201,7 +204,7 @@ function getChangedFiles(base, projectRoot, scope = 'all') {
     case 'staged':    cmd = 'git diff --cached --name-only';                   break;
     case 'working':   cmd = 'git diff HEAD --name-only';                       break;
     case 'worktree':  cmd = `git diff --name-only ${base}`;                    break;
-    default:          cmd = `git diff --cached --name-only ${base}`;           break; // 'all'
+    default:          cmd = buildBranchContribDiffCmd('committed', base);      break; // 'all' (issue #364)
   }
   const out = exec(cmd, { cwd: projectRoot });
   return out ? out.split('\n').filter(Boolean) : [];

--- a/plugins/sdlc-utilities/scripts/skill/review.js
+++ b/plugins/sdlc-utilities/scripts/skill/review.js
@@ -236,14 +236,15 @@ function fetchAndSplitDiff(base, projectRoot, scope = 'all') {
   let cmd;
   switch (scope) {
     // Three-dot for branch-contribution scope so files only present on the base
-    // branch after divergence don't appear in the per-dimension diff (issue #239).
+    // branch after divergence don't appear in the per-dimension diff
+    // (issue #239 for 'committed', issue #364 for default 'all').
     // Routed through lib/git.js::buildBranchContribDiffCmd so review and pr stay
     // in sync — DRY, no per-call divergence.
     case 'committed': cmd = buildBranchContribDiffCmd('content', base); break;
     case 'staged':    cmd = 'git diff --cached';                        break;
     case 'working':   cmd = 'git diff HEAD';                            break;
     case 'worktree':  cmd = `git diff ${base}`;                         break;
-    default:          cmd = `git diff --cached ${base}`;                break; // 'all'
+    default:          cmd = buildBranchContribDiffCmd('content', base); break; // 'all' (issue #364)
   }
   const raw = exec(cmd, { cwd: projectRoot });
   if (!raw) return new Map();

--- a/tests/promptfoo/datasets/git-lib-exec.yaml
+++ b/tests/promptfoo/datasets/git-lib-exec.yaml
@@ -65,3 +65,37 @@
   assert:
     - type: contains
       value: 'git diff main...HEAD'
+
+- description: "git-lib: getChangedFiles 'all' scope excludes base-only files in reverse-merge fixture (issue #364)"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/git-lib-test.js"
+    script_args: "--op getChangedFilesScope --project-root {{project_root}} --base main --scope all"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/git-lib-reverse-merge"
+  assert:
+    - type: contains
+      value: '"feature.js"'
+    - type: not-contains
+      value: '"base-only.js"'
+
+- description: "git-lib: getChangedFiles 'all' scope matches 'committed' scope output (issue #364)"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/git-lib-test.js"
+    script_args: "--op getChangedFilesScope --project-root {{project_root}} --base main --scope committed"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/git-lib-reverse-merge"
+  assert:
+    - type: contains
+      value: '"feature.js"'
+    - type: not-contains
+      value: '"base-only.js"'
+
+- description: "git-lib: getChangedFiles 'worktree' scope still works against reverse-merge fixture (regression guard)"
+  vars:
+    script_path: "repo://tests/promptfoo/scripts/git-lib-test.js"
+    script_args: "--op getChangedFilesScope --project-root {{project_root}} --base main --scope worktree"
+    script_cwd: "{{project_root}}"
+    project_root: "file://fixtures-fs/git-lib-reverse-merge"
+  assert:
+    - type: contains
+      value: '"feature.js"'

--- a/tests/promptfoo/fixtures-fs/git-lib-reverse-merge/setup.sh
+++ b/tests/promptfoo/fixtures-fs/git-lib-reverse-merge/setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Fixture for git-lib-exec.yaml — issue #364 reverse-merge test.
+# Builds a repo where `main` advanced after the feature branch forked, so that
+# two-dot (`main..HEAD`) reports zero base-only files but three-dot (`main...HEAD`)
+# correctly limits the diff to branch-contributed files only.
+#
+# History after setup (HEAD = feature):
+#
+#   * (main)    add base-only.js          <- after fork
+#   |
+#   | * (HEAD, feature) add feature.js
+#   |/
+#   * init seed.txt                       <- merge-base
+#
+# Expected behavior:
+#   getChangedFiles('main', repo, 'all')       -> ['feature.js']           (three-dot, post-fix)
+#   getChangedFiles('main', repo, 'committed') -> ['feature.js']           (three-dot, baseline)
+#   Pre-fix 'all' would emit `git diff --cached --name-only main`, which is
+#   wrong-direction (compares index to main) and leaks `base-only.js` because
+#   it is present on `main` but not in feature's index.
+set -e
+git init --quiet -b main
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Common ancestor — merge-base for both branches.
+echo "seed" > seed.txt
+git add seed.txt
+git commit --quiet -m "init"
+
+# Create feature branch off the seed commit; add feature.js.
+git checkout --quiet -b feature
+echo "feature" > feature.js
+git add feature.js
+git commit --quiet -m "feat: add feature.js"
+
+# Switch back to main and advance it with base-only.js (the reverse-merge scenario).
+git checkout --quiet main
+echo "base-only" > base-only.js
+git add base-only.js
+git commit --quiet -m "chore: add base-only.js on main"
+
+# Leave HEAD on feature so getChangedFiles sees the branch-contribution diff.
+git checkout --quiet feature

--- a/tests/promptfoo/scripts/git-lib-test.js
+++ b/tests/promptfoo/scripts/git-lib-test.js
@@ -11,12 +11,15 @@
  *                        [--scope <name-only|stat|content|cached>] [--no-throw-check]
  *
  * Operations:
- *   exports        — prints which helpers are exported (presence-only check)
- *   fetchBaseRef   — invokes fetchBaseRef(base, projectRoot); prints {ok:true} when no exception
- *                    (best-effort by contract — never throws, even when origin missing/unreachable)
- *   buildDiffCmd   — invokes buildBranchContribDiffCmd(scope, base) and prints the resulting
- *                    git command string. Used to assert 3-dot semantics for branch-contribution
- *                    scopes (committed/stat/content) — issue #239.
+ *   exports             — prints which helpers are exported (presence-only check)
+ *   fetchBaseRef        — invokes fetchBaseRef(base, projectRoot); prints {ok:true} when no exception
+ *                         (best-effort by contract — never throws, even when origin missing/unreachable)
+ *   buildDiffCmd        — invokes buildBranchContribDiffCmd(scope, base) and prints the resulting
+ *                         git command string. Used to assert 3-dot semantics for branch-contribution
+ *                         scopes (committed/stat/content) — issue #239.
+ *   getChangedFilesScope — invokes getChangedFiles(base, projectRoot, scope) against a fixture repo
+ *                         and prints {scope, base, files}. Used to assert default 'all' scope routes
+ *                         through buildBranchContribDiffCmd (three-dot) — issue #364.
  */
 'use strict';
 
@@ -85,6 +88,24 @@ switch (op) {
     }
     const cmd = lib.buildBranchContribDiffCmd(scope, base);
     console.log(JSON.stringify({ scope, base, cmd }, null, 2));
+    break;
+  }
+
+  case 'getChangedFilesScope': {
+    if (!projectRoot) {
+      console.error('--project-root required for getChangedFilesScope');
+      process.exit(1);
+    }
+    if (!scope) {
+      console.error('--scope required for getChangedFilesScope (all|committed|staged|working|worktree)');
+      process.exit(1);
+    }
+    if (typeof lib.getChangedFiles !== 'function') {
+      console.error('getChangedFiles is not exported');
+      process.exit(1);
+    }
+    const files = lib.getChangedFiles(base, projectRoot, scope);
+    console.log(JSON.stringify({ scope, base, files }, null, 2));
     break;
   }
 


### PR DESCRIPTION
## Summary
Fixes two issues: `review-sdlc`'s default "all" scope was using a two-dot diff, causing false-positive critical findings on branches where main received commits after the fork point. Also adds a PreToolUse hook that blocks Agent dispatches with `isolation: "worktree"` at the harness level to prevent code changes landing in ephemeral worktree paths.

## Business Context
Developers using `review-sdlc` without explicit scope flags were receiving spurious critical review findings — changes present only on the base branch (not the feature branch) were appearing in the per-dimension diff. This eroded trust in automated code review output and required manual filtering to distinguish real findings from noise.

## Business Benefits
- `review-sdlc` default invocations now produce accurate, branch-contribution-only diffs — eliminating false-positive findings
- Agent dispatches with `isolation: "worktree"` are blocked at harness level, preventing a class of code-placement bugs that caused changes to land in wrong worktree paths
- Both fixes are enforced structurally (git diff semantics, PreToolUse hook) rather than relying on prose-level instructions

## Github Issue
- Fixes #364 (review-sdlc false-positive findings from two-dot diff)

## Technical Design
**#364 — Three-dot diff for default "all" scope:**
Both `getChangedFiles` (git.js) and `fetchAndSplitDiff` (review.js) had a `default` case that used `git diff --cached --name-only <base>` (two-dot). On branches where `main` advanced after the fork, this caused base-branch-only files to appear in the diff. Routed the `default` case through `buildBranchContribDiffCmd` — the same helper used by the `'committed'` scope since issue #239 — completing that fix for the default review path.


## Technical Impact
- `git.js` `getChangedFiles` default case: switches from `git diff --cached --name-only <base>` to `buildBranchContribDiffCmd('committed', base)` — any caller using scope "all" (the default) now gets three-dot semantics
- `review.js` `fetchAndSplitDiff` default case: same change to `buildBranchContribDiffCmd('content', base)`
- New `.claude/settings.json` with PreToolUse hook — applies to all Agent dispatches in this repo
- No breaking changes to public skill interfaces or plugin manifests

## Changes Overview
- Fixed default "all" scope in changed-files calculation to use three-dot (branch-contribution) diff, consistent with the "committed" scope
- Fixed default "all" scope in diff content splitting to use three-dot diff, eliminating base-branch noise from review dimensions
- Added PreToolUse hook that blocks Agent dispatches with `isolation: "worktree"` and prints a diagnostic pointing to the correct SDLC worktree mechanism
- Added promptfoo exec test fixture (`git-lib-reverse-merge`) that constructs a repo where main advanced after fork, asserting "all" and "committed" scopes produce identical file lists and exclude base-only files
- Extended `git-lib-test.js` with a `getChangedFilesScope` operation to enable per-scope assertion against the fixture

## Testing
- Added promptfoo exec test cases in `git-lib-exec.yaml` covering three scenarios against the reverse-merge fixture: "all" scope excludes base-only files, "committed" scope excludes base-only files (parity check), and "worktree" scope still includes feature files (regression guard)
- Fixture `setup.sh` builds a deterministic git history: seed commit → feature branch adds `feature.js` → main advances with `base-only.js` → HEAD left on feature
- The hook is tested implicitly: any Agent dispatch with `isolation: "worktree"` will exit 1 during harness execution