### PR TITLE
fix(#387): harden-sdlc - persist approved proposals immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.20.7] - 2026-05-15
+
+### Fixed
+- harden-sdlc: each approved proposal is now persisted to disk immediately after approval, before advancing to the next iteration (#387)
+
 ## [0.20.6] - 2026-05-15
 
 ### Added

--- a/docs/skills/harden-sdlc.md
+++ b/docs/skills/harden-sdlc.md
@@ -164,6 +164,8 @@ Failure → harden classifies → proposes surface edits → user approves → n
 
 > **Boundary.** harden-sdlc strengthens config surfaces only: `.sdlc/config.json` guardrails, `.sdlc/review-dimensions/*.md`, and `.github/instructions/*.instructions.md`. It does not patch plugin code. Plugin defects route to [`/error-report-sdlc`](error-report-sdlc.md).
 
+> **Per-iteration persistence (issue #387).** Each approved proposal is written to disk immediately before the next proposal is presented — changes are never accumulated across proposals. At the start of each iteration `targetFile` is re-read from disk, ensuring a prior write's state is always the base for the next change.
+
 ---
 
 ## Prerequisites

--- a/docs/specs/harden-sdlc.md
+++ b/docs/specs/harden-sdlc.md
@@ -44,6 +44,8 @@
   - Acceptance: SKILL.md Step 5 contains a `5c` sub-step gated on `RESULT.classification === 'ambiguous' && RESULT.errorReportPayload != null` that surfaces an `AskUserQuestion` with options `dispatch error-report-sdlc | skip`; on dispatch, the canonical Glob-then-follow path from Step 6 is reused.
 - R-orchestrator-ambig (issue #288): `harden-orchestrator` MUST populate `errorReportPayload` on `ambiguous` classification only when the rationale cites plugin evidence (script crash inside `plugins/sdlc-utilities/`, agent malformed JSON, prepare-script exit 2). Pure user-code ambiguity emits `errorReportPayload: null`.
   - Acceptance: orchestrator response-shape rules in `agents/harden-orchestrator.md` document that `ambiguous + errorReportPayload != null` is a valid combination and provide a JSON example; `ambiguous + errorReportPayload == null` remains valid for user-code ambiguity.
+- R-iteration-write (issue #387): For each proposal the user approves in Step 5, SKILL.md MUST persist the change to disk before presenting the next proposal. It MUST re-read `targetFile` from disk at the start of each iteration (not hold an in-memory copy from the previous write), and MUST NOT accumulate approved changes across proposals before writing. On validation or write failure for a proposal, iteration halts for that proposal — SKILL.md does not silently advance to the next proposal.
+  - Acceptance: SKILL.md Step 5 contains an explicit per-iteration preamble stating the four rules (re-read, write-before-advance, no-accumulation, halt-on-failure); 5a explicitly re-reads `targetFile` from disk; 5b explicitly writes before advancing; no code path exists where two approved proposals are held in memory simultaneously before writing.
 
 ## Workflow Phases
 
@@ -63,7 +65,7 @@
 - G1: Proposal coherence — every emitted proposal MUST cite a specific failure-signal element (a guardrail id, a dimension name, a copilot pattern, or a verbatim phrase from `failure.text`) in its `rationale`
 - G2: Surface coverage — when failure signal is non-empty, the orchestrator MUST evaluate every loaded surface (skip is acceptable but must be intentional, not omission)
 - G3: Classification accuracy — `classification` MUST match observable evidence; `plugin-defect` requires the failure to point at plugin code (script crash inside `plugins/sdlc-utilities/`, agent malformed JSON, prepare-script exit 2), not user-code or config. An `ambiguous` classification MAY carry a non-null `errorReportPayload` when the rationale cites plugin evidence (R-orchestrator-ambig); pure user-code ambiguity emits `errorReportPayload: null`.
-- G4: No-silent-write invariant — across all paths (success, cancel, agent crash, validation fail) the count of files written without an `apply` AskUserQuestion answer MUST be zero
+- G4: No-silent-write and no-silent-drop invariant — across all paths (success, cancel, agent crash, validation fail) the count of files written without an `apply` AskUserQuestion answer MUST be zero; additionally, the count of approved proposals that were not immediately persisted to disk (dropped silently by accumulation or cross-iteration merge) MUST also be zero
 
 ## Prepare Script Contract
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
@@ -146,7 +146,13 @@ failure signal does not point at any of the loaded surfaces.` and exit cleanly
 
 ---
 
-## Step 5 — PRESENT and APPLY (R7, R8, R10, R12, C9, C10)
+## Step 5 — PRESENT and APPLY (R7, R8, R10, R12, C9, C10, R-iteration-write)
+
+**Per-iteration contract (R-iteration-write, issue #387) — applies to every pass through the proposal loop:**
+1. **Re-read before acting:** At the start of each iteration, re-read `targetFile` from disk. Never rely on an in-memory copy from a previous write.
+2. **Write before advancing:** Persist the approved change to disk (via Edit/Write) before presenting the next proposal. Do not accumulate approved changes across proposals and write them together.
+3. **No cross-proposal accumulation:** Hold only the current proposal's patch in memory. Clear per-proposal state after each write.
+4. **Halt on failure:** If validation or the write itself fails for a proposal, do not silently advance to the next proposal — halt iteration for this proposal and surface the error per 5a.
 
 For each proposal in `RESULT.proposals`, present the full patch preview to the
 user. Then use `AskUserQuestion`:
@@ -169,7 +175,9 @@ Options: **apply** | **skip** | **cancel**
 - **cancel** — abort the entire skill (no further proposals processed); the
   trap cleans up the manifest
 
-### 5a. Validate Before Write (R12)
+### 5a. Validate Before Write (R12, R-iteration-write)
+
+**Re-read `targetFile` from disk now** (implements R-iteration-write rule 1) — do not use any in-memory state from a prior iteration.
 
 When the user selects **apply**, validate the proposed change BEFORE writing:
 
@@ -196,7 +204,9 @@ When the user selects **apply**, validate the proposed change BEFORE writing:
 - For `surface == "copilot-instructions"`: no schema — apply the edit directly
   after the user's `apply` answer.
 
-### 5b. Write After Validation Passes
+### 5b. Write After Validation Passes (R-iteration-write)
+
+**Write to disk now, before advancing to the next proposal** (implements R-iteration-write rule 2). Do not proceed to the next AskUserQuestion until this proposal's change has been persisted.
 
 Use Edit (preferred) or Write to apply the approved, validated change to
 `proposal.targetFile`. Display a one-line confirmation:
@@ -295,6 +305,9 @@ the `.sdlc/learnings/` directory and `log.md` file if they don't exist.
 
 - Edit any surface without an `apply` AskUserQuestion answer recorded for that
   specific proposal — the no-silent-write invariant is non-negotiable.
+- Accumulate approved changes across multiple proposals and write them together
+  — each approved proposal MUST be written to disk immediately before advancing
+  to the next proposal (R-iteration-write, issue #387).
 - Propose relaxing or removing existing rules — v1 is strengthen-only.
 - Run full-suite or wide-subset `promptfoo eval` automatically — single targeted test scoped to the change is allowed; tight-loop retries are not.
 - Invoke `error-report-sdlc` for `user-code` classifications — only the

--- a/tests/promptfoo/datasets/harden-sdlc.yaml
+++ b/tests/promptfoo/datasets/harden-sdlc.yaml
@@ -42,6 +42,9 @@
         gates each proposal behind AskUserQuestion (apply | skip | cancel) and
         validates schema before write via ci/validate-guardrails.js. It does NOT
         propose relaxing or removing any existing rule.
+    # Per-iteration persistence: structural check for write-before-advancing wording
+    - type: regex
+      value: "(write.*before.*advanc|before.*next.*proposal|re.read.*disk|disk.*before.*advanc|persist.*before.*next|not.*batch|no.*batch.*accum)"
     # Per-iteration persistence: each approved proposal must be written immediately
     - type: llm-rubric
       value: >
@@ -230,6 +233,34 @@
       value: "(\\.claude/sdlc\\.json|sdlc\\.json.*write|apply.*proposal 1)"
     - type: not-regex
       value: "(both.*written|all.*proposals.*applied|skip.*also.*written)"
+
+- description: "harden-sdlc: two proposals both applied → write-before-advancing and no accumulation (R-iteration-write rules 2 and 3)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md"
+    project_context: "file://fixtures/harden-plan-guardrail-failure-context.md"
+    user_request: >
+      Two proposals are presented and the user selects "apply" for both.
+      Describe the order of operations Step 5 follows: when is each approved
+      change written to disk relative to presenting the next proposal? Does the
+      skill accumulate both approved patches and write them together at the end,
+      or does it write each one individually before moving on?
+  assert:
+    # Must write each proposal before advancing to the next (rule 2)
+    - type: regex
+      value: "(write.*before.*next|persist.*before.*advanc|written.*before.*present|disk.*before.*next|after.*write.*proposal.*1.*present.*proposal.*2)"
+    # Must NOT accumulate and batch-write
+    - type: not-regex
+      value: "(accum.*both|batch.*write|collect.*then.*write|write.*together.*end|all.*at.*once)"
+    # Behavioral: correct two-proposal iteration sequence
+    - type: llm-rubric
+      value: >
+        The response describes a per-iteration sequence: present proposal 1,
+        user applies, validate, write to disk immediately, THEN present proposal 2.
+        It does NOT describe collecting both approvals and writing them together
+        after the loop. It explicitly states (or clearly implies) that proposal 1
+        is persisted to disk before proposal 2 is presented to the user,
+        satisfying R-iteration-write rules 2 (write-before-advancing) and
+        3 (no cross-proposal accumulation).
 
 - description: "harden-sdlc: strengthen-only invariant — no relax/remove proposals"
   vars:

--- a/tests/promptfoo/datasets/harden-sdlc.yaml
+++ b/tests/promptfoo/datasets/harden-sdlc.yaml
@@ -42,6 +42,14 @@
         gates each proposal behind AskUserQuestion (apply | skip | cancel) and
         validates schema before write via ci/validate-guardrails.js. It does NOT
         propose relaxing or removing any existing rule.
+    # Per-iteration persistence: each approved proposal must be written immediately
+    - type: llm-rubric
+      value: >
+        The response describes Step 5 re-reading targetFile from disk at the start
+        of each proposal iteration (not using an in-memory copy from a prior write)
+        and writing the approved change to disk before advancing to the next
+        proposal. It does NOT describe accumulating multiple approved changes and
+        writing them together in a batch at the end.
 
 - description: "harden-sdlc: dimension-blocker rationale → proposes review-dimensions strengthening with dimension severity vocabulary"
   vars:


### PR DESCRIPTION
## Summary
Fixes a bug in the harden-sdlc skill where multiple approved proposals could be accumulated in memory and written together at the end of a session, rather than each being persisted to disk immediately after approval. This ensures users never lose approved changes if a session ends mid-iteration.

## Business Context
Users of harden-sdlc could approve multiple hardening proposals in a single session and then lose earlier approvals if the session crashed or was interrupted before the batch write completed. The skill's promise of "apply" meaning "written now" was not being upheld across iterations.

## Business Benefits
- Approved hardening proposals are now durable immediately — no risk of data loss on crash or interruption between proposals
- Users have a reliable guarantee: each "apply" is persisted before the next proposal is shown
- The invariant is now formally specified, documented, and tested

## Github Issue
Fixes #387

## Technical Design
Added a new spec requirement `R-iteration-write` to `docs/specs/harden-sdlc.md` that mandates four rules: re-read `targetFile` from disk at the start of each iteration, write before advancing, no cross-proposal accumulation, and halt-on-failure rather than silent advance. The SKILL.md Step 5 was updated with an explicit per-iteration contract preamble and sub-step headers reinforcing each rule. The "DO NOT" section gains an explicit prohibition on accumulating approved changes.

## Technical Impact
None — no breaking changes to plugin manifests, skill interfaces, hook payloads, or script APIs. The change is a behavioral tightening of the iteration loop within harden-sdlc Step 5.

## Changes Overview
- Spec: added `R-iteration-write` requirement with four rules (re-read, write-before-advance, no-accumulation, halt-on-failure) and extended `G4` invariant to cover silent drops
- SKILL.md: Step 5 gets an explicit per-iteration contract preamble; sub-steps 5a and 5b gain rule-reinforcing language; "DO NOT" section prohibits accumulation
- Reference docs: added a callout block documenting the per-iteration persistence guarantee for users
- Tests: structural regex assertion for write-before-advancing wording added to existing test; new two-proposal scenario test case validates correct iteration sequencing

## Testing
Behavioral tests extended in `tests/promptfoo/datasets/harden-sdlc.yaml`:
- Structural regex assertion checks that Step 5 description contains write-before-advancing language
- New test case presents a two-proposal scenario and asserts the correct per-iteration sequence (write proposal 1, then present proposal 2) — verified against the updated SKILL.md