### PR TITLE
fix(#382): agent-isolation-guard - block mode instead of deny permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.20.17] - 2026-05-20
+
+### Fixed
+- agent-isolation-guard: use block mode (`continue: false` + `stopReason`) instead of `permissionDecision: deny`; remove redundant `reason` key from emitted block response (#382)
+
 ## [0.20.16] - 2026-05-20
 
 ### Added

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.20.16",
+  "version": "0.20.17",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js
+++ b/plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js
@@ -45,7 +45,7 @@ function emitContinue() {
 
 function emitBlock(reason) {
   process.stderr.write(reason + '\n');
-  process.stdout.write(JSON.stringify({ continue: false, stopReason: reason, decision: 'block', reason }));
+  process.stdout.write(JSON.stringify({ continue: false, stopReason: reason, decision: 'block' }));
   process.exit(2);
 }
 

--- a/plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js
+++ b/plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js
@@ -8,8 +8,9 @@
  *   { tool_name, tool_input, ... }
  *
  * When tool_name === 'Agent' and tool_input.isolation === 'worktree',
- * emits a permissionDecision: 'deny' response — unless the developer has
- * opted out via .sdlc/local.json hooks.agentIsolationGuard.enabled: false.
+ * emits a blocking response (continue: false, stopReason, exit 2) that binds
+ * under mode: bypassPermissions — unless the developer has opted out via
+ * .sdlc/local.json hooks.agentIsolationGuard.enabled: false.
  *
  * Rationale: SDLC manages worktrees via util/worktree-create.js (git CLI).
  * The Agent SDK's isolation: "worktree" creates ephemeral worktrees at
@@ -42,14 +43,10 @@ function emitContinue() {
   process.stdout.write(JSON.stringify({ continue: true }));
 }
 
-function emitDeny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: reason,
-    },
-  }));
+function emitBlock(reason) {
+  process.stderr.write(reason + '\n');
+  process.stdout.write(JSON.stringify({ continue: false, stopReason: reason, decision: 'block', reason }));
+  process.exit(2);
 }
 
 /**
@@ -106,7 +103,7 @@ async function main() {
     return emitContinue();
   }
 
-  return emitDeny(
+  return emitBlock(
     'BLOCKED: isolation: "worktree" is forbidden on Agent dispatch. ' +
     'SDLC worktrees are managed by util/worktree-create.js (git CLI). ' +
     'Adding isolation: "worktree" here creates .claude/worktrees/agent-<id> ephemeral paths ' +

--- a/tests/promptfoo/datasets/agent-isolation-guard-exec.yaml
+++ b/tests/promptfoo/datasets/agent-isolation-guard-exec.yaml
@@ -1,8 +1,8 @@
 # Script execution tests for hooks/pre-tool-agent-isolation-guard.js.
-# Validates: deny on isolation:"worktree", continue otherwise, config opt-out, malformed-json fail-closed.
+# Validates: block on isolation:"worktree" (exit 2, continue:false), continue otherwise, config opt-out, malformed-json fail-closed.
 # Uses hook-runner provider (no LLM). Fixture git repos supply .sdlc/local.json context.
 
-- description: "agent-isolation-guard (#370 #372): Agent + isolation:worktree, no local.json → deny"
+- description: "agent-isolation-guard (#370 #372): Agent + isolation:worktree, no local.json → block (exit 2)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js"
     project_root: "file://fixtures-fs/agent-isolation-guard-no-config"
@@ -10,15 +10,15 @@
     script_stdin: '{"tool_name":"Agent","tool_input":{"isolation":"worktree","prompt":"do something"}}'
   assert:
     - type: icontains
-      value: '"exitCode": 0'
+      value: '"exitCode": 2'
     - type: icontains
-      value: "permissionDecision"
-    - type: icontains
-      value: "deny"
+      value: "stopReason"
     - type: icontains
       value: "BLOCKED"
     - type: icontains
       value: "isolation"
+    - type: not-icontains
+      value: "permissionDecision"
 
 - description: "agent-isolation-guard (#370 #372): Agent with no isolation field → continue"
   vars:
@@ -62,7 +62,7 @@
     - type: not-icontains
       value: 'permissionDecision'
 
-- description: "agent-isolation-guard (#370 #372): Agent + isolation:worktree + malformed local.json → deny (fails closed)"
+- description: "agent-isolation-guard (#370 #372): Agent + isolation:worktree + malformed local.json → block (fails closed)"
   vars:
     script_path: "repo://plugins/sdlc-utilities/hooks/pre-tool-agent-isolation-guard.js"
     project_root: "file://fixtures-fs/agent-isolation-guard-malformed"
@@ -70,10 +70,12 @@
     script_stdin: '{"tool_name":"Agent","tool_input":{"isolation":"worktree","prompt":"do something"}}'
   assert:
     - type: icontains
-      value: '"exitCode": 0'
+      value: '"exitCode": 2'
     - type: icontains
-      value: "permissionDecision"
-    - type: icontains
-      value: "deny"
+      value: "stopReason"
     - type: icontains
       value: "BLOCKED"
+    - type: icontains
+      value: "isolation"
+    - type: not-icontains
+      value: "permissionDecision"

--- a/tests/promptfoo/datasets/agent-isolation-guard-exec.yaml
+++ b/tests/promptfoo/datasets/agent-isolation-guard-exec.yaml
@@ -14,6 +14,8 @@
     - type: icontains
       value: "stopReason"
     - type: icontains
+      value: "\\\"continue\\\":false"
+    - type: icontains
       value: "BLOCKED"
     - type: icontains
       value: "isolation"
@@ -73,6 +75,8 @@
       value: '"exitCode": 2'
     - type: icontains
       value: "stopReason"
+    - type: icontains
+      value: "\\\"continue\\\":false"
     - type: icontains
       value: "BLOCKED"
     - type: icontains


### PR DESCRIPTION
## Summary

Fixes the `agent-isolation-guard` hook to use the correct blocking mechanism (`continue: false` + `stopReason` + `exit(2)`) instead of the `permissionDecision: 'deny'` approach, which does not bind under `bypassPermissions` mode. Also removes a redundant `reason` key from the block response and strengthens test assertions to validate the new blocking behavior.

## Business Context

The agent-isolation-guard hook is a security control that prevents Agent tool dispatches with `isolation: "worktree"` — a pattern that creates ephemeral worktrees outside SDLC's managed path and can corrupt workspace state. The previous `permissionDecision: 'deny'` implementation had a bypass: it does not take effect when Claude Code is running under `bypassPermissions` mode, leaving the guard ineffective in exactly the scenarios where agents are most likely to be dispatched autonomously.

## Business Benefits

- The isolation guard now reliably blocks forbidden `isolation: "worktree"` dispatches regardless of permission mode, closing the bypass vector.
- Test coverage is strengthened: assertions now validate exit code 2, `stopReason` presence, `continue: false`, and explicitly assert the absence of the old `permissionDecision` key — preventing regressions to the old behavior.
- Removes a redundant `reason` key from the block response, keeping the hook's output schema clean.

## Github Issue

Fixes #382

Note: Issue #383 (cwd-aware git state / workspace-branch diagnostic) was already resolved by commit `8d2eba1` in PR #406/#407.

## Technical Design

The hook's `emitDeny(reason)` function was replaced with `emitBlock(reason)`. The new function writes the reason to stderr, emits `{ continue: false, stopReason: reason, decision: 'block' }` to stdout, and calls `process.exit(2)`. This is the correct hook blocking protocol under all Claude Code permission modes, including `bypassPermissions`. The old `permissionDecision: 'deny'` approach only works when standard permission checks are active — it is silently ignored under `bypassPermissions`.

## Technical Impact

The hook's output schema changes: `permissionDecision` / `permissionDecisionReason` fields are removed; `continue: false`, `stopReason`, and `decision: 'block'` are emitted instead. Any test or monitoring that checks for `permissionDecision` in hook output must be updated (the dataset was updated in this PR). No plugin manifest or skill interface changes beyond the version bump to 0.20.17.

## Changes Overview

- **Agent isolation guard blocking mechanism**: replaced `permissionDecision: 'deny'` with `continue: false` + `stopReason` + `exit(2)` so the block is effective under all permission modes including `bypassPermissions`
- **Block response cleanup**: removed the redundant `reason` key from the emitted block object; `stopReason` already captures the blocking reason
- **Test assertion hardening**: updated exec dataset assertions to validate exit code 2, `stopReason`, `continue: false`, and assert absence of `permissionDecision` — two blocking test cases strengthened
- **CHANGELOG and version bump**: recorded the fix in v0.20.17 release entry

## Testing

Verified via promptfoo exec dataset (`agent-isolation-guard-exec.yaml`). Assertions updated to: check exit code 2 (was 0), check `stopReason` present (was `permissionDecision`), check `"continue":false` present, check `BLOCKED` and `isolation` present, and assert `permissionDecision` is absent. Two blocking scenarios covered: no-config (default block) and malformed-config (fail-closed block).