### PR TITLE
fix(#483): plan-sdlc - deterministic G18 floor and format gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.21.15] - 2026-06-27
+
+### Fixed
+- plan-sdlc: deterministic G18 floor and format gate — adds a PF7 deterministic floor to the G18 gate (backed by `validate-plan-format.js`) and a Step 6.6 format-validation gate so plan format is enforced by script rather than LLM judgement alone; PF9 adds a Verification Scorecard floor for Gate B on full-pipeline plans (#483)
+
 ## [0.21.14] - 2026-06-26
 
 ### Fixed

--- a/docs/skills/plan-sdlc.md
+++ b/docs/skills/plan-sdlc.md
@@ -47,7 +47,7 @@ Not every request needs a full planning pipeline:
 
 For plans with 5+ tasks, the skill also writes a `## Key Decisions` section — placed between the plan header and the first task — capturing architecture choices with rationale so executing agents understand *why* an approach was chosen, not just what to do.
 
-Every plan also carries a required **`## Deviations & assumptions`** section near the top (a table with `Item | asked | does | why` columns) recording where the plan diverges from what was asked and any assumptions made — so a reviewer can triage the plan in one pass. Its presence is enforced deterministically by the `validate-plan-format.js` PF6 check, not by an LLM gate.
+Every plan also carries a required **`## Deviations & assumptions`** section near the top (a table with `Item | asked | does | why` columns) recording where the plan diverges from what was asked and any assumptions made — so a reviewer can triage the plan in one pass. Its presence is enforced deterministically by the `validate-plan-format.js` PF6 check, not by an LLM gate. PF7 — Contract presence: every artifact-touching task (≥1 Create/Modify/Test Files entry) has a `**Contract:**` block (default check set). PF9 — Scorecard presence: `## Verification Scorecard` section present (under `--final` only; full-pipeline plans).
 
 Each task block carries `Complexity`, `Risk`, `Depends on`, `Verify`, `Files`, and `Acceptance criteria` metadata plus a `Contract:` (decided-shape) block. The free-prose **`Notes:`** field is **optional** and rationale-only (≤5 non-blank lines) — the executable "what" lives in `Files:` + `Contract:` + `Acceptance criteria:`. (Plans written before this convention used a mandatory `Description:` field; it is renamed `Notes:` and demoted to optional.)
 
@@ -496,6 +496,18 @@ See [OpenSpec Integration Guide](../openspec-integration.md) for the full workfl
 ## Link Verification (issue #198)
 
 Before declaring the plan ready (Step 7 handoff), the skill pipes the finalized plan file through `scripts/lib/links.js` as a hard gate. The validator auto-derives `expectedRepo` from `git remote origin` and `jiraSite` from `~/.sdlc-cache/jira/` — the skill never constructs the validator context. URL classes checked: GitHub issues/PRs (owner/repo identity + existence), Atlassian `*.atlassian.net/browse/<KEY>` (host match), and any other `http(s)://` URL (HEAD reachability, 5s timeout). Hosts in the built-in skip list (`linkedin.com`, `x.com`, `twitter.com`, `medium.com`) are reported as `skipped`, not violations. Set `SDLC_LINKS_OFFLINE=1` to skip generic reachability while keeping context-aware checks. On non-zero exit, Step 7 is **not** entered and the violation list is surfaced verbatim. No flag toggles this gate — it is hard.
+
+## Format Validation (issue #483)
+
+Immediately after Link Verification passes (Step 6.6), the skill runs the finalized plan file through `scripts/ci/validate-plan-format.js` as a second hard gate before Step 7 handoff. This enforces the *structural presence* of the review surfaces deterministically, so a plan can no longer be finalized missing them because an LLM critique lane silently did not run.
+
+Checks applied at this gate:
+
+- **PF6** — `## Deviations & assumptions` section present.
+- **PF7** — every artifact-touching task (≥1 `Create:`/`Modify:`/`Test:` Files entry) carries a `**Contract:**` block. This is the deterministic floor for the G18 settlement gate.
+- **PF9** — `## Verification Scorecard` section present. This is the deterministic floor for Gate B. PF9 is applied **only when `--final` is passed**, which the skill does only for full-pipeline plans (those that ran the Step 5 multi-lens review). Lightweight plans that skip Step 5 are not expected to carry a scorecard, so PF9 is omitted for them. The `--final` decision is driven by the Step 0 routing branch, never by scorecard presence (that would make the check circular).
+
+These are *presence* checks only — concreteness and content quality remain the job of the LLM gates G18/G19/G20/G21 (the calibrated ceiling above this floor). On non-zero exit, Step 7 is **not** entered and the violation report is surfaced verbatim. No flag toggles this gate — it is hard. G19 (render-don't-narrate) and G21 (self-contained code refs) have no deterministic floor by design: both require semantic judgment that a regex proxy would mis-fire on (see PF8-reserved in the spec).
 
 ---
 

--- a/docs/specs/plan-sdlc.md
+++ b/docs/specs/plan-sdlc.md
@@ -94,6 +94,8 @@
 - R50 (Fixes #472 — Mermaid): Mermaid fenced blocks are allowed for flow / call-order / state surfaces; no MDX.
 - R51 (Fixes #472 — self-contained code refs): A bare `file:line` change reference is forbidden; embed the surrounding lines (or the full function body) plus an inline `-`/`+` diff. Flagged by G21 (blocking). A `file:line` used as a pointer / `Contract.mirror` precedent anchor is exempt.
 - R52 (Fixes #472 — de-dup rationale convention): One rationale per decision — convention / guidance only, not gated.
+- R53 (Fixes #483 — deterministic gate backing): The structural PRESENCE of G18 (per-task `**Contract:**` block) and Gate B (`## Verification Scorecard` section) MUST be enforced deterministically by validate-plan-format.js — PF7 (Contract presence) and PF9 (Scorecard presence) — independent of the LLM gate lanes. PF7 runs in the default check set; PF9 runs only under `--final`. plan-sdlc Step 6.6 invokes the validator with `--final` as a hard gate blocking Step 7. PF9 is omitted (no `--final`) when Step 0 took the lightweight routing path (Step 5 skipped), so the scorecard floor applies only to full-pipeline plans. G19 and G21 remain LLM-only — both require semantic judgment (render-trigger detection; change-site vs precedent ref) that a deterministic proxy mis-fires, and a mis-fire would block valid plans at the Step 6.6 gate. The LLM gates G18/G19/G21 are retained as the concreteness/quality ceiling above the deterministic presence floor.
+- R54 (Fixes #483 — judge calibration): The content-coverage critique lane (owner of G18/G19/G20/G21) MUST receive the path to plan-format-reference.md and read it before judging those gates, evaluating concreteness / render / code-ref anchoring against its worked examples rather than the prose gate definitions alone. The Step 2 planner MUST read plan-format-reference.md and match its worked examples (read-then-match), not merely be pointed at it. The reference is read at runtime, never embedded in a dispatched prompt (prompt-cache stability).
 
 ## Workflow Phases
 
@@ -128,16 +130,16 @@
 - G15: Brief citation coverage — when `explorePack.manifestPath` was non-null AND the orchestrator produced a brief, every Standard/Complex task cites ≥1 `F-<DIM>-<n>` finding ID OR is marked "out-of-scope addition" with rationale. Trivial tasks are exempt. Severity: error when brief was produced; not applicable when fallback path ran.
 - G16: OpenSpec tasks.md coverage — when `fromOpenspecDirect` is true: every entry in `openspecContext.tasks[]` is either (a) referenced by ≥1 plan task's `openspec-task.ref`, or (b) listed in `## Out-of-scope OpenSpec tasks`. Error severity (blocking).
 - G17: Dimension Coverage — when G17 subagent dispatched: emit proposals per R31 criteria with R31 suppression and ranking rules. Severity: advisory (non-blocking).
-- G18: Settlement / contract concreteness — every artifact-touching task carries a `Contract:` block whose decided shape is concrete for the task's plan type (type derived from `Files:` paths); flag any task that leaves the shape unsettled (absent Contract or a restatement of 'update X to do Y'). Error-severity; owned by the content-coverage lane.
+- G18: Settlement / contract concreteness — every artifact-touching task carries a `Contract:` block whose decided shape is concrete for the task's plan type (type derived from `Files:` paths); flag any task that leaves the shape unsettled (absent Contract or a restatement of 'update X to do Y'). Error-severity; owned by the content-coverage lane. Backed by deterministic presence floor PF7 (validate-plan-format.js, default check set); LLM G18 judges concreteness above the floor.
 - G19: Render-don't-narrate — flags any task touching a render-trigger surface (R46
   catalog #1–#8) that renders no concrete artifact for it. Trivial docs/rename tasks
   are not flagged. Also flags any Contract that includes more than one rendered example
   per distinct contract shape (per R49 cap — one elided example per unique method+path
-  for REST, or flag+type for CLI). Error-severity; owned by the content-coverage lane.
+  for REST, or flag+type for CLI). Error-severity; owned by the content-coverage lane. LLM-only (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
 - G20: Notes rationale-only — flags a `Notes:` block that restates the task's
   Contract/acceptance instead of carrying only rationale. Error-severity; owned by the content-coverage lane.
 - G21: Self-contained code refs — flags a bare `file:line` change reference not
-  anchored with surrounding lines (or the full function body) plus an inline diff. Error-severity; owned by the content-coverage lane.
+  anchored with surrounding lines (or the full function body) plus an inline diff. Error-severity; owned by the content-coverage lane. LLM-only (semantic — change-site vs precedent ref); no deterministic floor (KD6).
 
 ### Verification Scorecard (Gates A/B)
 
@@ -151,6 +153,8 @@ Gates A and B apply the per-check severity model from opsx:verify verbatim (CRIT
 - When uncertain, prefer SUGGESTION > WARNING > CRITICAL (per opsx:verify heuristic)
 
 Gate A (intake audit, R39) runs before decomposition when `openspecContext.requirements` is present. Gate B (plan audit, R40) runs at Step 5 and produces the `## Verification Scorecard` section. Verdict labels are verbatim: any CRITICAL → *"…Fix before archiving."*; warnings only → *"…Ready for archive (with noted improvements)."*; clean → *"All checks passed. Ready for archive."* Both gates degrade gracefully when artifacts are missing (R43).
+
+Gate B (plan audit, R40): `## Verification Scorecard` section presence enforced deterministically by PF9 (validate-plan-format.js, `--final`); LLM Gate B judges content quality above the floor.
 
 ## Prepare Script Contract
 
@@ -196,6 +200,9 @@ Deterministic checks performed by `plugins/sdlc-utilities/scripts/ci/validate-pl
 - PF4: Dependency references valid (no cycles, all targets exist)
 - PF5: Task body valid (`Acceptance criteria` present with ≥1 checkbox; optional `Notes` block capped at ≤5 non-blank lines)
 - PF6: `## Deviations & assumptions` section present at top of plan (implements R47 deterministic enforcement — not an LLM gate)
+- PF7: Contract presence — every artifact-touching task (≥1 `Create:`/`Modify:`/`Test:` Files entry) carries a `**Contract:**` block (implements R53 deterministic floor for G18). Runs in the default check set.
+- PF8: reserved — intentionally unallocated. A deterministic floor for G21 (self-contained code refs) was considered and dropped: distinguishing a change-site `file:line` from a precedent/context ref is semantic, so a PF8 proxy would mis-fire and block valid plans at the Step 6.6 gate (the same objection that keeps G19 LLM-only). G21 stays the LLM ceiling. The number is preserved to keep PF references stable.
+- PF9: Scorecard presence — `## Verification Scorecard` section present (implements R53 deterministic floor for Gate B). Runs only under `--final`; omitted for lightweight plans that skip Step 5.
 
 ## Constraints
 

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.21.14",
+  "version": "0.21.15",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
+++ b/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
@@ -11,6 +11,7 @@
  *   --file <path>           Plan file to validate (required)
  *   --json                  JSON output to stdout (default)
  *   --markdown              Formatted markdown output to stdout
+ *   --final                 Also enforce PF9 (Verification Scorecard)
  *
  * Exit codes: 0 = all pass, 1 = issues found, 2 = script error
  *
@@ -21,6 +22,8 @@
  *   PF4 — Dependency validity (valid refs, no cycles)
  *   PF5 — Task body (Acceptance criteria; optional Notes capped at 5 lines)
  *   PF6 — Deviations & assumptions section present
+ *   PF7 — Contract presence (artifact-touching tasks have **Contract:** block)
+ *   PF9 — Scorecard presence (under --final only)
  *
  * Uses only Node.js built-in modules. No npm install required.
  */
@@ -42,6 +45,7 @@ function parseArgs(argv) {
   let projectRoot  = resolveSdlcRoot();
   let filePath     = null;
   let outputFormat = 'json';
+  let requireScorecard = false;
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -53,10 +57,12 @@ function parseArgs(argv) {
       outputFormat = 'json';
     } else if (a === '--markdown') {
       outputFormat = 'markdown';
+    } else if (a === '--final') {
+      requireScorecard = true;
     }
   }
 
-  return { projectRoot, filePath, outputFormat };
+  return { projectRoot, filePath, outputFormat, requireScorecard };
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +321,23 @@ function checkPF6(content) {
   return { id: 'PF6', status: 'pass', message: 'Deviations & assumptions section present' };
 }
 
+function checkPF7(tasks) {
+  const offenders = tasks
+    .filter(t => /^[-*]\s+(Create|Modify|Test):/m.test(t.body)
+              && !/^\*\*Contract:\*\*/m.test(t.body))
+    .map(t => `Task ${t.number}`);
+  return offenders.length
+    ? { id: 'PF7', status: 'fail', message: `Missing **Contract:** block: ${offenders.join(', ')}` }
+    : { id: 'PF7', status: 'pass', message: 'All artifact-touching tasks have a Contract block' };
+}
+
+function checkPF9(content) {
+  const stripped = content.replace(/^```[\s\S]*?^```/gm, '');
+  return /^##\s+Verification\s+Scorecard/im.test(stripped)
+    ? { id: 'PF9', status: 'pass', message: 'Verification Scorecard section present' }
+    : { id: 'PF9', status: 'fail', message: 'Missing required "## Verification Scorecard" section' };
+}
+
 // ---------------------------------------------------------------------------
 // Output formatters
 // ---------------------------------------------------------------------------
@@ -346,7 +369,7 @@ function formatMarkdown(report) {
 // ---------------------------------------------------------------------------
 
 try {
-  const { projectRoot, filePath, outputFormat } = parseArgs(process.argv);
+  const { projectRoot, filePath, outputFormat, requireScorecard } = parseArgs(process.argv);
 
   if (!filePath) {
     process.stderr.write('validate-plan-format.js error: --file <path> is required\n');
@@ -368,7 +391,9 @@ try {
     checkPF4(tasks),
     checkPF5(tasks),
     checkPF6(content),
+    checkPF7(tasks),
   ];
+  if (requireScorecard) checks.push(checkPF9(content));
 
   const passed = checks.every(c => c.status === 'pass');
   const report = {

--- a/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
@@ -310,7 +310,7 @@ Plan tasks NOT derived from any OpenSpec task MUST omit the field. N:1 mapping (
 
 **Key decisions:** Note every decision where you chose between valid approaches. Focus on choices where a reasonable implementer might differ without the rationale. Skip obvious decisions.
 
-**Per-task metadata (required, consumed by execute-plan-sdlc):** Use the exact format from `./plan-format-reference.md`:
+**Per-task metadata (required, consumed by execute-plan-sdlc):** Read `./plan-format-reference.md` first and match its worked examples:
 
 ```markdown
 ### Task N: [Component Name]
@@ -343,15 +343,15 @@ Files + Contract + Acceptance criteria — do not restate it here.]
 
 **Contract block (required — implements R45):** Every artifact-touching task MUST include a `**Contract:**` block per `./plan-format-reference.md`, carrying the type-appropriate decided shape (code: signatures/types/flags/error-cases/import-paths; docs: template+sections+audience+cross-links; openspec/spec: requirement IDs ADD/MODIFY/REMOVE + delta text + numbering). The plan type is derived from the task's `Files:` paths; a mixed-artifact task uses its dominant artifact's column. A task whose Contract is absent or merely restates "update X to do Y" is flagged by G18 in Step 3.
 
-**G18 — Settlement / contract concreteness (error-severity):** Flags any artifact-touching task whose `Contract:` is absent or merely restates "update X to do Y" without a concrete type-appropriate shape. Owned by the content-coverage lane. Blocks plan approval until the Contract pins the decided shape.
+**G18 — Settlement / contract concreteness (error-severity):** Flags any artifact-touching task whose `Contract:` is absent or merely restates "update X to do Y" without a concrete type-appropriate shape. Owned by the content-coverage lane. Blocks plan approval until the Contract pins the decided shape. Backed by deterministic presence floor PF7 (validate-plan-format.js, default check set); LLM G18 judges concreteness above the floor.
 
 **Render don't narrate (surface-conditional — implements R46):** When a task touches a concrete-artifact surface (payload, struct/schema field change, status enum, flow, config/flag delta, error mode, data-writing end-state), RENDER the artifact (fenced block / table / before→after diff) — do not describe it in prose. Use the catalog + conventions in ./plan-format-reference.md. Cap: one elided (…) example per distinct contract shape (a distinct contract shape is one unique combination of method + path for REST, or flag + type for CLI — two endpoints with the same method but different paths are distinct shapes). Trivial docs/rename tasks render nothing. (Mermaid fenced blocks allowed for flow/call-order/state surfaces; no MDX.) A task whose concrete-artifact surface is described in prose rather than rendered is flagged by G19 in Step 3.
 
-**G19 — Render-don't-narrate (error-severity):** Flags a task that touches a render-trigger surface (REST/RPC endpoint, CLI flag, schema field, status enum, state/flow/enum, config delta, error taxonomy) but describes it in prose instead of rendering a fenced block, table, or before→after diff. Owned by the content-coverage lane. Blocks plan approval until the surface is rendered. Not-applicable for trivial tasks and pure docs/rename tasks.
+**G19 — Render-don't-narrate (error-severity):** Flags a task that touches a render-trigger surface (REST/RPC endpoint, CLI flag, schema field, status enum, state/flow/enum, config delta, error taxonomy) but describes it in prose instead of rendering a fenced block, table, or before→after diff. Owned by the content-coverage lane. Blocks plan approval until the surface is rendered. Not-applicable for trivial tasks and pure docs/rename tasks. LLM-only (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
 
 **G20 — Notes rationale-only (error-severity):** Flags a `Notes:` block that restates the task's Contract/acceptance instead of carrying only rationale. Owned by the content-coverage lane (lanes[1]). Blocks plan approval until the `Notes:` block is rationale-only.
 
-**G21 — Self-contained code refs (error-severity):** Flags a bare `file:line` change reference not anchored with surrounding lines (or the full function body) plus an inline diff. A `file:line` used as a pointer / `Contract.mirror` precedent anchor is exempt. Owned by the content-coverage lane (lanes[1]). Blocks plan approval until the reference is self-contained.
+**G21 — Self-contained code refs (error-severity):** Flags a bare `file:line` change reference not anchored with surrounding lines (or the full function body) plus an inline diff. A `file:line` used as a pointer / `Contract.mirror` precedent anchor is exempt. Owned by the content-coverage lane (lanes[1]). Blocks plan approval until the reference is self-contained. LLM-only (semantic — change-site vs precedent ref); no deterministic floor (KD6).
 
 **Verification strategy — match to task type:**
 - Feature/logic → TDD (write failing test, implement, pass)
@@ -380,6 +380,7 @@ For each `lanes[i]` entry (i = 0..4):
 - prompt body: Read `lanes[i].promptTemplatePath` and fill template variables:
   - All lanes: `{PLAN_FILE_PATH}` (absolute path to plan file), `{PROJECT_ROOT}` (cwd)
   - Lanes 0–3 non-G17: `{REQUIREMENTS_SUMMARY}` (the numbered requirements list from Step 1 CONSUME — same content as `{REQUIREMENTS_CHECKLIST}` in Step 5; retained in memory from Step 1), `{ACTIVE_GUARDRAILS}` (from `guardrails[]` P7), `{OPENSPEC_TASKS}` (from `openspecContext.tasks` P13, null when not OpenSpec-sourced), `{BRIEF_FINDING_IDS}` (from `explorePack.manifestPath` context, null when no brief)
+  - Lane 1 (content-coverage) additionally: `{FORMAT_REFERENCE_PATH}` — absolute path to plan-format-reference.md (sibling of lane-content-coverage-prompt.md in the same skill directory; resolve as `dirname(lanes[1].promptTemplatePath)/plan-format-reference.md`)
   - Lane 4 (G17/dimension-coverage): `{DIMENSIONS_DIR}` (`.sdlc/review-dimensions/`), `{COPILOT_DIR}` (`.github/instructions/`), `{GITHUB_HOSTING_DETECTED}` (`githubHosting.detected` from P14), `{LEARNINGS_LOG_PATH}` (`.sdlc/learnings/log.md`), `{PR_COMMIT_WINDOW}` (best-effort "last 14 days" if unknown)
 
 **Null `promptTemplatePath` handling:** When `lanes[i].promptTemplatePath` is null (prepare script reported it could not find the template), skip that lane's dispatch and immediately add a synthetic blocking issue:
@@ -548,6 +549,37 @@ On non-zero exit (`LINK_EXIT != 0`):
 - Stop. Do not retry. Do not edit URLs without user input. Do not bypass.
 
 On zero exit, proceed to Step 7. `SDLC_LINKS_OFFLINE=1` skips network reachability while keeping context-aware checks (GitHub identity match, Atlassian host match) — use in sandboxed CI.
+
+## Step 6.6 (FORMAT VALIDATION): Validate plan structure — HARD GATE
+
+After link verification passes, run the deterministic plan format validator. PF9 (Verification Scorecard presence) is applied only when this run executed Step 5 (the multi-lens review).
+
+**Set `FINAL_FLAG` from the Step 0 routing branch THIS run took** — NOT from scorecard presence (deriving it from the artifact it checks would make PF9 circular):
+
+- **Full-pipeline plan** (Step 0 routed through Step 5, the multi-lens review — i.e. ≥4 files): `FINAL_FLAG="--final"`. A scorecard is expected, so PF9 is enforced.
+- **Lightweight plan** (Step 5 skipped): `FINAL_FLAG=""`. No scorecard expected, so PF9 is not applied.
+
+Substitute the correct value into the block below before running it; `${FINAL_FLAG:+--final}` expands to `--final` only when `FINAL_FLAG` is non-empty, and to nothing otherwise (no word-splitting, no empty positional argument).
+
+```bash
+VALIDATOR=$(find ~/.claude/plugins -name "validate-plan-format.js" -path "*/sdlc*/scripts/ci/validate-plan-format.js" 2>/dev/null | sort -V | tail -1)
+[ -z "$VALIDATOR" ] && [ -f "plugins/sdlc-utilities/scripts/ci/validate-plan-format.js" ] && VALIDATOR="plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+[ -z "$VALIDATOR" ] && { echo "ERROR: Could not locate scripts/ci/validate-plan-format.js. Is the sdlc plugin installed?" >&2; exit 2; }
+# FINAL_FLAG is set above from the Step 0 routing branch THIS run took:
+#   "--final" for a full-pipeline plan (Step 5 ran → scorecard expected),
+#   ""        for a lightweight plan (Step 5 skipped → PF9 not applied).
+# It is NOT derived from scorecard presence (that would make PF9 circular).
+node "$VALIDATOR" ${FINAL_FLAG:+--final} --markdown --file "$plan_path"
+FORMAT_EXIT=$?
+```
+
+On non-zero exit (`FORMAT_EXIT != 0`):
+- The script has already printed the violation report to stdout (markdown format).
+- Do NOT proceed to Step 7 (Handoff). The plan is not ready.
+- Surface the violation report verbatim to the user.
+- Stop. Do not retry. Do not auto-edit. Do not bypass.
+
+On zero exit, proceed to Step 7.
 
 ## Step 7: Handoff
 

--- a/plugins/sdlc-utilities/skills/plan-sdlc/lane-content-coverage-prompt.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/lane-content-coverage-prompt.md
@@ -16,8 +16,11 @@ You receive:
 - `{OPENSPEC_TASKS}` — OpenSpec tasks from tasks.md (null when not an OpenSpec-sourced plan)
 - `{ACTIVE_GUARDRAILS}` — guardrail IDs active for this project (for context)
 - `{BRIEF_FINDING_IDS}` — F-<DIM>-<n> finding IDs from the discovery brief (null when no brief produced)
+- `{FORMAT_REFERENCE_PATH}` — absolute path to plan-format-reference.md (the worked-example catalog: Contract shape, the render-trigger catalog, code-ref anchoring)
 
 Read the plan file at `{PLAN_FILE_PATH}` before evaluating.
+
+Read the catalog at `{FORMAT_REFERENCE_PATH}` before judging G18/G19/G20/G21. Its Contract examples, the 8-row render-trigger catalog, and the before→after code-ref diff are the calibration standard — judge concreteness / render / anchoring against those worked examples, not the prose gate definitions alone.
 
 ---
 

--- a/plugins/sdlc-utilities/skills/plan-sdlc/plan-format-reference.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/plan-format-reference.md
@@ -127,6 +127,7 @@ an indented `- key: value` list, mirroring the `**openspec-task:**` sub-block pr
 pins the **decided shape** of the deliverable so execution renders it verbatim rather than
 re-deriving (or stalling BLOCKED on) a design decision planning already closed. The G18 settlement
 gate flags any artifact-touching task whose Contract is absent or merely restates "update X to do Y".
+Deterministically enforced by PF7 (validate-plan-format.js, default check set) — every artifact-touching task must carry this block.
 
 Keys: `shape`, `names`, `mirror`, `decisions`, `sync`.
 
@@ -316,6 +317,8 @@ Carve-out: `Contract.mirror` line-anchors (e.g. `src/utils/hash.ts:1-40`) remain
 are **precedent pointers** to existing structure being copied, not change references. The mirror
 anchor names the source of truth to imitate; the prohibition applies only to lines the task edits.
 
+G21 (self-contained code refs) remains an LLM judgment — no deterministic check (see KD6 in plan docs).
+
 ### One rationale per decision (R52)
 
 State each de-dup or design rationale exactly once and reference it; do not repeat the same
@@ -343,6 +346,14 @@ gate (R38) does not suppress the suggestion at execute time.
 
 Format:
 - <verbatim OpenSpec task title> — <one-line rationale>
+
+---
+
+## Verification Scorecard (full-pipeline plans)
+
+Present only in full-pipeline plans (i.e., `--from-openspec` or equivalent multi-task runs). Assembled by plan-sdlc at Step 5 (after the lens merge). Contains a dimension table, a traceability matrix, and a go/no-go verdict. See [`docs/skills/plan-sdlc.md`](../../../docs/skills/plan-sdlc.md) — Gate B section for the full format specification.
+
+Deterministically enforced by PF9 (validate-plan-format.js, --final) — the section must be present in full-pipeline plans.
 
 ---
 

--- a/tests/promptfoo/datasets/plan-format-exec.yaml
+++ b/tests/promptfoo/datasets/plan-format-exec.yaml
@@ -150,3 +150,40 @@
       value: '"passed": true'
     - type: regex
       value: '"failed":\s*0'
+
+- description: "plan-format: artifact task without Contract triggers PF7 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/plan.md --json"
+    project_root: "file://fixtures-fs/project-plan-missing-contract"
+  assert:
+    - type: icontains
+      value: '"passed": false'
+    - type: icontains
+      value: "PF7"
+    - type: icontains
+      value: "Contract"
+
+- description: "plan-format: --final without scorecard triggers PF9 fail"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/test-plan.md --final --json"
+    project_root: "file://fixtures-fs/project-valid-plan"
+  assert:
+    - type: icontains
+      value: '"passed": false'
+    - type: icontains
+      value: "PF9"
+    - type: icontains
+      value: "Verification Scorecard"
+
+- description: "plan-format: --final with scorecard present passes PF9"
+  vars:
+    script_path: "repo://plugins/sdlc-utilities/scripts/ci/validate-plan-format.js"
+    script_args: "--project-root {{project_root}} --file {{project_root}}/plans/plan.md --final --json"
+    project_root: "file://fixtures-fs/project-plan-with-scorecard"
+  assert:
+    - type: icontains
+      value: '"passed": true'
+    - type: icontains
+      value: "PF9"

--- a/tests/promptfoo/fixtures-fs/project-plan-missing-contract/plans/plan.md
+++ b/tests/promptfoo/fixtures-fs/project-plan-missing-contract/plans/plan.md
@@ -1,0 +1,31 @@
+# Fix something: Implementation Plan
+
+**Goal:** Test goal — triggers PF7 (missing Contract block on artifact task).
+**Architecture:** Single module approach.
+**Source:** GitHub issue #999
+**Verification:** manual
+
+---
+
+## Deviations & assumptions
+
+| Item | asked | does | why |
+|---|---|---|---|
+| None | — | — | — |
+
+---
+
+### Task 1: Do the thing
+
+**Complexity:** Standard
+**Risk:** Low
+**Depends on:** —
+**Verify:** manual
+
+**Files:**
+- Modify: `src/foo.js` — update the helper
+
+**Acceptance criteria:**
+- [ ] Helper updated
+
+---

--- a/tests/promptfoo/fixtures-fs/project-plan-with-scorecard/plans/plan.md
+++ b/tests/promptfoo/fixtures-fs/project-plan-with-scorecard/plans/plan.md
@@ -1,0 +1,56 @@
+# Fix something: Implementation Plan
+
+**Goal:** Test goal — full valid plan with Verification Scorecard.
+**Architecture:** Single helper module change.
+**Source:** GitHub issue #998
+**Verification:** node test
+
+---
+
+## Deviations & assumptions
+
+| Item | asked | does | why |
+|---|---|---|---|
+| None | — | — | — |
+
+---
+
+### Task 1: Do the thing
+
+**Complexity:** Standard
+**Risk:** Low
+**Depends on:** —
+**Verify:** manual
+
+**Files:**
+- Modify: `src/foo.js` — update the helper
+
+**Acceptance criteria:**
+- [ ] Helper updated
+
+**Contract:**
+- shape (code): `function doThing(input: string): string` — returns processed string
+- names: `doThing`
+- mirror: `src/foo.js`
+- decisions: none
+- sync: none
+
+---
+
+## Verification Scorecard
+
+*(Requirement traceability)*
+
+### Requirement → Task traceability
+
+| Surface | Requirement | Covered by |
+|---|---|---|
+| src/foo.js | Helper updated | Task 1 |
+
+### Quality dimensions
+
+| Dimension | Verdict | Notes |
+|---|---|---|
+| Completeness | PASS | Task 1 covers the change |
+
+**Verdict: Ready to execute.**

--- a/tests/promptfoo/fixtures-fs/project-valid-plan/plans/test-plan.md
+++ b/tests/promptfoo/fixtures-fs/project-valid-plan/plans/test-plan.md
@@ -38,6 +38,13 @@ Create a utility module that exports a `formatDate(date)` function. It should ac
 - [ ] `formatDate` returns null for null/undefined input
 - [ ] Tests cover both cases
 
+**Contract:**
+- shape (code): `function formatDate(date: Date | null | undefined): string | null` — returns ISO 8601 string or null
+- names: `formatDate`
+- mirror: src/utils/helper.js
+- decisions: none
+- sync: none
+
 ---
 
 ### Task 2: Create API endpoint
@@ -59,6 +66,13 @@ Create a GET `/api/dates/now` endpoint that returns the current date using the `
 - [ ] Response contains `date` field with ISO string
 - [ ] Uses formatDate from Task 1
 
+**Contract:**
+- shape (code): `router.get('/now', handler)` — handler returns `{ date: string }` via `res.json`
+- names: `datesRouter`, handler
+- mirror: src/routes/dates.js
+- decisions: none
+- sync: none
+
 ---
 
 ### Task 3: Add documentation
@@ -77,3 +91,10 @@ Add a section to the README documenting the new `/api/dates/now` endpoint, inclu
 **Acceptance criteria:**
 - [ ] README contains endpoint documentation
 - [ ] Example request and response included
+
+**Contract:**
+- shape (prose): markdown section `## API: /api/dates/now` with `GET` example request and JSON response block
+- names: none
+- mirror: README.md
+- decisions: none
+- sync: none


### PR DESCRIPTION
## Summary
Hardens the plan-sdlc skill's plan-quality gates with deterministic enforcement. A new PF7 check in `validate-plan-format.js` makes the G18 "contract concreteness" gate fail-closed on missing Contract blocks, a new PF9 check (under `--final`) enforces Verification Scorecard presence for full-pipeline plans (Gate B), and a new Step 6.6 FORMAT VALIDATION hard gate wires the validator into the plan workflow.

## Business Context
The plan-sdlc quality gates (G18 contract concreteness, Gate B verification scorecard) were enforced by LLM judgement alone. LLM judges can be inconsistent on structural presence checks, so a malformed plan — one missing a Contract block or the required Verification Scorecard section — could slip past review depending on model variance. Users of the sdlc-marketplace plugin rely on these gates to guarantee plans are concrete and executable before handoff to execute-plan-sdlc.

## Business Benefits
- Plan format violations are now caught deterministically by a script rather than only by LLM judgement, so the same malformed plan fails every time instead of intermittently.
- Clearer separation of responsibility: the deterministic floor catches missing structure; the LLM judge focuses on content quality above the floor — reducing false passes.
- The content-coverage LLM judge is now calibrated against the worked examples in `plan-format-reference.md`, making G18/G19/G20/G21 verdicts more consistent.

## Github Issue
Fixes #483

## Technical Design
- `validate-plan-format.js` gains two checks. PF7 (in the default check set) flags any artifact-touching task (a `Create:`/`Modify:`/`Test:` bullet) that lacks a `**Contract:**` block. PF9 (gated behind a new `--final` flag) requires a `## Verification Scorecard` section, scanning content with fenced code blocks stripped to avoid false matches inside examples.
- plan-sdlc gains Step 6.6 (FORMAT VALIDATION) — a hard gate that runs the validator after link verification. The `--final` flag is derived from the Step 0 routing branch the run actually took (full-pipeline vs lightweight), explicitly NOT from scorecard presence, to keep PF9 non-circular.
- The gate definitions for G18/G19/G21 are annotated to document the deterministic-vs-LLM split: G18 has a PF7 deterministic floor with the LLM judging concreteness above it; G19 and G21 remain LLM-only (semantic detection) with no deterministic floor, per design decisions KD2 and KD6.
- A new `{FORMAT_REFERENCE_PATH}` template variable is passed to the lane-1 content-coverage prompt so the judge reads `plan-format-reference.md` and calibrates against its worked examples.

## Technical Impact
- `validate-plan-format.js` adds a new opt-in `--final` flag; default invocation behavior is unchanged except PF7 now runs as part of the default check set, which can newly fail plans that omit Contract blocks.
- plan-sdlc adds a new hard gate (Step 6.6); plans that previously passed on structure alone via LLM leniency may now be blocked until the missing Contract or Verification Scorecard is supplied.
- No breaking changes to plugin manifests, hook payloads, or external script APIs.

## Changes Overview
- Added a deterministic PF7 contract-presence floor backing the G18 gate.
- Added a deterministic PF9 verification-scorecard floor (full-pipeline plans only) backing Gate B, behind a new `--final` flag.
- Added a Step 6.6 FORMAT VALIDATION hard gate that runs the validator within the plan workflow, with non-circular derivation of the final-plan flag.
- Documented the deterministic-vs-LLM enforcement split for the G18/G19/G21 gates across the skill, spec, and reference docs.
- Calibrated the content-coverage LLM judge against the plan-format reference via a new format-reference path template variable.
- Added promptfoo exec fixtures and a dataset covering the new validator behavior (missing contract, scorecard present, valid plan).

## Testing
- Added promptfoo exec test cases in `plan-format-exec.yaml` exercising the validator against three filesystem fixtures: a plan missing a Contract block (PF7 should fail), a plan with a Verification Scorecard (PF9 should pass under `--final`), and a valid plan.
- Covered both the default check set (PF7) and the `--final` path (PF9) per the project's promptfoo-only testing policy.
