### PR TITLE
feat(#386): jira-sdlc - add Test Case and Test Plan description templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.20.6] - 2026-05-15
+
+### Added
+- jira-sdlc: Test Case and Test Plan templates for QA workflows — Test Case supports Gherkin-based step definitions, Preconditions, and Expected Results; Test Plan includes Objective, Entry/Exit Criteria, and Scope partitioning (#386)
+
 ## [0.20.5] - 2026-05-14
 
 ### Fixed

--- a/docs/skills/jira-sdlc.md
+++ b/docs/skills/jira-sdlc.md
@@ -110,6 +110,8 @@ Default templates ship in `plugins/sdlc-utilities/skills/jira-sdlc/templates/` â
 - `Epic.md`
 - `Sub-task.md`
 - `Spike.md`
+- `Test Case.md`
+- `Test Plan.md`
 
 Project-level overrides live at `.claude/jira-templates/<IssueTypeName>.md`. File names must match Jira issue type names exactly (case-sensitive).
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/jira-sdlc/templates/Test Case.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/templates/Test Case.md
@@ -1,0 +1,35 @@
+## Preconditions
+
+- [System state or data that must exist before executing this test]
+- [User role, permissions, or account type required]
+- [Environment: staging / local / other]
+
+## Steps
+
+[Test steps written in Gherkin format. Use Scenario Outline with Examples table for
+parametric cases where the same flow is repeated with different inputs.]
+
+```gherkin
+Feature: <Feature Name>
+
+  Scenario: <Scenario name>
+    Given <precondition — the starting state>
+    When <action — what the user does>
+    Then <expected outcome — what the user observes>
+```
+
+## Expected Results
+
+- [Primary observable outcome — what the user or system should show]
+- [Secondary outcomes, if any]
+- [Negative assertion — what must NOT happen as a result of this action]
+
+## Test Data
+
+- [Specific data, accounts, configuration, or values required to execute this test]
+- [For Scenario Outline: describe the significance of each example row]
+
+## Notes
+
+[Edge cases to watch for, known limitations, dependencies on other test cases, or links
+to related bugs or requirements.]

--- a/plugins/sdlc-utilities/skills/jira-sdlc/templates/Test Plan.md
+++ b/plugins/sdlc-utilities/skills/jira-sdlc/templates/Test Plan.md
@@ -1,0 +1,45 @@
+## Objective
+
+[1-3 sentences describing what is being validated and why. Focus on the user-facing behavior
+or business outcome being tested, not the implementation details.]
+
+## Scope
+
+### In Scope
+
+- [Feature area or user flow covered by this test plan]
+- [Acceptance criteria or requirement being verified]
+
+### Out of Scope
+
+- [Items explicitly excluded — deferred to another plan or out of bounds for this cycle]
+
+## Test Types
+
+| Type       | Count | Notes                                                |
+| ---------- | ----- | ---------------------------------------------------- |
+| Smoke      | N     | Critical happy paths; must pass before wider testing |
+| Regression | N     | Full automated suite                                 |
+| Manual     | N     | Exploratory, visual, or low-automation-ROI flows     |
+
+## Entry Criteria
+
+- [ ] Implementation complete and deployed to test environment
+- [ ] Test data available and accessible
+
+## Exit Criteria
+
+- [ ] All high-priority test cases passed
+- [ ] All smoke scenarios green
+- [ ] No open P1/P2 defects
+- [ ] QA sign-off obtained
+
+## Risks and Mitigations
+
+| Risk                                       | Mitigation                                  |
+| ------------------------------------------ | ------------------------------------------- |
+| [Potential issue that could block testing] | [How it will be addressed or worked around] |
+
+## Notes
+
+[Known limitations, external dependencies, deferred items, or cross-references to related plans.]

--- a/tests/promptfoo/datasets/jira-sdlc-exec.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc-exec.yaml
@@ -226,6 +226,10 @@
       value: '"Whim"'
     - type: icontains
       value: '"Sub-task": "default"'
+    - type: icontains
+      value: '"Test Case": "default"'
+    - type: icontains
+      value: '"Test Plan": "default"'
 
 - description: "jira-prepare: --check surfaces templates.fallbacks for unmapped subtask variants"
   vars:

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -1,6 +1,7 @@
 # Fixture appropriateness:
 #   jira-ticket-created            -- CORRECT: simulates a created Jira ticket, triggers workflow continuation
 #   jira-create-task               -- CORRECT: simulates Jira cache with project metadata for create operation
+#   jira-create-test-types         -- CORRECT: simulates Jira cache with Test Case / Test Plan issue types for template rendering
 #   jira-comment-adf               -- CORRECT: simulates Jira cache for comment operation with ADF conversion
 #   jira-multi-project-closed-list -- CORRECT: simulates jira.projects in config to trigger closed-list prompt
 #   jira-unsampled-transition      -- CORRECT: simulates cache with workflows[Type].unsampled=true to force live fallback
@@ -66,6 +67,76 @@
         contentFormat: "markdown" and the cloudId from cache. It does NOT fabricate
         fields not present in the cache (no components, no custom fields unless the
         user asked). The summary matches what the user requested exactly.
+
+- description: "jira-sdlc: renders Test Case template (Gherkin steps) on createJiraIssue"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-test-types.md"
+    user_request: >
+      Run /jira-sdlc. Create a Test Case in PROJ with summary "Verify login with
+      valid credentials". The Jira cache is loaded in the project context and the
+      shipped Test Case template applies (no override). Walk through the
+      createJiraIssue payload you would dispatch — show the resolved description
+      that will be sent.
+  assert:
+    # Must resolve the Test Case template (R18) — section anchors from templates/Test Case.md
+    - type: icontains
+      value: "Preconditions"
+    - type: icontains
+      value: "Steps"
+    - type: icontains
+      value: "Expected Results"
+    # Must include the Gherkin block from the shipped template
+    - type: regex
+      value: "(gherkin|Given|When|Then)"
+    # Must not fabricate a free-form description that ignores the template
+    - type: not-regex
+      value: "free.?form|free.?text|unstructured description"
+    # Behavioral: shipped Test Case template is read and applied verbatim
+    - type: llm-rubric
+      value: >
+        The response resolves the shipped `Test Case.md` template (no project override)
+        and renders its structural sections — Preconditions, Steps (with a Gherkin
+        Given/When/Then block), Expected Results, Test Data, Notes — into the
+        createJiraIssue description payload. The template content is treated as
+        the source of structure (R18); the skill does NOT invent a free-form
+        description or omit shipped sections. Placeholders left unresolved are
+        flagged or filled, never silently dropped.
+
+- description: "jira-sdlc: renders Test Plan template (Objective / Entry / Exit Criteria) on createJiraIssue"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/jira-sdlc/SKILL.md"
+    project_context: "file://fixtures/jira-create-test-types.md"
+    user_request: >
+      Run /jira-sdlc. Create a Test Plan in PROJ with summary "Q2 release
+      regression plan". The Jira cache is loaded in the project context and the
+      shipped Test Plan template applies (no override). Walk through the
+      createJiraIssue payload you would dispatch — show the resolved description
+      that will be sent.
+  assert:
+    # Must resolve the Test Plan template (R18) — section anchors from templates/Test Plan.md
+    - type: icontains
+      value: "Objective"
+    - type: icontains
+      value: "Entry Criteria"
+    - type: icontains
+      value: "Exit Criteria"
+    # Must include scope partitioning from the shipped template
+    - type: regex
+      value: "(In Scope|Out of Scope|Scope)"
+    # Must not fabricate a free-form description that ignores the template
+    - type: not-regex
+      value: "free.?form|free.?text|unstructured description"
+    # Behavioral: shipped Test Plan template is read and applied verbatim
+    - type: llm-rubric
+      value: >
+        The response resolves the shipped `Test Plan.md` template (no project override)
+        and renders its structural sections — Objective, Scope (In Scope / Out of
+        Scope), Test Types, Entry Criteria, Exit Criteria, Risks and Mitigations,
+        Notes — into the createJiraIssue description payload. The template content
+        is treated as the source of structure (R18); the skill does NOT invent a
+        free-form description or omit shipped sections. Placeholders left
+        unresolved are flagged or filled, never silently dropped.
 
 - description: "jira-sdlc: converts comment to ADF before posting via addCommentToJiraIssue"
   vars:

--- a/tests/promptfoo/datasets/jira-sdlc.yaml
+++ b/tests/promptfoo/datasets/jira-sdlc.yaml
@@ -204,10 +204,10 @@
     project_context: "file://fixtures/jira-create-task.md"
     user_request: >
       Run /jira-sdlc. Create a Subtask in PROJ: "refactor cache layer". Note that
-      this skill ships templates only for Bug, Story, Task, Spike, and Epic — there
-      is no Subtask.md template, and no override is configured at
-      .claude/jira-templates/Subtask.md. Walk through how the skill resolves the
-      description template.
+      this skill ships templates only for Bug, Story, Task, Spike, Epic, Sub-task,
+      Test Case, and Test Plan — there is no Subtask.md template, and no override
+      is configured at .claude/jira-templates/Subtask.md. Walk through how the
+      skill resolves the description template.
   assert:
     # Must ask which template to use rather than fabricating a description
     - type: regex
@@ -220,7 +220,7 @@
       value: >
         The response recognizes that no Subtask template ships and no override
         exists, then prompts the user via AskUserQuestion with a closed list of
-        available templates (Bug, Story, Task, Spike, Epic) — never inventing a
+        available templates (Bug, Story, Task, Spike, Epic, Sub-task, Test Case, Test Plan) — never inventing a
         description and never proceeding with a free-form description. The skill
         treats the absence of a template as a user-resolution event (R18), not a
         silent fallback.

--- a/tests/promptfoo/fixtures-fs/jira-template-fallback/.sdlc-cache/jira/acme_atlassian_net/FALL.json
+++ b/tests/promptfoo/fixtures-fs/jira-template-fallback/.sdlc-cache/jira/acme_atlassian_net/FALL.json
@@ -12,7 +12,9 @@
     "Sub-bug": { "id": "10003", "subtask": true, "hierarchyLevel": -1 },
     "Sub-task": { "id": "10004", "subtask": true, "hierarchyLevel": -1 },
     "Subtask": { "id": "10005", "subtask": true, "hierarchyLevel": -1 },
-    "Whim": { "id": "10006", "subtask": false, "hierarchyLevel": 0 }
+    "Whim": { "id": "10006", "subtask": false, "hierarchyLevel": 0 },
+    "Test Case": { "id": "10007", "subtask": false, "hierarchyLevel": 0 },
+    "Test Plan": { "id": "10008", "subtask": false, "hierarchyLevel": 0 }
   },
   "fieldSchemas": {
     "Bug": { "summary": { "required": true, "type": "string" } },
@@ -20,7 +22,9 @@
     "Sub-bug": { "summary": { "required": true, "type": "string" } },
     "Sub-task": { "summary": { "required": true, "type": "string" } },
     "Subtask": { "summary": { "required": true, "type": "string" } },
-    "Whim": { "summary": { "required": true, "type": "string" } }
+    "Whim": { "summary": { "required": true, "type": "string" } },
+    "Test Case": { "summary": { "required": true, "type": "string" } },
+    "Test Plan": { "summary": { "required": true, "type": "string" } }
   },
   "workflows": {
     "Bug": { "transitions": {} },

--- a/tests/promptfoo/fixtures/jira-create-test-types.md
+++ b/tests/promptfoo/fixtures/jira-create-test-types.md
@@ -1,0 +1,37 @@
+# Jira Project Context
+
+## Cache (from jira-prepare.js)
+```json
+{
+  "project": "PROJ",
+  "cloudId": "abc-123-def-456",
+  "issueTypes": ["Bug", "Story", "Task", "Sub-task", "Epic", "Test Case", "Test Plan"],
+  "fieldSchemas": {
+    "Test Case": {
+      "summary": { "required": true, "type": "string" },
+      "description": { "required": false, "type": "string" },
+      "labels": { "required": false, "type": "array" }
+    },
+    "Test Plan": {
+      "summary": { "required": true, "type": "string" },
+      "description": { "required": false, "type": "string" },
+      "labels": { "required": false, "type": "array" }
+    }
+  },
+  "workflows": {},
+  "linkTypes": [],
+  "userMappings": {}
+}
+```
+
+## Shipped templates available
+
+The jira-sdlc plugin ships default templates for these issue types under
+`plugins/sdlc-utilities/skills/jira-sdlc/templates/`:
+
+- `Bug.md`, `Story.md`, `Task.md`, `Spike.md`, `Epic.md`, `Sub-task.md`
+- `Test Case.md` — sections: Preconditions, Steps (Gherkin), Expected Results, Test Data, Notes
+- `Test Plan.md` — sections: Objective, Scope (In/Out), Test Types, Entry Criteria, Exit Criteria, Risks and Mitigations, Notes
+
+No project-level overrides exist at `.claude/jira-templates/` for these types,
+so the skill must resolve to the shipped defaults (R18).


### PR DESCRIPTION
## Summary

Adds two new Jira issue type description templates to jira-sdlc — Test Case and Test Plan — giving QA teams a structured starting point when creating these issue types in Jira. Two behavioral test cases and updated fixtures validate that the skill resolves and renders these templates correctly.

## Business Context

Teams using jira-sdlc for QA workflows previously had no structured template for Test Case or Test Plan issue types. Without a template, the skill would prompt users to choose from available templates (none matched), leading to unstructured descriptions or user confusion.

## Business Benefits

- QA engineers get Gherkin-ready test case structure (Preconditions, Steps, Expected Results, Test Data, Notes) auto-inserted when creating Test Case issues
- Test Plan issues receive a comprehensive planning skeleton (Objective, Scope, Test Types, Entry/Exit Criteria, Risks) without manual setup
- Reduces friction in QA workflows using Jira alongside the sdlc plugin

## Github Issue

Fixes #386

## Technical Design

Two markdown templates were added to the shipped default template set under `plugins/sdlc-utilities/skills/jira-sdlc/templates/`:

- **Test Case.md**: Structures test cases with Gherkin `Given/When/Then` steps, Preconditions, Expected Results, Test Data, and Notes sections
- **Test Plan.md**: Provides Objective, Scope (In/Out), Test Types table, Entry/Exit Criteria checklists, Risks and Mitigations table, and Notes

Both templates follow the same resolution path as existing templates (R18): shipped defaults apply when no project-level override exists at `.claude/jira-templates/<TypeName>.md`.

## Technical Impact

None — additive change only. No changes to skill interfaces, hook payloads, or script APIs. Existing issue type templates are unaffected.

## Changes Overview

- Two new Jira description templates added to the shipped default set: Test Case (Gherkin-based structure) and Test Plan (planning lifecycle structure)
- Template fallback fixture updated to include Test Case and Test Plan issue type metadata, enabling exec tests to verify template resolution
- Behavioral test cases added to validate that the skill renders shipped template sections without fabrication or omission
- Existing test fixture narrative updated to reflect the expanded set of shipped templates (Bug, Story, Task, Spike, Epic, Sub-task, Test Case, Test Plan)
- Documentation updated to list the two new templates in the shipped defaults reference
- CHANGELOG and plugin version bumped to v0.20.6

## Testing

Two behavioral test cases added to `tests/promptfoo/datasets/jira-sdlc.yaml`:
1. **Test Case rendering**: Asserts that the skill resolves `Test Case.md` and renders Preconditions, Steps (Gherkin), and Expected Results sections into the `createJiraIssue` description payload
2. **Test Plan rendering**: Asserts that the skill resolves `Test Plan.md` and renders Objective, Entry/Exit Criteria, and Scope (In/Out) sections into the description payload

Both use a dedicated fixture (`jira-create-test-types.md`) with cached Jira project metadata containing the new issue types. Exec test updated to assert `--check` surfaces both new templates as `"default"` fallbacks.