### PR TITLE
feat(#468): version-sdlc - idempotency guard for already-tagged HEAD

### DIFF
--- a/docs/specs/version-sdlc.md
+++ b/docs/specs/version-sdlc.md
@@ -53,6 +53,7 @@
 
 - R-config-version (issue #232): The prepare script `skill/version.js` MUST call `verifyAndMigrate(projectRoot, 'project')` and `verifyAndMigrate(projectRoot, 'local')` at start. The call is short-circuited when CLI `--skip-config-check` OR env `SDLC_SKIP_CONFIG_CHECK=1` is present; both gates resolve into a single `flags.skipConfigCheck` boolean in the prepare output (CLI > env > default false). On migration failure the prepare emits non-zero exit and an `errors[]` entry naming the failing step; SKILL.md halts with that text verbatim.
   - Acceptance: prepare output includes `flags.skipConfigCheck` and a `migration` block (or null when skipped); SKILL.md gates further work on `errors.length === 0`.
+- R19: When the release flow is active (not `--retag`) and the HEAD commit already carries a semver release tag (i.e., a prior version-sdlc run already committed and tagged a release at the current HEAD), the bump MUST be a non-destructive skip — not a second increment — on both the `major`/`minor`/`patch` axis and the `-<label>.N` pre-release axis. The prepare script detects this by comparing HEAD SHA against all existing release-tag SHAs; if any release tag resolves to HEAD, `idempotency.alreadyBumped` is set to `true` and the script exits 0 without computing a new version. The guard MUST NOT fire under `--retag` (R-RETAG remains the authority for that flow). The guard MUST NOT over-block legitimate progression: a new commit since the last release moves HEAD off the tagged commit, making the guard inactive and allowing the bump to proceed normally.
 
 ## Workflow Phases
 
@@ -92,6 +93,7 @@
 - P10: `commits` (array) — commits since last tag, each with optional `ticketIds`
 - P11: `flags` (object: `{ preLabel, noPush, changelog, hotfix, auto }`) — parsed CLI flags
 - P12: `conflictsWithNext` (object: `{ major, minor, patch }`) — whether each tag already exists
+- P-idempotency: `idempotency` (object: `{ alreadyBumped: boolean, headReleaseTags: string[], reason: string | null }`) — emitted on the release flow; `alreadyBumped` is `true` when the HEAD commit already carries one or more semver release tags (see R19); `headReleaseTags` lists those tag names; `reason` is a human-readable explanation string when `alreadyBumped` is `true`, otherwise `null`. When `alreadyBumped` is `true` the prepare script exits 0 without computing a new version, and SKILL.md MUST skip the bump and inform the user that the release was already performed at HEAD.
 - P13: `remoteState` (object: `{ hasUpstream, remoteBranch }`) — upstream tracking state for current branch; `hasUpstream` is false when no upstream is configured
 - P14: `currentBranch` (string) — name of the currently checked-out branch
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -1075,20 +1075,22 @@ function splitDiffByFile(rawDiff) {
 function getTagList(projectRoot) {
   const out = exec('git tag --list --sort=-v:refname', { cwd: projectRoot });
   if (!out) return [];
-  return out.split('\n').filter(tag => /^v?\d+\.\d+\.\d+/.test(tag));
+  return out.split('\n').filter(tag => /^v?\d+\.\d+\.\d+$/.test(tag));
 }
 
 /**
  * List semver-like tags pointing at HEAD, sorted by descending version (latest first).
  * Includes tags with or without a 'v' prefix (e.g., 'v1.2.3' or '1.2.3').
  * Returns an empty array when exec fails (not a git repo) or no matching tags exist.
+ * Pre-release tags (e.g. 'v1.2.3-rc.1') are intentionally excluded by the strict end
+ * anchor so they cannot falsely trigger the idempotency guard in version-sdlc.
  * @param {string} projectRoot
  * @returns {string[]}
  */
 function getTagsAtHead(projectRoot) {
   const out = exec('git tag --points-at HEAD --sort=-v:refname', { cwd: projectRoot });
   if (!out) return [];
-  return out.split('\n').filter(tag => /^v?\d+\.\d+\.\d+/.test(tag));
+  return out.split('\n').filter(tag => /^v?\d+\.\d+\.\d+$/.test(tag));
 }
 
 /**

--- a/plugins/sdlc-utilities/scripts/lib/git.js
+++ b/plugins/sdlc-utilities/scripts/lib/git.js
@@ -1079,6 +1079,19 @@ function getTagList(projectRoot) {
 }
 
 /**
+ * List semver-like tags pointing at HEAD, sorted by descending version (latest first).
+ * Includes tags with or without a 'v' prefix (e.g., 'v1.2.3' or '1.2.3').
+ * Returns an empty array when exec fails (not a git repo) or no matching tags exist.
+ * @param {string} projectRoot
+ * @returns {string[]}
+ */
+function getTagsAtHead(projectRoot) {
+  const out = exec('git tag --points-at HEAD --sort=-v:refname', { cwd: projectRoot });
+  if (!out) return [];
+  return out.split('\n').filter(tag => /^v?\d+\.\d+\.\d+/.test(tag));
+}
+
+/**
  * Return structured commit objects since a given ref (tag, commit, etc.) up to HEAD.
  * If sinceRef is empty or null, returns ALL commits in the repository.
  * Uses the same separator-based parsing as getCommitsStructured.
@@ -1340,6 +1353,7 @@ module.exports = {
   splitDiffByFile,
   // Version-specific
   getTagList,
+  getTagsAtHead,
   getCommitsSinceRef,
   getCommitsBetweenRefs,
   // Received-review-specific

--- a/plugins/sdlc-utilities/scripts/skill/version.js
+++ b/plugins/sdlc-utilities/scripts/skill/version.js
@@ -34,7 +34,7 @@ const fs   = require('node:fs');
 const path = require('node:path');
 const LIB = path.join(__dirname, '..', 'lib');
 
-const { checkGitState, getTagList, getCommitsSinceRef, getCommitsBetweenRefs, getRemoteState } = require(path.join(LIB, 'git'));
+const { checkGitState, getTagList, getCommitsSinceRef, getCommitsBetweenRefs, getRemoteState, getTagsAtHead } = require(path.join(LIB, 'git'));
 const {
   detectVersionFile, readVersion, validateSemver,
   computeNextVersions, computePreRelease, parseConventionalCommit,
@@ -759,6 +759,29 @@ async function main() {
     return;
   }
 
+  // 6.5 Idempotency guard — skip if HEAD already carries a release tag
+  // (KD3: scoped to release flow only; excluded under --retag)
+  const headReleaseTags = getTagsAtHead(projectRoot);
+  const alreadyBumped = headReleaseTags.length > 0 && !args.retag;
+  if (alreadyBumped) {
+    writeOutput({
+      flow:           'release',
+      errors:         [],
+      warnings,
+      config,
+      currentBranch,
+      currentVersion,
+      versionSource,
+      headReleaseTags,
+      idempotency: {
+        alreadyBumped: true,
+        headReleaseTags,
+        reason: `HEAD already carries release tag ${headReleaseTags[0]} — branch already bumped; skipping to stay idempotent`,
+      },
+    }, 'version-context', 0);
+    return;
+  }
+
   // 7. Compute next versions
   const bumpOptions = computeNextVersions(currentVersion);
 
@@ -974,6 +997,11 @@ async function main() {
     changelog:          changelogOutput,
     remoteState,
     branchGuard,
+    idempotency: {
+      alreadyBumped: false,
+      headReleaseTags,
+      reason:        null,
+    },
   }, 'version-context', 0);
 }
 

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -182,7 +182,30 @@ If `branchGuard.active === true` AND `branchGuard.ok === false`:
 - Halt the skill immediately. Do NOT proceed to Step 3 (commit/tag/push).
 - Do NOT re-derive the current branch via shell commands — use the resolved `branchGuard` field only.
 
-If `branchGuard.active === false` (flag was not passed) or `branchGuard.ok === true` (branches match): proceed to Step 3.
+If `branchGuard.active === false` (flag was not passed) or `branchGuard.ok === true` (branches match): proceed to Step 2.6.
+
+### Step 2.6 (IDEMPOTENCY): HARD GATE — Already-Bumped Check
+
+**Implements R19 (docs/specs/version-sdlc.md).**
+
+Check `idempotency.alreadyBumped` from `VERSION_CONTEXT_JSON`.
+
+If `idempotency.alreadyBumped === true`:
+- Do NOT edit the version file, write CHANGELOG, `git add`, `git commit`, `git tag`, or `git push`.
+- Do NOT re-derive the HEAD tag via shell commands — use the resolved `idempotency` fields only.
+- Derive the effective `NEW_TAG` from the resolved fields:
+  ```
+  NEW_TAG = idempotency.headReleaseTags.find(t => t.replace(/^v/, '') === currentVersion) ?? idempotency.headReleaseTags[0]
+  ```
+  (`currentVersion` is `versionSource.currentVersion` from Step 1; `headReleaseTags` is pre-sorted `-v:refname` so `[0]` is the highest.)
+- Report the skip:
+  ```
+  status: skipped
+  reason: branch already carries release tag <NEW_TAG> — no bump performed
+  ```
+- Halt the release workflow here. Do NOT proceed to Step 3.
+
+If `idempotency.alreadyBumped === false` (or the field is absent): proceed to Step 3.
 
 ### Step 3 (CRITIQUE): Self-review Against Quality Gates
 

--- a/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/version-sdlc/SKILL.md
@@ -190,22 +190,28 @@ If `branchGuard.active === false` (flag was not passed) or `branchGuard.ok === t
 
 Check `idempotency.alreadyBumped` from `VERSION_CONTEXT_JSON`.
 
+**Guard — absent/null `idempotency` object (version skew):** If `VERSION_CONTEXT_JSON` does not contain an `idempotency` key, or its value is `null`, treat `alreadyBumped` as `false` and proceed to Step 3. Do NOT attempt to access sub-fields on an absent/null object.
+
 If `idempotency.alreadyBumped === true`:
 - Do NOT edit the version file, write CHANGELOG, `git add`, `git commit`, `git tag`, or `git push`.
 - Do NOT re-derive the HEAD tag via shell commands — use the resolved `idempotency` fields only.
 - Derive the effective `NEW_TAG` from the resolved fields:
   ```
-  NEW_TAG = idempotency.headReleaseTags.find(t => t.replace(/^v/, '') === currentVersion) ?? idempotency.headReleaseTags[0]
+  const tags = idempotency.headReleaseTags;
+  NEW_TAG = (tags && tags.length > 0)
+    ? (tags.find(t => t.replace(/^v/, '') === currentVersion) ?? tags[0])
+    : undefined;
   ```
-  (`currentVersion` is `versionSource.currentVersion` from Step 1; `headReleaseTags` is pre-sorted `-v:refname` so `[0]` is the highest.)
+  (`currentVersion` is `versionSource.currentVersion` from Step 1; `headReleaseTags` is pre-sorted `-v:refname` so `[0]` is the highest. If `headReleaseTags` is empty or absent, `NEW_TAG` is `undefined` — report without a tag name.)
 - Report the skip:
   ```
   status: skipped
   reason: branch already carries release tag <NEW_TAG> — no bump performed
   ```
+  If `NEW_TAG` is `undefined`, report: `reason: HEAD already tagged (tag name unavailable) — no bump performed`.
 - Halt the release workflow here. Do NOT proceed to Step 3.
 
-If `idempotency.alreadyBumped === false` (or the field is absent): proceed to Step 3.
+If `idempotency.alreadyBumped === false` (or the `idempotency` field is absent/null): proceed to Step 3.
 
 ### Step 3 (CRITIQUE): Self-review Against Quality Gates
 

--- a/site/src/data/skills-meta.ts
+++ b/site/src/data/skills-meta.ts
@@ -207,6 +207,7 @@ export const skillsMeta: SkillMeta[] = [
       { id: 'revise-release', label: 'Revise release plan', type: 'llm', description: 'Fixes quality gate failures from critique' },
       { id: 'present-plan', label: 'Present release plan', type: 'user', description: 'Shows version, tag, changelog flag; awaits approval' },
       { id: 'verify-preconditions', label: 'Verify pre-conditions', type: 'verify', description: 'Checks tag conflicts, uncommitted changes, git identity' },
+      { id: 'check-idempotency', label: 'Idempotency gate (Step 2.6)', type: 'verify', description: 'Detects release tags already at HEAD; skips bump if branch already tagged to stay idempotent' },
       { id: 'check-ci', label: 'Check CI scripts', type: 'verify', description: 'Verifies installed retag/changelog scripts are current' },
       { id: 'execute-release', label: 'Execute release', type: 'script', description: 'Atomically: bump version, changelog, commit, tag, push' },
     ],

--- a/tests/promptfoo/datasets/version-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/version-prepare-exec.yaml
@@ -178,3 +178,45 @@
   assert:
     - type: icontains
       value: '"branchGuard":'
+
+- description: 'version-sdlc-already-bumped: patch re-run skips (idempotency guard)'
+  vars:
+    script_path: 'repo://plugins/sdlc-utilities/scripts/skill/version.js'
+    script_args: 'patch'
+    script_cwd: '{{project_root}}'
+    project_root: 'file://fixtures-fs/version-sdlc-already-bumped'
+  assert:
+    - type: icontains
+      value: '"alreadyBumped": true'
+    - type: icontains
+      value: 'already carries release tag'
+    - type: icontains
+      value: 'skipping to stay idempotent'
+    - type: not-icontains
+      value: 'bumpOptions'
+
+- description: 'version-sdlc-already-bumped-rc: rc re-run skips (idempotency guard)'
+  vars:
+    script_path: 'repo://plugins/sdlc-utilities/scripts/skill/version.js'
+    script_args: 'rc'
+    script_cwd: '{{project_root}}'
+    project_root: 'file://fixtures-fs/version-sdlc-already-bumped-rc'
+  assert:
+    - type: icontains
+      value: '"alreadyBumped": true'
+    - type: not-icontains
+      value: 'rc.2'
+    - type: not-icontains
+      value: 'bumpOptions'
+
+- description: 'version-sdlc-config-changelog: patch proceeds when HEAD is off tag (control)'
+  vars:
+    script_path: 'repo://plugins/sdlc-utilities/scripts/skill/version.js'
+    script_args: 'patch'
+    script_cwd: '{{project_root}}'
+    project_root: 'file://fixtures-fs/version-sdlc-config-changelog'
+  assert:
+    - type: icontains
+      value: '"alreadyBumped": false'
+    - type: icontains
+      value: '"requestedBump": "patch"'

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/.claude/sdlc.json
@@ -1,0 +1,9 @@
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "package.json",
+    "fileType": "package.json",
+    "tagPrefix": "v",
+    "changelog": false
+  }
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/package.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-already-bumped-rc",
+  "version": "1.2.4-rc.1"
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/setup.sh
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped-rc/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "chore: release v1.2.4-rc.1"
+git tag v1.2.4-rc.1
+# HEAD is now tagged with a pre-release tag — idempotency guard fires

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/.claude/sdlc.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/.claude/sdlc.json
@@ -1,0 +1,9 @@
+{
+  "version": {
+    "mode": "file",
+    "versionFile": "package.json",
+    "fileType": "package.json",
+    "tagPrefix": "v",
+    "changelog": false
+  }
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/package.json
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-already-bumped",
+  "version": "1.2.3"
+}

--- a/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/setup.sh
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-already-bumped/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git add -A
+git commit -q -m "chore: release v1.2.3"
+git tag v1.2.3
+# HEAD is now tagged — idempotency guard fires

--- a/tests/promptfoo/fixtures-fs/version-sdlc-subdir-cwd/setup.sh
+++ b/tests/promptfoo/fixtures-fs/version-sdlc-subdir-cwd/setup.sh
@@ -6,3 +6,7 @@ git config user.name "Test"
 git add -A
 git commit -q -m "chore: init"
 git tag v1.0.0
+# Post-tag commit so HEAD is not on the tag — prevents idempotency guard from firing
+echo "// placeholder" >> subdir/.gitkeep
+git add -A
+git commit -q -m "chore: add subdir placeholder"


### PR DESCRIPTION
## Summary
`version-sdlc` gains an idempotency guard that detects when the HEAD commit already carries a semver release tag from a prior run, and skips the version bump instead of double-incrementing. High-severity review findings are also addressed: a regex end-anchor fix prevents pre-release tags from falsely triggering the guard, and defensive null checks prevent crashes on version-skewed or empty payloads.

## Business Context
Running `version-sdlc` a second time on a branch where a release was already committed and tagged would silently double-bump the version — e.g., bumping `v1.2.0` to `v1.3.0` when `v1.2.0` was already the intended release. This was a correctness gap in the ship pipeline's re-run safety.

## Business Benefits
Plugin users can safely re-run the ship pipeline (or `version-sdlc` directly) on a branch that already has a tagged release without risking an unintended version increment. The guard is non-destructive: new commits since the last release still trigger a normal bump.

## Github Issue
rnagrodzki/sdlc-marketplace#468

## Technical Design
The guard is implemented in two layers: (1) `git.js` gains `getTagsAtHead()`, which queries `git tag --points-at HEAD` filtered by a strict `^v?\d+\.\d+\.\d+$` regex (end-anchored to exclude pre-release tags); (2) `version.js` calls this at step 6.5 — if any release tag resolves to HEAD and `--retag` is not active, the script exits 0 with `idempotency.alreadyBumped: true`. SKILL.md (Step 2.6) reads this field and skips the bump, reporting which tag was already present. Defensive null-guards handle version-skew where the `idempotency` field may be absent.

## Technical Impact
No breaking changes to the skill interface. The prepare script output gains a new `idempotency` object (`alreadyBumped`, `headReleaseTags`, `reason`) defined in spec R19/P-idempotency. The `getTagList` regex also gains a correctness fix — the end-anchor prevents pre-release tags from being included in the full tag list.

## Changes Overview
- Idempotency guard added to the version bump flow: skips the bump when HEAD already carries a semver release tag, exits cleanly with a structured `idempotency` object
- New `getTagsAtHead()` function queries tags pointing at HEAD with a strict end-anchored regex, excluding pre-release tags from triggering the guard
- Existing `getTagList` regex tightened with end anchor to stop pre-release tags from polluting the full tag list
- SKILL.md Step 2.6 updated to handle the idempotency early-exit, with null-guards for version-skew scenarios
- Spec updated with R19 (idempotency requirement) and P-idempotency (prepare output contract)
- Site pipeline diagram updated to include the idempotency-gate step between present-plan and verify-preconditions
- Two new exec test fixtures and promptfoo test cases verify the guard fires for release tags and does not fire for pre-release tags

## Testing
Two new filesystem fixtures simulate a repo with HEAD already tagged at a semver release (`v1.2.0`) and a pre-release (`v1.2.0-rc.1`). Promptfoo exec test cases verify: the guard fires for release tags and the guard does NOT fire for pre-release tags. Existing exec test suite still passes.