### PR TITLE
docs(#341): dimension scoping - plan guardrails authoring guides

### DIFF
--- a/docs/skills/execute-guardrails-best-practices.md
+++ b/docs/skills/execute-guardrails-best-practices.md
@@ -131,4 +131,5 @@ Only `warning`-severity guardrails are non-blocking under `--auto`. They are rep
 
 - [execute-plan-sdlc](execute-plan-sdlc.md) — Guardrail Enforcement section documents the loading, pre-wave, and post-wave evaluation stages
 - [plan-sdlc](plan-sdlc.md) — plan guardrails (`plan.guardrails[]`) evaluated at planning time
+- [plan-guardrails-best-practices](plan-guardrails-best-practices.md) — how to write evaluable plan guardrails for the planning-time critique gate
 - [setup-sdlc](setup-sdlc.md) — run with `--execution-guardrails` for interactive configuration of `execute.guardrails[]`

--- a/docs/skills/plan-guardrails-best-practices.md
+++ b/docs/skills/plan-guardrails-best-practices.md
@@ -1,0 +1,103 @@
+# Plan Guardrails — Authoring Best Practices
+
+## Overview
+
+Plan guardrails are natural-language rules evaluated by `plan-sdlc` at the Step 3 critique gate. They are configured under `plan.guardrails` in `.sdlc/config.json`. Each guardrail's `description` field is evaluated by the critique LLM against the plan text — if the plan violates the rule, the gate blocks (`error`) or warns (`warning`) before execution begins.
+
+---
+
+## Anatomy of an evaluable guardrail
+
+Three properties separate a guardrail that produces signal from one that produces noise:
+
+- **Specific** — names concrete files, paths, or behaviors. "Do not modify `src/auth/`" is evaluable. "Write good code" is not.
+- **Testable against plan text** — the critique LLM reads the plan document, not the runtime. It cannot evaluate test results, performance numbers, or future behavior — only what the plan explicitly says.
+- **Severity-justified** — `error` reserves for outcomes that are wrong regardless of context. `warning` is for conventions where exceptions are legitimate.
+
+---
+
+## Severity selection rubric
+
+| Severity | When to use | Effect |
+|---|---|---|
+| `error` | Violating this guardrail causes a bad outcome regardless of context — wrong scope, wrong files, missing safety step. | Blocks the plan; user must override or fix before execution. |
+| `warning` | Important convention, but exceptions legitimately exist (style preferences, soft norms). | Advisory only; plan proceeds. |
+
+Default when `severity` is absent: `error`.
+
+---
+
+## Worked scenarios — bad vs good
+
+### A. "Don't touch auth code in unrelated tasks"
+
+**Bad:** `"Avoid auth changes"` — vague; the LLM cannot determine what "avoid" means or which files constitute "auth".
+
+**Good:**
+
+```json
+{
+  "id": "auth-scope-guard",
+  "description": "Plan must not modify files under src/auth/ unless the user request explicitly references authentication",
+  "severity": "error"
+}
+```
+
+### B. "Migration tasks should not add new features"
+
+**Bad:** `"Keep migrations clean"` — no file anchor, no behavioral constraint the plan text can be evaluated against.
+
+**Good:**
+
+```json
+{
+  "id": "migration-no-new-api",
+  "description": "If the plan title mentions migration or refactor, no new public API surface (new exported functions, new endpoints) may be introduced",
+  "severity": "error"
+}
+```
+
+### C. "DB schema changes need an explicit rollback step"
+
+**Bad:** `"Be careful with schema changes"` — not evaluable; "careful" has no definition in plan text.
+
+**Good:**
+
+```json
+{
+  "id": "schema-rollback-required",
+  "description": "Any plan task touching prisma/schema.prisma or *.sql must include a rollback or down-migration sub-task",
+  "severity": "warning"
+}
+```
+
+### D. "Stay within the requested package"
+
+**Bad:** `"Don't change unrelated packages"` — "unrelated" requires runtime inference; the critique gate only sees the plan document.
+
+**Good:**
+
+```json
+{
+  "id": "package-scope-guard",
+  "description": "Plan must not modify files outside the package directory named in the original user request",
+  "severity": "error"
+}
+```
+
+---
+
+## Anti-patterns
+
+**Process guardrails** — rules like `"write good code"` or `"follow best practices"` give the critique LLM no plan-text signal to evaluate. Every plan trivially satisfies them; they produce no blocking behavior and no useful signal.
+
+**Tautologies** — `"plan should implement what was asked"` is always true by definition. It will never block a plan, so it serves no purpose in the guardrail list.
+
+**Unverifiable-from-plan** — guardrails about runtime behavior, test outcomes, or performance numbers cannot be evaluated at plan-critique time. The plan document does not contain that information. Example of what not to write: `"Implementation must not regress p95 latency above 200ms"`. The critique gate cannot evaluate this; it will either always pass or always fail depending on how the LLM interprets the ambiguity.
+
+---
+
+## See Also
+
+- [`plan-sdlc.md`](plan-sdlc.md) — the skill that evaluates these guardrails at the Step 3 critique gate
+- [`execute-guardrails-best-practices.md`](execute-guardrails-best-practices.md) — the sibling concept for execution-time guardrails (`execute.guardrails` in `.sdlc/config.json`)

--- a/docs/skills/plan-sdlc.md
+++ b/docs/skills/plan-sdlc.md
@@ -247,3 +247,4 @@ Before declaring the plan ready (Step 7 handoff), the skill pipes the finalized 
 
 - [`/execute-plan-sdlc`](execute-plan-sdlc.md) — executes the plans this skill produces
 - [`/review-sdlc`](review-sdlc.md) — review changes after plan execution
+- [Guardrails authoring best practices](plan-guardrails-best-practices.md) — how to write evaluable plan guardrails

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -146,6 +146,52 @@ triggers:
 
 When `model:` is absent, the orchestrator falls back to `manifest.subagent_model` (default: `sonnet`).
 
+> For guidance on writing effective `triggers` and `skip-when` patterns, see [Dimension scoping best practices](#dimension-scoping-best-practices) below.
+
+---
+
+### Dimension scoping best practices
+
+Narrow `triggers` keep reviewer subagents focused on the files they are qualified to evaluate. Broad globs hand every changed file to every dimension — cost scales roughly with `dimensions × changed_files`. A 40-file PR reviewed by 5 dimensions with `triggers: ["**/*"]` sends ~200 file-reads to subagents; the same PR with each dimension scoped to its real surface sends ~40 (~5× reduction). Token savings compound on large PRs where most changed files are irrelevant to most dimensions.
+
+#### How matching works
+
+`scripts/skill/review.js::matchFiles` (around L176–L188) intersects the `triggers` glob list against the changed-file set, then subtracts any files matched by `skip-when`. The resulting per-dimension `matched_files` array is the only context the reviewer subagent sees — it does not receive the full diff unless `requires-full-diff: true` is set. There is no implicit fallback: an empty `triggers` list matches zero files and the dimension is reported `SKIPPED`. When a dimension matches more than 80% of changed files, the plan-critique step flags it as `over_broad_dimensions` (around `review.js:599`) — the existing automated signal for this anti-pattern.
+
+#### Glob → dimension examples
+
+| `triggers` | Dimension | Why scoped this way |
+|---|---|---|
+| `**/*.test.{ts,js}` | `test-quality` | Assertions, isolation, coverage — only meaningful on test files |
+| `scripts/**` | `script-conventions` | Exit codes, error handling, Node patterns — irrelevant for app code |
+| `**/*.{yaml,yml}` | `config-schema` | Required fields, type correctness, env references |
+| `plugins/**/SKILL.md` | `skill-authoring` | Skill format, required sections — only valid on SKILL.md files |
+
+Use `skip-when` to carve out sub-paths you do not want reviewed by a broad trigger:
+
+```yaml
+triggers:
+  - "src/**/*.ts"
+skip-when:
+  - "**/*.test.ts"
+  - "**/__generated__/**"
+```
+
+This sends only non-test, non-generated TypeScript files to the dimension — a meaningful reduction on projects that co-locate tests and source.
+
+#### Anti-pattern: the catch-all dimension
+
+Do not author a "general code review" dimension with `triggers: ["**/*"]` and no `skip-when`. Every changed file — config, docs, generated code, test fixtures — is dispatched to that subagent on every review. The cost is `files × dimensions`; the signal is low because the reviewer wastes attention on files unrelated to its stated purpose. The `plan_critique.over_broad_dimensions` warning is the automated detection for this pattern.
+
+#### Migrating from a broad dimension
+
+1. Run `/review-sdlc --dry-run` on a recent PR and inspect which files the broad dimension matched. Look for natural clusters (auth code, migration files, config, tests).
+2. Author one focused dimension per cluster with explicit `triggers`, adding `skip-when` to exclude tests or generated artifacts where appropriate.
+
+Avoid relying on `max-files` truncation as a substitute for scoping — truncation silently drops the tail of the match list, so some files are never reviewed rather than being reviewed by a qualified dimension.
+
+For canonical `triggers:` blocks and complete dimension examples, see [`EXAMPLES.md`](../../plugins/sdlc-utilities/skills/review-sdlc/EXAMPLES.md).
+
 ---
 
 ## Consolidated Comment Format

--- a/docs/skills/review-sdlc.md
+++ b/docs/skills/review-sdlc.md
@@ -156,7 +156,7 @@ Narrow `triggers` keep reviewer subagents focused on the files they are qualifie
 
 #### How matching works
 
-`scripts/skill/review.js::matchFiles` (around L176–L188) intersects the `triggers` glob list against the changed-file set, then subtracts any files matched by `skip-when`. The resulting per-dimension `matched_files` array is the only context the reviewer subagent sees — it does not receive the full diff unless `requires-full-diff: true` is set. There is no implicit fallback: an empty `triggers` list matches zero files and the dimension is reported `SKIPPED`. When a dimension matches more than 80% of changed files, the plan-critique step flags it as `over_broad_dimensions` (around `review.js:599`) — the existing automated signal for this anti-pattern.
+`scripts/skill/review.js::matchFiles` (around L176–L188) intersects the `triggers` glob list against the changed-file set, then subtracts any files matched by `skip-when`. The resulting per-dimension `matched_files` array is the only context the reviewer subagent sees — it does not receive the full diff unless `requires-full-diff: true` is set. There is no implicit fallback: an empty `triggers` list matches zero files and the dimension is reported `SKIPPED`. When a dimension matches more than 80% of changed files, the plan-critique step flags it as `over_broad_dimensions` (around `review.js:291` in `critiquePlan`) — the existing automated signal for this anti-pattern.
 
 #### Glob → dimension examples
 


### PR DESCRIPTION
## Summary

Adds two documentation guides to the skills reference: a best-practices guide for authoring plan guardrails (`plan.guardrails[]`) and a dimension scoping best-practices subsection for `review-sdlc`. Adds reciprocal cross-links between all affected skill docs so the guides are discoverable from their entry points.

## JIRA Ticket

Not detected

## Business Context

N/A — pure internal developer tooling documentation with no customer-facing business dimension.

## Business Benefits

N/A — pure internal tooling documentation.

## Technical Design

Two new reference artifacts:

1. **plan-guardrails-best-practices.md** — a standalone guide covering: anatomy of an evaluable guardrail (specific, testable, severity-justified), a severity rubric, four worked bad-vs-good scenarios, and an anti-patterns section. Designed to be linked from `plan-sdlc.md` and `execute-guardrails-best-practices.md`.

2. **Dimension scoping best practices subsection in review-sdlc.md** — explains how `triggers`/`skip-when` matching works (references `review.js::matchFiles` around L176–L188 and `critiquePlan` around L291), provides a glob-to-dimension examples table, documents the catch-all anti-pattern, and provides a migration path from broad dimensions to focused ones.

Cross-links added: `plan-sdlc.md` → new guide, `execute-guardrails-best-practices.md` → new guide (reciprocal link).

## Technical Impact

Documentation only — no behavior changes to any skill, script, or hook. No breaking changes or migration requirements.

## Changes Overview

- New guardrail authoring guide covering specificity rules, severity selection, worked bad-vs-good examples, and anti-patterns for `plan.guardrails[]` configuration
- New dimension scoping subsection in review-sdlc reference explaining `triggers`/`skip-when` matching mechanics, cost implications, glob examples, and migration guidance
- Reciprocal cross-links added between `plan-sdlc.md`, `execute-guardrails-best-practices.md`, and the new guardrails guide so both entry points lead to the authoring reference
- Forward reference added at the top of the dimension scoping section in `review-sdlc.md` to anchor discovery

## Testing

Documentation-only changes. No behavioral code modified; no automated tests applicable. Content verified against the referenced source locations (`review.js::matchFiles` ~L176–L188, `critiquePlan` ~L291) and cross-checked against existing skill docs for consistency.

Closes #341
Closes #342