### PR TITLE
fix(#474): harden-sdlc — worktree-aware surface writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.21.12] - 2026-06-24
+
+### Fixed
+- harden-sdlc: worktree-aware surface writes — when `/harden-sdlc` runs from a linked git worktree, approved review-dimension and Copilot-instruction edits now land in the active worktree (branch-tracked content) while guardrail/config edits stay in the main worktree's shared `.sdlc/` config (#474)
+
 ## [0.21.11] - 2026-06-21
 
 ### Fixed

--- a/docs/skills/harden-sdlc.md
+++ b/docs/skills/harden-sdlc.md
@@ -241,6 +241,10 @@ Failure → harden classifies → proposes surface edits → user approves → n
 
 No file is written without an explicit `apply` AskUserQuestion answer recorded for that specific proposal.
 
+> **Worktrees.** From a linked git worktree, review-dimension and Copilot-instruction
+> edits land in the **active** worktree (your branch); guardrail edits to `.sdlc/config.json`
+> land in the **main** worktree (shared config). In a single worktree the two coincide.
+
 ---
 
 ## Related Skills

--- a/docs/specs/harden-sdlc.md
+++ b/docs/specs/harden-sdlc.md
@@ -101,8 +101,9 @@
 - P8: `surfaces.copilotInstructions[]` — `{applyTo, name, path}` objects
 - P9: `surfaces.errorReportSkillPath` (string) — absolute path to resolved `error-report-sdlc/REFERENCE.md`
 - P10: `pipeline.shipState` / `pipeline.executeState` — optional summaries of paused pipeline state (or `null`)
-- P11: `repository.root` / `repository.branch` / `repository.recentDiffSummary` — git short-stat only, no full body
+- P11: `repository.root` / `repository.branch` / `repository.recentDiffSummary` — `repository.root` is the MAIN worktree (config/`.sdlc/` root, = `resolveSdlcRoot()`); `branch`/`recentDiffSummary` describe the ACTIVE checkout (resolved against `repository.contentRoot`); git short-stat only, no full body
 - P12: `pluginRepoUrl` (string) — constant URL of the plugin's GitHub repository, surfaced verbatim to the user prompt and forwarded as context to error-report-sdlc.
+- P13: `repository.contentRoot` (string) — the ACTIVE worktree root (`resolveActiveWorktreeSafe()`); equals `repository.root` in the single-worktree case. Branch-tracked surface paths (`reviewDimensions[].path`, `copilotInstructions[].path`) are rooted here, NOT at `repository.root`.
 
 ## Error Handling
 
@@ -127,8 +128,10 @@
 - C8: Must not re-derive data the prepare script already computes via shell commands, tool calls, or LLM inference — script output is the sole source for all factual context, preserving deterministic behavior
 - C9: Must not propose relaxing or removing existing rules in v1 (strengthen-only invariant)
 - C10: Must not auto-dispatch from caller skills — every caller integration is opt-in via menu selection only
-- C-projectroot: Scripts that use `process.cwd()` as the project root silently break when invoked from a sub-directory or a git worktree. All projectRoot resolutions in this skill's scripts MUST route through `resolveSdlcRoot()` (lib/config.js); `process.cwd()` is forbidden except in documented bootstrap entry points.
+- C-projectroot: Scripts that use `process.cwd()` as the project root silently break when invoked from a sub-directory or a git worktree. All projectRoot resolutions in this skill's scripts MUST route through `resolveSdlcRoot()` (lib/config.js); `process.cwd()` is forbidden except in documented bootstrap entry points. Scope: config/guardrail/state paths only — branch-tracked content paths use `contentRoot` per C-contentroot.
   - Acceptance: `resolveSdlcRoot()` is called to establish `projectRoot` in `skill/harden-prepare.js`; no bare `process.cwd()` usage contributes to any path resolved against the project root; invoking the script from a repo sub-directory yields the correct root.
+- C-contentroot: Branch-tracked surfaces (review-dimensions, copilot-instructions) and their pre-flight validation MUST resolve against `contentRoot = resolveActiveWorktreeSafe()` (lib/worktree.js), so writes land in the active worktree. Config/guardrail surfaces (plan/execute guardrails) and their pre-flight validation MUST resolve against `projectRoot = resolveSdlcRoot()` (main worktree) for both read and write — config is shared, main-rooted state (#351, `workspace-mode-compatibility`). The orchestrator builds the `.sdlc/config.json` targetFile from `repository.root` (main) and dimension/copilot targetFiles from each surface's `path` field (content). `PROJECT_ROOT` passed to the orchestrator is `repository.contentRoot`; the "do not Read outside PROJECT_ROOT" rule is scoped to Reads (the config targetFile under `repository.root` is an emitted path, not a Read).
+  - Acceptance: invoking `harden-prepare.js` from a linked worktree yields `reviewDimensions[].path` and `copilotInstructions[].path` under the active worktree and `repository.contentRoot` = active root, while `planGuardrails`/`executeGuardrails` are read from the main config and `repository.root` = main; in a single worktree all roots are identical.
 - C-11: Caller list MUST appear inline in this spec at I1 only. All other harden-sdlc surfaces (SKILL.md, `docs/skills/harden-sdlc.md`, `agents/harden-orchestrator.md`) MUST reference I1 by name rather than restating the list.
 - C-12: Strengthen-only invariant MUST appear inline at R8 (rule) and C9 (constraint) only. All other surfaces MUST reference R8 and C9 by name rather than restating the invariant text.
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.21.11",
+  "version": "0.21.12",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/agents/harden-orchestrator.md
+++ b/plugins/sdlc-utilities/agents/harden-orchestrator.md
@@ -16,7 +16,7 @@ inherit no conversation context — everything you need is in the manifest.
 ## Inputs (provided in your prompt)
 
 - **MANIFEST_FILE**: Absolute path to the JSON manifest written by `harden-prepare.js`
-- **PROJECT_ROOT**: The project's working directory
+- **PROJECT_ROOT**: the active worktree root (= `repository.contentRoot` in the manifest)
 
 ## Step 0 — Load Manifest
 
@@ -35,12 +35,17 @@ Read the manifest JSON from `MANIFEST_FILE`. The manifest contains:
 | `surfaces.copilotInstructions[]` | `{applyTo, name, path}` |
 | `surfaces.errorReportSkillPath` | Resolved REFERENCE.md path for `error-report-sdlc` |
 | `pipeline.shipState` / `pipeline.executeState` | Optional paused-pipeline state, or `null` |
-| `repository.root` / `repository.branch` / `repository.recentDiffSummary` | Repo metadata |
+| `repository.root` | MAIN worktree — config/`.sdlc/` root; use to build the `.sdlc/config.json` targetFile for guardrail proposals |
+| `repository.contentRoot` | ACTIVE worktree — root of `reviewDimensions[].path` / `copilotInstructions[].path`; equals `PROJECT_ROOT` |
+| `repository.branch` / `repository.recentDiffSummary` | Active-checkout metadata |
 | `pluginRepoUrl` | Constant URL of the plugin's GitHub repository (issue #288) — read directly from `MANIFEST_FILE` by SKILL.md (Steps 5c and 6) to construct the user-facing prompt; NOT included in orchestrator output JSON |
 
 If you need the full body of a specific dimension or copilot instruction file to
-draft a proposal, you MAY Read the file via the `path` field in the manifest. Do
-not Read files outside `PROJECT_ROOT`.
+draft a proposal, you MAY Read the file via the `path` field in the manifest
+(these live under `PROJECT_ROOT` = `repository.contentRoot`). Do not Read files
+outside `PROJECT_ROOT`. Building the `.sdlc/config.json` targetFile under
+`repository.root` (the main worktree) is emitting a path string, not a Read, and
+is permitted.
 
 ## Step 1 — Classify the Failure
 
@@ -101,7 +106,7 @@ Each proposal:
 {
   "surface": "plan-guardrails | execute-guardrails | review-dimensions | copilot-instructions",
   "action": "add | strengthen | consolidate",
-  "targetFile": "absolute path to the file that would be edited",
+  "targetFile": "absolute path to the file that would be edited — for plan-guardrails/execute-guardrails use `<repository.root>/.sdlc/config.json` (main worktree); for review-dimensions/copilot-instructions use that surface's `path` field verbatim (active worktree, = repository.contentRoot-rooted)",
   "patch": "preview block — for sdlc.json, the new/modified guardrail object as JSON; for review-dimensions, the new frontmatter or new rule line; for copilot-instructions, the new checklist line",
   "rationale": "one to two sentences linking back to the failure signal"
 }

--- a/plugins/sdlc-utilities/scripts/skill/harden-prepare.js
+++ b/plugins/sdlc-utilities/scripts/skill/harden-prepare.js
@@ -20,6 +20,7 @@ const surfaces = require(path.join(LIB, 'harden-surfaces'));
 const { resolveSkipConfigCheck, ensureConfigVersion } = require(path.join(LIB, 'config-version-prepare'));
 const { detectResumeState } = require(path.join(LIB, 'state'));
 const { resolveSdlcRoot } = require(path.join(LIB, 'config'));
+const { resolveActiveWorktreeSafe } = require(path.join(LIB, 'worktree')); // #474: branch-tracked surfaces
 
 // Plugin repo URL (issue #288). Hardcoded inline by design — do NOT extract to
 // lib/harden-surfaces.js, do NOT share with error-report-prepare.js::TARGET_REPO.
@@ -72,9 +73,9 @@ function readStdinJson() {
   }
 }
 
-function safeExec(cmd) {
+function safeExec(cmd, opts = {}) {
   try {
-    return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'], ...opts }).toString().trim();
   } catch (err) {
     process.stderr.write(`harden-prepare: git command failed (${cmd.split(' ')[0]}): ${err.stderr ? err.stderr.toString().trim() : err.message}\n`);
     return '';
@@ -225,8 +226,10 @@ function main() {
     return;
   }
 
-  // R-projectroot: main-worktree-rooted resolution (#360).
+  // R-projectroot: main-worktree-rooted resolution (#360) — config/guardrails.
   const projectRoot = resolveSdlcRoot();
+  // #474: branch-tracked surfaces (dimensions, copilot) live in the active worktree.
+  const contentRoot = resolveActiveWorktreeSafe();
   const surfaceLoadErrors = [];
 
   // R16 — Pre-flight validation: validate existing .sdlc/config.json guardrails
@@ -243,7 +246,7 @@ function main() {
     }
   }
 
-  const dimDir = resolveDimensionsDir(projectRoot);
+  const dimDir = resolveDimensionsDir(contentRoot); // #474: validate the active worktree's dimensions
   if (fs.existsSync(dimDir)) {
     let dimFiles = [];
     try {
@@ -270,8 +273,8 @@ function main() {
   // Load all five surfaces deterministically (R4).
   const planGuardrails    = surfaces.loadGuardrails(projectRoot, 'plan',    surfaceLoadErrors);
   const executeGuardrails = surfaces.loadGuardrails(projectRoot, 'execute', surfaceLoadErrors);
-  const reviewDimensions  = surfaces.loadReviewDimensions(projectRoot, surfaceLoadErrors);
-  const copilotInstructions = surfaces.loadCopilotInstructions(projectRoot, surfaceLoadErrors);
+  const reviewDimensions  = surfaces.loadReviewDimensions(contentRoot, surfaceLoadErrors);   // #474
+  const copilotInstructions = surfaces.loadCopilotInstructions(contentRoot, surfaceLoadErrors); // #474
   const errorReportSkillPath = surfaces.resolveErrorReportSkill(projectRoot, surfaceLoadErrors);
 
   const { shipState, executeState } = readPipelineState();
@@ -300,9 +303,10 @@ function main() {
       executeState,
     },
     repository: {
-      root:   projectRoot,
-      branch: safeExec('git rev-parse --abbrev-ref HEAD'),
-      recentDiffSummary: safeExec('git diff --shortstat HEAD~1..HEAD 2>/dev/null'),
+      root:        projectRoot,   // main worktree — config/.sdlc root (#474 KD1)
+      contentRoot,                // active worktree — branch-tracked surface root (#474)
+      branch: safeExec('git rev-parse --abbrev-ref HEAD', { cwd: contentRoot }),
+      recentDiffSummary: safeExec('git diff --shortstat HEAD~1..HEAD 2>/dev/null', { cwd: contentRoot }),
     },
     pluginRepoUrl: PLUGIN_REPO_URL,
     timestamp: new Date().toISOString(),

--- a/plugins/sdlc-utilities/scripts/skill/harden-prepare.js
+++ b/plugins/sdlc-utilities/scripts/skill/harden-prepare.js
@@ -74,8 +74,12 @@ function readStdinJson() {
 }
 
 function safeExec(cmd, opts = {}) {
+  // Whitelist only `cwd` from caller opts — spread of arbitrary opts (e.g. shell, env)
+  // would silently undermine the fixed stdio posture and defense-in-depth intent.
+  const execOpts = { stdio: ['ignore', 'pipe', 'pipe'] };
+  if (opts.cwd !== undefined) execOpts.cwd = opts.cwd;
   try {
-    return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'], ...opts }).toString().trim();
+    return execSync(cmd, execOpts).toString().trim();
   } catch (err) {
     process.stderr.write(`harden-prepare: git command failed (${cmd.split(' ')[0]}): ${err.stderr ? err.stderr.toString().trim() : err.message}\n`);
     return '';

--- a/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
@@ -129,11 +129,13 @@ Use the `Agent` tool with:
 
   ```text
   MANIFEST_FILE: <ERROR_CONTEXT_FILE>
-  PROJECT_ROOT: <cwd>
+  PROJECT_ROOT: <repository.contentRoot read from MANIFEST_FILE>
   ```
 
-  Substitute `<ERROR_CONTEXT_FILE>` with the absolute path captured in Step 1
-  (`MANIFEST_FILE`) and `<cwd>` with the current working directory.
+  Substitute `<ERROR_CONTEXT_FILE>` with the Step 1 `MANIFEST_FILE` path and
+  `<repository.contentRoot …>` with the `repository.contentRoot` value read from
+  that manifest JSON (the active worktree root; same single-source pattern used
+  for `pluginRepoUrl`). Do NOT recompute it via `git`.
 
 The orchestrator returns ONLY a JSON object:
 
@@ -255,18 +257,20 @@ When it holds, derive `<name>` from the dimension filename (`.sdlc/review-dimens
    GEN=$(find ~/.claude/plugins -name "dimension-to-instructions.js" -path "*/sdlc*/scripts/lib/dimension-to-instructions.js" 2>/dev/null | sort -V | tail -1)
    [ -z "$GEN" ] && [ -f "plugins/sdlc-utilities/scripts/lib/dimension-to-instructions.js" ] && GEN="plugins/sdlc-utilities/scripts/lib/dimension-to-instructions.js"
    [ -z "$GEN" ] && { echo "ERROR: Could not locate dimension-to-instructions.js. Is the sdlc plugin installed?" >&2; exit 2; }
-   MIRROR=$(node "$GEN" --file ".sdlc/review-dimensions/<name>.md")
+   # #474: read the just-written dimension at its ABSOLUTE content-rooted path,
+   # not a cwd-relative one (the dimension lives in the active worktree).
+   MIRROR=$(node "$GEN" --file "<proposal.targetFile>")
    GEN_EXIT=$?
    ```
    A non-zero `GEN_EXIT` (unparseable dimension) is a hard failure — halt per R-iteration-write rule 4 (see step 4) and surface the partial state (dimension written, mirror not).
 
-2. **Ensure the mirror directory exists:** `mkdir -p .github/instructions` (R-copilot-mirror: create if missing).
+2. **Ensure the mirror directory exists:** `mkdir -p "<CONTENT_ROOT>/.github/instructions"` (#474 — active worktree).
 
-3. **Write or patch the mirror** at `.github/instructions/<name>.instructions.md`:
+3. **Write or patch the mirror** at `<CONTENT_ROOT>/.github/instructions/<name>.instructions.md`:
    - If the mirror does NOT exist → Write the generator's `$MIRROR` output verbatim (via the native Write tool — subprocess FS writes do not persist).
    - If the mirror ALREADY exists → this branch covers **only a manually pre-seeded mirror** (the orchestrator reads but never proposes a copilot-instructions write for a not-yet-created dimension's mirror, so a normal `action === "add"` flow arrives here only if someone seeded the file by hand). Patch it **strengthen-only** (R-copilot-mirror / R8/C9): apply only additive checklist/severity-guide rows and tightened `applyTo`/severity from `$MIRROR`; never remove existing checklist items or lower a severity. Use Edit to merge, not a blind overwrite. `strengthen` proposals on an already-mirrored dimension are excluded by the outer gate (condition (b)) and never reach this step.
 
-4. **Halt on partial-write failure (R-iteration-write rule 4):** if the dimension write in 5b succeeded but the generator (step 1) or the mirror Write/Edit (step 3) fails, do NOT silently advance to the next proposal. Halt this iteration and surface the partial state explicitly: `Dimension written to .sdlc/review-dimensions/<name>.md but the Copilot mirror .github/instructions/<name>.instructions.md could not be created — resolve manually before continuing.`
+4. **Halt on partial-write failure (R-iteration-write rule 4):** if the dimension write in 5b succeeded but the generator (step 1) or the mirror Write/Edit (step 3) fails, do NOT silently advance to the next proposal. Halt this iteration and surface the partial state explicitly: `Dimension written to <proposal.targetFile> but the Copilot mirror <CONTENT_ROOT>/.github/instructions/<name>.instructions.md could not be created — resolve manually before continuing.` Where `<CONTENT_ROOT>` is `repository.contentRoot` from the manifest.
 
 5. Display a one-line confirmation on success: `Mirrored review dimension → .github/instructions/<name>.instructions.md`.
 

--- a/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md
@@ -132,10 +132,17 @@ Use the `Agent` tool with:
   PROJECT_ROOT: <repository.contentRoot read from MANIFEST_FILE>
   ```
 
-  Substitute `<ERROR_CONTEXT_FILE>` with the Step 1 `MANIFEST_FILE` path and
-  `<repository.contentRoot …>` with the `repository.contentRoot` value read from
-  that manifest JSON (the active worktree root; same single-source pattern used
-  for `pluginRepoUrl`). Do NOT recompute it via `git`.
+  Substitute `<ERROR_CONTEXT_FILE>` with the Step 1 `MANIFEST_FILE` path.
+  For `PROJECT_ROOT`, read `repository.contentRoot` from the manifest JSON:
+
+  ```bash
+  CONTENT_ROOT=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$MANIFEST_FILE','utf8')).repository.contentRoot)")
+  MAIN_ROOT=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$MANIFEST_FILE','utf8')).repository.root)")
+  ```
+
+  `CONTENT_ROOT` = `repository.contentRoot` (active worktree — dimensions/copilot paths rooted here).
+  `MAIN_ROOT` = `repository.root` (main worktree — `.sdlc/config.json` rooted here).
+  Do NOT recompute either via `git`. Store both; they are needed in Steps 5a and 5b.
 
 The orchestrator returns ONLY a JSON object:
 
@@ -211,7 +218,11 @@ Options: **apply** | **skip** | **cancel**
 When the user selects **apply**, validate the proposed change BEFORE writing:
 
 - For `surface == "plan-guardrails"` or `"execute-guardrails"`: the target is
-  `.sdlc/config.json`. Construct the prospective merged JSON in memory, then
+  `<MAIN_ROOT>/.sdlc/config.json` (the main worktree root from the manifest —
+  `repository.root`). This is deliberate: guardrail config is shared/main-rooted
+  (spec C-contentroot / KD2), even when the skill is invoked from a linked
+  worktree. `targetFile` in the proposal is already an absolute path rooted at
+  `repository.root`. Construct the prospective merged JSON in memory, then
   validate via the canonical guardrails validator:
 
   ```bash
@@ -247,7 +258,9 @@ Use Edit (preferred) or Write to apply the approved, validated change to
 Applied {action} on {surface} → {targetFile}
 ```
 
-**Copilot mirror for NEW review dimensions (R-copilot-mirror, issue #456) — same atomic, approved write step.** Immediately after the dimension write above (still inside this 5b iteration, before advancing to the next proposal), gate on BOTH: (a) `proposal.surface === "review-dimensions"` AND `proposal.targetFile` is under `.sdlc/review-dimensions/`, AND (b) `proposal.action === "add"` (a NEW dimension — existing dimensions are NOT retroactively mirrored per R8/C9; `strengthen` actions on an already-mirrored dimension do not re-run this). When the gate does not hold, skip this block entirely.
+**Copilot mirror for NEW review dimensions (R-copilot-mirror, issue #456) — same atomic, approved write step.** Immediately after the dimension write above (still inside this 5b iteration, before advancing to the next proposal), gate on BOTH: (a) `proposal.surface === "review-dimensions"` AND `proposal.targetFile` (an absolute path emitted by the orchestrator, rooted at `repository.contentRoot`) contains `.sdlc/review-dimensions/`, AND (b) `proposal.action === "add"` (a NEW dimension — existing dimensions are NOT retroactively mirrored per R8/C9; `strengthen` actions on an already-mirrored dimension do not re-run this). When the gate does not hold, skip this block entirely.
+
+Before this block runs, ensure `CONTENT_ROOT` is set from `repository.contentRoot` in the manifest (derived in Step 3; re-derive here if in a fresh shell block using the same one-liner pattern from Step 3).
 
 When it holds, derive `<name>` from the dimension filename (`.sdlc/review-dimensions/<name>.md` → `<name>.instructions.md`) and:
 

--- a/tests/promptfoo/datasets/harden-prepare-exec.yaml
+++ b/tests/promptfoo/datasets/harden-prepare-exec.yaml
@@ -118,3 +118,57 @@
     - type: icontains
       value: "pre-flight validation failed"
       description: "stderr must emit pre-flight validation failed (proves exit-1 code path)"
+
+# #474 — linked-worktree content-root rooting
+
+- description: "harden-prepare #474: reviewDimensions paths rooted in active linked worktree"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/harden-prepare.js"
+    script_args: '--failure-text "test failure" --skill plan-sdlc'
+    script_cwd: "{{project_root}}/linked-wt"
+    project_root: "file://fixtures-fs/harden-worktree-content-root"
+  assert:
+    - type: javascript
+      value: |
+        const m = JSON.parse(output);
+        const paths = (m.surfaces.reviewDimensions || []).map(d => d.path);
+        return paths.length > 0 && paths.every(p => p.includes('/linked-wt/'));
+      description: "all reviewDimension paths must be under the linked-wt directory"
+    - type: javascript
+      value: |
+        const m = JSON.parse(output);
+        const names = (m.surfaces.reviewDimensions || []).map(d => d.name);
+        return names.includes('branch-only') && !names.includes('main-only');
+      description: "branch-only dimension present and main-only absent when running from linked-wt"
+
+- description: "harden-prepare #474: repository.contentRoot equals active linked worktree"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/harden-prepare.js"
+    script_args: '--failure-text "test failure" --skill plan-sdlc'
+    script_cwd: "{{project_root}}/linked-wt"
+    project_root: "file://fixtures-fs/harden-worktree-content-root"
+  assert:
+    - type: javascript
+      value: |
+        const m = JSON.parse(output);
+        return typeof m.repository.contentRoot === 'string' && m.repository.contentRoot.includes('/linked-wt');
+      description: "repository.contentRoot must contain linked-wt path"
+
+- description: "harden-prepare #474: repository.root stays main-rooted; planGuardrails from main config"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/skill/harden-prepare.js"
+    script_args: '--failure-text "test failure" --skill plan-sdlc'
+    script_cwd: "{{project_root}}/linked-wt"
+    project_root: "file://fixtures-fs/harden-worktree-content-root"
+  assert:
+    - type: javascript
+      value: |
+        const m = JSON.parse(output);
+        return !m.repository.root.includes('linked-wt');
+      description: "repository.root must NOT contain linked-wt (stays main worktree)"
+    - type: javascript
+      value: |
+        const m = JSON.parse(output);
+        const ids = (m.surfaces.planGuardrails || []).map(g => g.id);
+        return ids.includes('main-config-guardrail');
+      description: "planGuardrails must include main-config-guardrail loaded from main config"

--- a/tests/promptfoo/datasets/harden-sdlc.yaml
+++ b/tests/promptfoo/datasets/harden-sdlc.yaml
@@ -510,3 +510,24 @@
         mutual-exclusion message. The skill does NOT proceed to the prepare script in this case —
         it stops at Step 0 (Parse Arguments). No manifest is written. The response cites R19
         and the Step 0 mutual-exclusion guard.
+
+# #474 — worktree-aware write behavior (behavioral; NOT auto-run per no-auto-eval)
+
+- description: "harden-sdlc #474: SKILL.md passes PROJECT_ROOT from repository.contentRoot (not cwd)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md"
+    project_context: "file://fixtures/harden-plugin-defect-context.md"
+    user_request: >
+      A developer runs /harden-sdlc from a linked git worktree (linked-wt/) on branch feat/x.
+      The harden-prepare.js manifest contains repository.root = /main and
+      repository.contentRoot = /main/linked-wt. When dispatching the orchestrator in Step 3,
+      what value does SKILL.md pass for PROJECT_ROOT, and how is it obtained?
+  assert:
+    - type: llm-rubric
+      value: >
+        The response states that SKILL.md reads repository.contentRoot from the manifest JSON
+        (MANIFEST_FILE) and passes it as PROJECT_ROOT to the orchestrator — NOT the current
+        working directory and NOT a value computed via git. The response must cite that this
+        follows the single-source pattern used for pluginRepoUrl (read directly from the
+        manifest). The response must NOT describe passing cwd or running git rev-parse as
+        the source for PROJECT_ROOT.

--- a/tests/promptfoo/fixtures-fs/harden-worktree-content-root/setup.sh
+++ b/tests/promptfoo/fixtures-fs/harden-worktree-content-root/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Fixture for harden-prepare-exec.yaml — linked-worktree content-root rooting (#474).
+# Creates a main worktree with config.json + a main-only dimension, then a linked
+# worktree (feat/x) whose branch removes main-only and adds branch-only.
+# The test runs harden-prepare.js from linked-wt/ to assert content-root rooting.
+set -e
+
+git init -q -b main
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# --- main worktree: config + main-only dimension ---
+mkdir -p .sdlc/review-dimensions
+
+cat > .sdlc/config.json <<'CONFIG'
+{
+  "sdlc": "1.0.0",
+  "plan": {
+    "guardrails": [
+      {
+        "id": "main-config-guardrail",
+        "description": "A guardrail that lives in the main worktree config.",
+        "severity": "warning"
+      }
+    ]
+  },
+  "execute": {
+    "guardrails": []
+  }
+}
+CONFIG
+
+cat > .sdlc/review-dimensions/main-only.md <<'DIMENSION'
+---
+name: main-only
+description: "A review dimension that exists only in the main worktree branch."
+severity: medium
+triggers:
+  - "**/*.ts"
+---
+
+# Main-Only Dimension
+
+This dimension is committed on the main branch and should NOT appear when
+harden-prepare.js is invoked from the linked worktree (feat/x).
+DIMENSION
+
+git add -A
+git commit -q -m "init: main worktree with config + main-only dimension"
+
+# --- linked worktree on feat/x ---
+git worktree add --quiet linked-wt -b feat/x
+
+# Remove main-only dimension from the branch, add branch-only
+rm linked-wt/.sdlc/review-dimensions/main-only.md
+
+cat > linked-wt/.sdlc/review-dimensions/branch-only.md <<'DIMENSION'
+---
+name: branch-only
+description: "A review dimension that exists only in the active linked worktree branch."
+severity: medium
+triggers:
+  - "**/*.ts"
+---
+
+# Branch-Only Dimension
+
+This dimension is committed on the feat/x branch and MUST appear when
+harden-prepare.js is invoked from the linked worktree (feat/x).
+DIMENSION
+
+cd linked-wt && git add -A && git commit -q -m "feat/x: replace main-only dimension with branch-only"

--- a/tests/promptfoo/fixtures-fs/harden-worktree-content-root/setup.sh
+++ b/tests/promptfoo/fixtures-fs/harden-worktree-content-root/setup.sh
@@ -6,8 +6,8 @@
 set -e
 
 git init -q -b main
-git config user.email "test@test.com"
-git config user.name "Test"
+git config --local user.email "test@test.com"
+git config --local user.name "Test"
 
 # --- main worktree: config + main-only dimension ---
 mkdir -p .sdlc/review-dimensions


### PR DESCRIPTION
## Summary

- **Root cause:** `harden-prepare.js` used a single main-worktree root for all surface loaders, so `reviewDimensions[].path` and `copilotInstructions[].path` pointed to the main worktree even when invoked from a linked worktree — approved edits landed on the wrong branch.
- **Fix:** Adopt the dual-root pattern (`projectRoot = resolveSdlcRoot()` for config/guardrails; `contentRoot = resolveActiveWorktreeSafe()` for branch-tracked surfaces). The manifest now emits `repository.contentRoot`; SKILL.md reads it for `PROJECT_ROOT` and the copilot-mirror path.
- **Scope:** `harden-prepare.js`, `harden-orchestrator.md`, `harden-sdlc/SKILL.md`, spec P13/C-contentroot, user-facing worktree note in `docs/skills/`, exec tests with a real linked-worktree fixture (3/3 passing).

## Changes

| File | Change |
|------|--------|
| `plugins/sdlc-utilities/scripts/skill/harden-prepare.js` | Import `resolveActiveWorktreeSafe`; add `contentRoot`; route dim pre-flight + dim/copilot loaders + branch/diff cwd through `contentRoot`; emit `repository.contentRoot`; whitelist `cwd`-only in `safeExec` |
| `plugins/sdlc-utilities/agents/harden-orchestrator.md` | Add `repository.contentRoot` field-table row; clarify `repository.root` = main; per-surface `targetFile` rule; update `PROJECT_ROOT` description; scope read-boundary to Reads |
| `plugins/sdlc-utilities/skills/harden-sdlc/SKILL.md` | Step 3: read `CONTENT_ROOT`/`MAIN_ROOT` from manifest (no git recompute); Step 5b: pass absolute `proposal.targetFile` to generator; root mirror dir at `CONTENT_ROOT` |
| `docs/specs/harden-sdlc.md` | Amend P11; add P13 (`repository.contentRoot`); add C-contentroot; add scope note to C-projectroot |
| `docs/skills/harden-sdlc.md` | Add worktree behavior callout under "What It Creates or Modifies" |
| `tests/promptfoo/fixtures-fs/harden-worktree-content-root/setup.sh` | New fixture: main (config + `main-only` dim) + linked worktree `feat/x` (`branch-only` dim) |
| `tests/promptfoo/datasets/harden-prepare-exec.yaml` | 3 new exec cases: `reviewDimensions` rooted in linked-wt, `contentRoot` = linked-wt, `root` stays main |
| `tests/promptfoo/datasets/harden-sdlc.yaml` | 1 behavioral case for SKILL.md `PROJECT_ROOT` sourcing (authored; not auto-run) |

## Test plan

- [x] `promptfoo eval -c tests/promptfoo/promptfooconfig-exec.yaml --filter-pattern "harden-prepare #474"` → 3/3 passed
- [x] `node .claude/skills/validate-plugin-consistency/check-consistency.js` → all checks passed
- [x] `node .claude/skills/validate-skill-docs/check-docs-consistency.js` → 0 errors (28 pre-existing warnings in other skills)
- [x] Smoke-test single-worktree: `contentRoot === root` ✓ (KD4 — no behavior change outside linked worktree)

Fixes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)