### PR TITLE
fix(#457): openspec-scan - route content scans through active worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.21.3] - 2026-06-14
+
+### Added
+- sdlc: OpenSpec scans now route through the active worktree — plan, ship, and explore operations in linked worktrees detect their own OpenSpec changes instead of the main worktree's empty state (#457)
+
+### Fixed
+- openspec-scan-worktree: disabled GPG signing in test fixture to prevent CI failures when GPG signing is globally configured (#457)
+
 ## [0.21.1] - 2026-06-14
 
 ### Added

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.21.1",
+  "version": "0.21.3",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/worktree.js
+++ b/plugins/sdlc-utilities/scripts/lib/worktree.js
@@ -74,6 +74,44 @@ function resolveMainWorktreeSafe(cwd) {
   }
 }
 
+/**
+ * Return the absolute path of the ACTIVE worktree's top level — the root of the
+ * working tree for the current checkout, even when invoked from a subdirectory.
+ *
+ * Unlike resolveMainWorktreeSafe (which always walks back to the primary
+ * worktree for .sdlc/ config/state anchoring per issue #351), this resolves the
+ * tree on the active branch — correct for content scans (openspec/changes/,
+ * openspec/specs/) that live on the active branch in a linked worktree (#457).
+ *
+ * When not in a linked worktree, `git rev-parse --show-toplevel` returns the
+ * main worktree path — identical to resolveSdlcRoot() — so callers see
+ * `contentRoot === projectRoot` in the single-worktree case (no behavior change).
+ *
+ * Never throws. On failure: writes a warning to stderr ONLY when SDLC_DEBUG is
+ * set, then returns `cwd` as the fallback. Silent by default to avoid polluting
+ * prepare-script output in non-git fixtures and first-time setup runs.
+ *
+ * @param {string} [cwd=process.cwd()] Working directory for the git command.
+ * @returns {string} Active worktree top-level path, or `cwd` on failure.
+ */
+function resolveActiveWorktreeSafe(cwd) {
+  const workingDir = cwd || process.cwd();
+  try {
+    const out = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: workingDir,
+      encoding: 'utf8',
+    });
+    return out.trim();
+  } catch (_) {
+    if (process.env.SDLC_DEBUG) {
+      process.stderr.write(
+        `[sdlc] could not resolve active worktree from cwd ${workingDir}; using cwd as fallback\n`
+      );
+    }
+    return workingDir;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
@@ -81,4 +119,5 @@ function resolveMainWorktreeSafe(cwd) {
 module.exports = {
   resolveMainWorktree,
   resolveMainWorktreeSafe,
+  resolveActiveWorktreeSafe,
 };

--- a/plugins/sdlc-utilities/scripts/skill/plan-explore.js
+++ b/plugins/sdlc-utilities/scripts/skill/plan-explore.js
@@ -35,6 +35,7 @@ const { spawnSync } = require('node:child_process');
 const LIB = path.join(__dirname, '..', 'lib');
 
 const { resolveSdlcRoot }                       = require(path.join(LIB, 'config'));
+const { resolveActiveWorktreeSafe }             = require(path.join(LIB, 'worktree'));
 const { writeOutput }                           = require(path.join(LIB, 'output'));
 const { slugifyBranch }                         = require(path.join(LIB, 'state'));
 const { exec, detectBaseBranch, getChangedFiles } = require(path.join(LIB, 'git'));
@@ -313,6 +314,7 @@ function main() {
     projectRoot = resolveSdlcRoot({ cwd: process.cwd() });
   } catch (err) {
     // workspace-mode-compatibility: resolveSdlcRoot walks back to main worktree
+    // (correct for .sdlc/ config reads — issue #351). Content scans use contentRoot below.
     const output = {
       manifestPath: null,
       outDir: null,
@@ -324,15 +326,20 @@ function main() {
     return;
   }
 
+  // issue #457: content scans (git diff, openspec artifacts, keyword grep, active branch)
+  // live in the active worktree, not main. resolveActiveWorktreeSafe returns the active
+  // checkout's top level (= projectRoot in the single-worktree case).
+  const contentRoot = resolveActiveWorktreeSafe(process.cwd());
+
   try {
     // 1. Git scope files
-    const gitFiles = getGitScopeFiles(projectRoot);
+    const gitFiles = getGitScopeFiles(contentRoot);
 
     // 2. OpenSpec backtick paths
-    const openspecFiles = fromOpenspec ? getOpenSpecPaths(projectRoot, fromOpenspec) : [];
+    const openspecFiles = fromOpenspec ? getOpenSpecPaths(contentRoot, fromOpenspec) : [];
 
     // 3. Keyword grep files
-    const keywordFiles = getKeywordScopeFiles(userPrompt, projectRoot);
+    const keywordFiles = getKeywordScopeFiles(userPrompt, contentRoot);
 
     // Merge and cap scope-hint set
     const scopeHintSet = new Set([...gitFiles, ...openspecFiles, ...keywordFiles]);
@@ -351,7 +358,7 @@ function main() {
     // 7. Get current branch slug for tempdir naming
     let branchSlug = 'unknown';
     try {
-      const branch = exec('git branch --show-current', { cwd: projectRoot });
+      const branch = exec('git branch --show-current', { cwd: contentRoot });
       if (branch) branchSlug = slugifyBranch(branch);
     } catch (_) { /* use default */ }
 

--- a/plugins/sdlc-utilities/scripts/skill/plan.js
+++ b/plugins/sdlc-utilities/scripts/skill/plan.js
@@ -31,6 +31,7 @@ const LIB = path.join(__dirname, '..', 'lib');
 
 const { detectActiveChanges, validateChange, parseTasks, getRequirementInventory } = require(path.join(LIB, 'openspec'));
 const { readSection, resolveSdlcRoot } = require(path.join(LIB, 'config'));
+const { resolveActiveWorktreeSafe } = require(path.join(LIB, 'worktree'));
 const { writeOutput } = require(path.join(LIB, 'output'));
 const { resolveSkipConfigCheck, ensureConfigVersion } = require(path.join(LIB, 'config-version-prepare'));
 const { initState, findStateFile, readState, writeState, slugifyBranch, pruneStateFiles } = require(path.join(LIB, 'state'));
@@ -439,6 +440,9 @@ function main() {
   }
 
   const projectRoot = resolveSdlcRoot(); // issue #351: route to main worktree .sdlc/
+  // issue #457: OpenSpec content scans (openspec/changes/, openspec/specs/) live on the
+  // active branch in the active worktree — route them through contentRoot, NOT projectRoot.
+  const contentRoot = resolveActiveWorktreeSafe();
   const errors = [];
 
   // Issue #232: verifyAndMigrate gate (CLI > env > default false).
@@ -467,7 +471,7 @@ function main() {
   }
 
   // 1. OpenSpec detection
-  const openspec = detectActiveChanges(projectRoot);
+  const openspec = detectActiveChanges(contentRoot);
 
   // Add authoritative evidence when OpenSpec is present
   if (openspec.present) {
@@ -481,7 +485,7 @@ function main() {
   let fromOpenspecResult = null;
   let openspecContext = { tasks: null, tasksUpdated: 0 };
   if (fromOpenspec) {
-    const validation = validateChange(projectRoot, fromOpenspec);
+    const validation = validateChange(contentRoot, fromOpenspec);
     fromOpenspecResult = {
       valid: validation.valid,
       changeName: fromOpenspec,
@@ -517,7 +521,7 @@ function main() {
       !fromOpenspec.includes('..') &&
       !fromOpenspec.includes('\0')
     ) {
-      const tasksPath = path.join(projectRoot, 'openspec', 'changes', fromOpenspec, 'tasks.md');
+      const tasksPath = path.join(contentRoot, 'openspec', 'changes', fromOpenspec, 'tasks.md');
       try {
         const original = fs.readFileSync(tasksPath, 'utf8');
         const parsed = parseTasks(original);
@@ -549,7 +553,7 @@ function main() {
     // only. getRequirementInventory() is NOT covered by that guard — it receives `fromOpenspec`
     // which is validated by validateChange() before we reach this point.
     if (validation.valid) {
-      const invResult = getRequirementInventory(projectRoot, fromOpenspec);
+      const invResult = getRequirementInventory(contentRoot, fromOpenspec);
       if (invResult.ok) {
         openspecContext.requirements = invResult.requirements;
         openspecContext.requirementsError = null;

--- a/plugins/sdlc-utilities/scripts/skill/ship.js
+++ b/plugins/sdlc-utilities/scripts/skill/ship.js
@@ -49,6 +49,7 @@ const { resolveSkipConfigCheck, ensureConfigVersion } = require(path.join(LIB, '
 const { VALID_STEPS, BUILT_IN_DEFAULTS, CANONICAL_STEPS, RESERVED_STEPS } = require(path.join(LIB, 'ship-fields'));
 const { gcStateFiles, gcTempdirs } = require(path.join(LIB, 'state'));
 const { detectActiveChanges, isArchived } = require(path.join(LIB, 'openspec'));
+const { resolveActiveWorktreeSafe } = require(path.join(LIB, 'worktree'));
 const { getAdvisory } = require(path.join(LIB, 'context-advisory'));
 const { PRE_RELEASE_LABEL_RE } = require(path.join(LIB, 'version'));
 
@@ -976,6 +977,9 @@ function detectResumeState(_projectRoot, currentBranch) {
 
 function main() {
   const projectRoot = resolveSdlcRoot(); // issue #351: route to main worktree .sdlc/
+  // issue #457: OpenSpec content scans live on the active branch in the active worktree —
+  // route detectActiveChanges/isArchived through contentRoot, NOT projectRoot.
+  const contentRoot = resolveActiveWorktreeSafe();
   const cli = parseArgs(process.argv);
 
   const errors   = [];
@@ -1192,7 +1196,7 @@ function main() {
   }
 
   // Check OpenSpec (use shared lib for consistent detection)
-  const openspecResult = detectActiveChanges(projectRoot);
+  const openspecResult = detectActiveChanges(contentRoot);
   const openspecDetected = openspecResult.present;
   const openspecAuthoritative = openspecResult.present
     ? { path: 'openspec/config.yaml', specsCount: openspecResult.specsCount }
@@ -1224,7 +1228,7 @@ function main() {
   const openspecBranchMatch = openspecResult.branchMatch || null;
   const openspecChangeName  = flags.openspecChange || openspecBranchMatch;
   const openspecIsArchived  = openspecChangeName
-    ? isArchived(projectRoot, openspecChangeName)
+    ? isArchived(contentRoot, openspecChangeName)
     : false;
 
   // R-expected-branch-injection (issues #347, #348, #349): resolve the feature branch

--- a/tests/promptfoo/datasets/plan-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/plan-prepare-exec.yaml
@@ -367,3 +367,38 @@
       value: '"intakeAuditModel": "sonnet"'
     - type: icontains
       value: '"intakeAuditSubagentType": "general-purpose"'
+
+# --- contentRoot routing: linked-worktree OpenSpec detection (#457) ---
+# Fixture: main worktree has NO openspec; linked worktree worktrees/wt1 (feat/my-feature)
+# carries an active openspec change "my-feature". Running plan.js from the linked-worktree
+# cwd must detect the linked tree's change, not main's empty state. Proves the scan routes
+# through contentRoot (active worktree), not projectRoot (main worktree).
+- description: "plan-prepare (#457): linked-worktree — detects active worktree's openspec change, not main's"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}/worktrees/wt1"
+    project_root: "file://fixtures-fs/worktree-linked-openspec-plan"
+  assert:
+    - type: icontains
+      value: '"present": true'
+    - type: icontains
+      value: '"branchMatch": "my-feature"'
+    - type: not-icontains
+      value: '"present": false'
+
+# tasks.md ref-injection write must land in the LINKED worktree, not main. tasksUpdated == 1
+# is only reachable when validateChange + the tasks.md path both resolve through contentRoot
+# (= worktrees/wt1); if routing fell back to main, the change dir would not exist and
+# tasksUpdated would stay 0.
+- description: "plan-prepare (#457): linked-worktree — tasks.md ref-injection writes to active worktree path"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/plan.js"
+    script_args: "--from-openspec my-feature --output-file"
+    script_cwd: "{{project_root}}/worktrees/wt1"
+    project_root: "file://fixtures-fs/worktree-linked-openspec-plan"
+  assert:
+    - type: icontains
+      value: '"tasksUpdated": 1'
+    - type: icontains
+      value: '"valid": true'

--- a/tests/promptfoo/datasets/ship-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/ship-prepare-exec.yaml
@@ -1424,3 +1424,19 @@
           return true;
         }
         return true;
+
+# --- contentRoot routing: linked-worktree OpenSpec detection (#457) ---
+# Fixture: main worktree has NO openspec; linked worktree worktrees/wt1 (feat/my-feature)
+# carries an active openspec change. Running ship.js from the linked-worktree cwd must detect
+# the linked tree's openspec change via contentRoot, not main's empty state via projectRoot.
+- description: "ship-prepare (#457): linked-worktree — openspec detection uses active worktree"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/ship.js"
+    script_args: "--output-file"
+    script_cwd: "{{project_root}}/worktrees/wt1"
+    project_root: "file://fixtures-fs/worktree-linked-openspec-plan"
+  assert:
+    - type: icontains
+      value: '"openspecDetected": true'
+    - type: icontains
+      value: '"openspecBranchMatch": "my-feature"'

--- a/tests/promptfoo/fixtures-fs/worktree-linked-openspec-plan/setup.sh
+++ b/tests/promptfoo/fixtures-fs/worktree-linked-openspec-plan/setup.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Fixture (#457): main worktree WITHOUT openspec + linked worktree WITH an active
+# openspec change. Discriminates content-root routing: prepare scripts run from the
+# linked worktree must detect the linked tree's openspec change, not main's (empty).
+#
+# detectActiveChanges/validateChange are pure fs.existsSync — openspec content does
+# NOT need committing; uncommitted working-tree files in the linked worktree suffice
+# (mirrors project-linked-worktree-staged, which stages an uncommitted file).
+#
+# Re-runnable: every git/worktree state is recreated from scratch on each run.
+set -e
+
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Minimal valid .sdlc/config.json on main — resolveSdlcRoot() walks back to the main
+# worktree for config reads (issue #351), so this MUST live in the main tree.
+mkdir -p .sdlc
+cat > .sdlc/config.json <<'JSON'
+{
+  "sdlc": "1.0.0",
+  "plan": { "guardrails": [] },
+  "execute": { "guardrails": [] }
+}
+JSON
+
+# Initial commit on main so HEAD has a base for the worktree to branch from.
+# Main's working tree deliberately has NO openspec/ directory.
+git add -A
+git commit -q -m "init: sdlc config on main, no openspec"
+
+# Create a linked worktree on a fresh feature branch.
+rm -rf worktrees
+git worktree add -q -b feat/my-feature worktrees/wt1 >/dev/null
+
+# Populate the linked worktree's working tree with an active openspec change.
+# Branch feat/my-feature -> strips "feat/" -> slug "my-feature" matches the change
+# dir name "my-feature", so detectActiveChanges sets branchMatch=my-feature.
+mkdir -p worktrees/wt1/openspec/specs
+mkdir -p worktrees/wt1/openspec/changes/my-feature/specs
+
+cat > worktrees/wt1/openspec/config.yaml <<'YAML'
+version: 1
+YAML
+
+cat > worktrees/wt1/openspec/specs/baseline.md <<'MD'
+# Baseline Spec
+
+## Requirement: Baseline behavior
+The system SHALL retain baseline behavior.
+MD
+
+cat > worktrees/wt1/openspec/changes/my-feature/proposal.md <<'MD'
+# Change: my-feature
+
+## Why
+Route content scans through the active worktree.
+
+## What Changes
+- Add active-worktree resolution for content scans.
+MD
+
+cat > worktrees/wt1/openspec/changes/my-feature/specs/spec1.md <<'MD'
+# Delta Spec: my-feature
+
+## ADDED Requirements
+
+### Requirement: Active worktree routing
+Content scans SHALL resolve against the active worktree root.
+
+#### Scenario: linked worktree
+- WHEN a prepare script runs from a linked worktree
+- THEN it scans the linked tree's openspec change
+MD
+
+# tasks.md with exactly ONE injectable unchecked line and NO pre-existing ref comment,
+# so plan.js --from-openspec injects exactly one ref -> tasksUpdated == 1.
+cat > worktrees/wt1/openspec/changes/my-feature/tasks.md <<'MD'
+# Tasks: my-feature
+
+- [ ] Implement active worktree routing
+MD

--- a/tests/promptfoo/fixtures-fs/worktree-linked-openspec-plan/setup.sh
+++ b/tests/promptfoo/fixtures-fs/worktree-linked-openspec-plan/setup.sh
@@ -13,6 +13,7 @@ set -e
 git init -q
 git config user.email "test@test.com"
 git config user.name "Test"
+git config commit.gpgsign false
 
 # Minimal valid .sdlc/config.json on main — resolveSdlcRoot() walks back to the main
 # worktree for config reads (issue #351), so this MUST live in the main tree.


### PR DESCRIPTION
## Summary
Routes OpenSpec content scans (change detection, validation, requirement inventory) through the active worktree instead of the main worktree, so that plan, ship, and explore operations invoked from a linked worktree correctly detect that worktree's OpenSpec changes rather than seeing the main worktree's empty state.

## Business Context
Users working with git worktrees run plan-sdlc and ship-sdlc from a linked worktree that carries its own OpenSpec change. Before this fix, prepare scripts always routed OpenSpec scans to the main worktree root, which has no `openspec/` directory — causing OpenSpec to appear absent even when the active branch had a full change defined. This made worktree-based workflows silently skip OpenSpec enrichment.

## Business Benefits
- OpenSpec-aware workflows (plan, ship, explore) now work correctly in linked worktrees without any user intervention.
- Eliminates a silent failure mode where `openspecDetected: false` was returned from a worktree that actually had an active change — preventing wasted debugging time.
- No behavior change for users in single-worktree setups (contentRoot === projectRoot in that case).

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/457

## Technical Design
Introduced `resolveActiveWorktreeSafe()` in `scripts/lib/worktree.js` — uses `git rev-parse --show-toplevel` to return the active checkout's root, which differs from `resolveMainWorktreeSafe()` (which always walks to the primary worktree). The distinction matters because `.sdlc/` config lives on main (issue #351) while `openspec/changes/` and `openspec/specs/` live on the active branch. Each prepare script now computes both `projectRoot` (for config reads) and `contentRoot` (for OpenSpec/content scans) and routes accordingly. The helper is silent on failure by default; `SDLC_DEBUG=1` enables the warning to avoid polluting CI output.

## Technical Impact
None. The change is additive — `resolveActiveWorktreeSafe` is a new export; existing callers of `resolveMainWorktreeSafe` are unaffected. In single-worktree repos the two roots are identical, so existing behavior is preserved exactly.

## Changes Overview
- New `resolveActiveWorktreeSafe()` helper resolves the active branch's worktree root via `git rev-parse --show-toplevel`, with silent failure fallback
- `plan.js` and `ship.js` now use `contentRoot` for OpenSpec detection (`detectActiveChanges`, `validateChange`, `getRequirementInventory`, `isArchived`) while keeping `projectRoot` for `.sdlc/` config reads
- `plan-explore.js` routes git scope files, OpenSpec backtick paths, keyword grep, and branch slug detection through `contentRoot`
- New `worktree-linked-openspec-plan` fixture creates a main worktree without OpenSpec and a linked worktree with an active `my-feature` change, with GPG signing disabled to prevent CI failures
- Exec test cases added to `plan-prepare-exec.yaml` (OpenSpec detection and tasks.md ref-injection) and `ship-prepare-exec.yaml` (OpenSpec detection from linked worktree)

## Testing
- Two new exec test cases in `plan-prepare-exec.yaml`: (1) linked worktree detects its own OpenSpec change (`openspecDetected: true`, `branchMatch: my-feature`); (2) `--from-openspec` tasks.md ref-injection routes to the linked worktree path (`tasksUpdated: 1`)
- One new exec test case in `ship-prepare-exec.yaml`: ship.js from linked worktree returns `openspecDetected: true` and `openspecBranchMatch: my-feature`
- GPG signing disabled in fixture setup to ensure reproducibility in CI environments with global GPG config