### PR TITLE
fix(#488): plan-sdlc - enforce render-don't-narrate, trim prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harvest-learnings: `harvest-learnings.js` now reads from `.sdlc/learnings/log.md` (canonical path per #231 spec); legacy `.claude/learnings/log.md` triggers a one-version stderr deprecation fallback; `migrate-learnings-log.js` available for one-shot migration (#356)
 - ship-sdlc: post-PR CI verification and remote-review awaiting are now opt-in via `ship.steps[]` entries (`verify-pipeline`, `await-remote-review`). Boolean flags `ship.verifyPipeline` / `ship.awaitReview` removed; CLI flags `--verify-pipeline` / `--await-review` removed (passing them now produces a clear migration-pointer error). Schema bumped v3 → v4 with auto-migration on first read.
 
+## [0.21.16] - 2026-07-21
+
+### Fixed
+- plan-sdlc: clarified G19 render-don't-narrate gate reporting and split surface-vs-shape capping rules, tightening how format violations are reported (#488)
+
 ## [0.21.15] - 2026-06-27
 
 ### Fixed

--- a/docs/skills/plan-sdlc.md
+++ b/docs/skills/plan-sdlc.md
@@ -416,10 +416,14 @@ diff — or, for flow / call-order / state surfaces, a Mermaid fenced block
 | Frontmatter / manifest contract | `plugin.json` fields, `Contract:` block keys |
 | Error taxonomy | error codes, HTTP status map |
 
-**Per distinct contract shape, not per surface.** When a task touches multiple
-distinct event/endpoint/operation shapes, each distinct shape renders its own
-record — one illustrative, elided (`…`) example per distinct contract shape (not
-one example per surface category).
+**Each render-trigger surface must be rendered.** When a task touches multiple
+surfaces (e.g., REST endpoint AND CLI flag), each distinct surface must have its
+own render — rendering one surface does not excuse prose narration of another.
+
+**Cap: one example per distinct contract shape.** Within a surface, when a task
+touches multiple distinct event/endpoint/operation shapes, each distinct shape
+renders its own record — one illustrative, elided (`…`) example per distinct
+contract shape (not an exhaustive dump, and not one example per surface category).
 
 **Anti-bloat carve-out:** G19 is **not-applicable** for trivial tasks (Trivial complexity, or tasks whose only files match `docs/**`, `*.md` outside skills, or pure rename/move). These tasks have no render-trigger surface worth flagging.
 

--- a/docs/specs/plan-sdlc.md
+++ b/docs/specs/plan-sdlc.md
@@ -95,7 +95,8 @@
 - R51 (Fixes #472 — self-contained code refs): A bare `file:line` change reference is forbidden; embed the surrounding lines (or the full function body) plus an inline `-`/`+` diff. Flagged by G21 (blocking). A `file:line` used as a pointer / `Contract.mirror` precedent anchor is exempt.
 - R52 (Fixes #472 — de-dup rationale convention): One rationale per decision — convention / guidance only, not gated.
 - R53 (Fixes #483 — deterministic gate backing): The structural PRESENCE of G18 (per-task `**Contract:**` block) and Gate B (`## Verification Scorecard` section) MUST be enforced deterministically by validate-plan-format.js — PF7 (Contract presence) and PF9 (Scorecard presence) — independent of the LLM gate lanes. PF7 runs in the default check set; PF9 runs only under `--final`. plan-sdlc Step 6.6 invokes the validator with `--final` as a hard gate blocking Step 7. PF9 is omitted (no `--final`) when Step 0 took the lightweight routing path (Step 5 skipped), so the scorecard floor applies only to full-pipeline plans. G19 and G21 remain LLM-only — both require semantic judgment (render-trigger detection; change-site vs precedent ref) that a deterministic proxy mis-fires, and a mis-fire would block valid plans at the Step 6.6 gate. The LLM gates G18/G19/G21 are retained as the concreteness/quality ceiling above the deterministic presence floor.
-- R54 (Fixes #483 — judge calibration): The content-coverage critique lane (owner of G18/G19/G20/G21) MUST receive the path to plan-format-reference.md and read it before judging those gates, evaluating concreteness / render / code-ref anchoring against its worked examples rather than the prose gate definitions alone. The Step 2 planner MUST read plan-format-reference.md and match its worked examples (read-then-match), not merely be pointed at it. The reference is read at runtime, never embedded in a dispatched prompt (prompt-cache stability).
+- R54 (Fixes #483 — judge calibration): The content-coverage critique lane (owner of G18/G19/G20/G21) MUST receive the path to plan-format-reference.md and read it before judging those gates, evaluating concreteness / render / code-ref anchoring against its worked examples rather than the prose gate definitions alone. The Step 2 planner MUST read plan-format-reference.md and match its worked examples (read-then-match), not merely be pointed at it. The reference is read at runtime, never embedded in a dispatched prompt (prompt-cache stability). The calibration reference MUST also contain at least one negative exemplar — a labeled BAD → GOOD pair showing prose narrating a render-trigger surface (R46/G19) alongside its corrected render — so the lane has a negative anchor to pattern-match against, not positive exemplars alone (Fixes #488).
+- R55 (Fixes #488 — report integrity): The format-floor result MUST be presented as deterministic-structure-only, distinct from the Step 3 content gates (G18–G21). A format-floor PASS alone MUST NOT be reported as "validated."
 
 ## Workflow Phases
 
@@ -131,11 +132,14 @@
 - G16: OpenSpec tasks.md coverage — when `fromOpenspecDirect` is true: every entry in `openspecContext.tasks[]` is either (a) referenced by ≥1 plan task's `openspec-task.ref`, or (b) listed in `## Out-of-scope OpenSpec tasks`. Error severity (blocking).
 - G17: Dimension Coverage — when G17 subagent dispatched: emit proposals per R31 criteria with R31 suppression and ranking rules. Severity: advisory (non-blocking).
 - G18: Settlement / contract concreteness — every artifact-touching task carries a `Contract:` block whose decided shape is concrete for the task's plan type (type derived from `Files:` paths); flag any task that leaves the shape unsettled (absent Contract or a restatement of 'update X to do Y'). Error-severity; owned by the content-coverage lane. Backed by deterministic presence floor PF7 (validate-plan-format.js, default check set); LLM G18 judges concreteness above the floor.
-- G19: Render-don't-narrate — flags any task touching a render-trigger surface (R46
-  catalog #1–#8) that renders no concrete artifact for it. Trivial docs/rename tasks
-  are not flagged. Also flags any Contract that includes more than one rendered example
-  per distinct contract shape (per R49 cap — one elided example per unique method+path
-  for REST, or flag+type for CLI). Error-severity; owned by the content-coverage lane. LLM-only (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
+- G19: Render-don't-narrate — for EACH render-trigger surface (R46 catalog #1–#8) a
+  task touches, flags that surface if its shape is narrated in prose rather than
+  rendered as a concrete artifact; a render for one surface does NOT excuse prose for
+  another surface in the same task. Trivial docs/rename tasks are not flagged. Also
+  flags any Contract that includes more than one rendered example per distinct
+  contract shape (per R49 cap — one elided example per unique method+path for REST,
+  or flag+type for CLI). Error-severity; owned by the content-coverage lane. LLM-only
+  (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
 - G20: Notes rationale-only — flags a `Notes:` block that restates the task's
   Contract/acceptance instead of carrying only rationale. Error-severity; owned by the content-coverage lane.
 - G21: Self-contained code refs — flags a bare `file:line` change reference not

--- a/plugins/sdlc-utilities/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Skills and commands for software development lifecycle workflows: pull requests, code reviews, release",
-  "version": "0.21.15",
+  "version": "0.21.16",
   "author": {
     "name": "rnagrodzki"
   }

--- a/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
+++ b/plugins/sdlc-utilities/scripts/ci/validate-plan-format.js
@@ -350,7 +350,9 @@ function formatMarkdown(report) {
   const lines = [];
   lines.push('# Plan Format Validation Report');
   lines.push('');
-  lines.push(`**Overall:** ${report.passed ? 'PASS' : 'FAIL'} | ${report.summary.passed}/${report.summary.total} checks passed`);
+  lines.push(`**Format floor:** ${report.passed ? 'PASS' : 'FAIL'} | ${report.summary.passed}/${report.summary.total} deterministic structure checks`);
+  lines.push('');
+  lines.push('_Format floor checks STRUCTURE only (headers, Contract presence, metadata). It does NOT judge render-vs-narrate or prose density — that is Step 3 gates G18–G21._');
   lines.push('');
 
   lines.push('| Check | Status | Message |');

--- a/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md
@@ -347,7 +347,7 @@ Files + Contract + Acceptance criteria — do not restate it here.]
 
 **Render don't narrate (surface-conditional — implements R46):** When a task touches a concrete-artifact surface (payload, struct/schema field change, status enum, flow, config/flag delta, error mode, data-writing end-state), RENDER the artifact (fenced block / table / before→after diff) — do not describe it in prose. Use the catalog + conventions in ./plan-format-reference.md. Cap: one elided (…) example per distinct contract shape (a distinct contract shape is one unique combination of method + path for REST, or flag + type for CLI — two endpoints with the same method but different paths are distinct shapes). Trivial docs/rename tasks render nothing. (Mermaid fenced blocks allowed for flow/call-order/state surfaces; no MDX.) A task whose concrete-artifact surface is described in prose rather than rendered is flagged by G19 in Step 3.
 
-**G19 — Render-don't-narrate (error-severity):** Flags a task that touches a render-trigger surface (REST/RPC endpoint, CLI flag, schema field, status enum, state/flow/enum, config delta, error taxonomy) but describes it in prose instead of rendering a fenced block, table, or before→after diff. Owned by the content-coverage lane. Blocks plan approval until the surface is rendered. Not-applicable for trivial tasks and pure docs/rename tasks. LLM-only (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
+**G19 — Render-don't-narrate (error-severity):** For each render-trigger surface (REST/RPC endpoint, CLI flag, schema field, status enum, state/flow/enum, config delta, error taxonomy) a task touches, flags that surface if its shape is narrated in prose instead of rendered as a fenced block, table, or before→after diff — a render for one surface does NOT excuse prose for another surface in the same task. Owned by the content-coverage lane. Blocks plan approval until every touched surface is rendered. Not-applicable for trivial tasks and pure docs/rename tasks. LLM-only (semantic — render-trigger detection); hardened by prose. No deterministic floor (KD2).
 
 **G20 — Notes rationale-only (error-severity):** Flags a `Notes:` block that restates the task's Contract/acceptance instead of carrying only rationale. Owned by the content-coverage lane (lanes[1]). Blocks plan approval until the `Notes:` block is rationale-only.
 
@@ -358,8 +358,6 @@ Files + Contract + Acceptance criteria — do not restate it here.]
 - Config/infrastructure → build verification
 - Documentation → manual review
 - Integration → integration test or E2E
-
-Do not mandate TDD for config, documentation, or infrastructure tasks.
 
 **Write to plan file:** Append Key Decisions section (if applicable) and all task blocks. Populate the top-of-plan `## Deviations & assumptions` table (implements R47): one row per place the plan diverges from or assumes beyond the literal request (columns Item | asked | does | why). When the plan matches the request exactly, replace the placeholder row with a single "none" row. **De-dup rationale convention (implements R52):** Each decision gets one rationale entry — do not duplicate rationale across multiple decisions for the same topic.
 
@@ -412,7 +410,7 @@ Lane 4 (dimension-coverage/G17) returns the G17 findings JSON — parse the `fin
 
 Note every issue from `allIssues`. Do NOT write to the plan file in this step.
 
-**JOIN barrier — `guardrailsEvaluated` (implements R20, R35, issue #285):** After the guardrail-compliance lane (lanes[3]) result is incorporated into the merged issue list, record the checkpoint. **Do NOT write this marker before lanes[3] returns.** Each `--mark` block re-resolves `$SCRIPT` because SKILL.md bash blocks do not share shell state.
+**JOIN barrier — `guardrailsEvaluated` (implements R20, R35, issue #285):** After the guardrail-compliance lane (lanes[3]) result is incorporated into the merged issue list, record the checkpoint. **Do NOT write this marker before lanes[3] returns.**
 
 ```bash
 SCRIPT=$(find ~/.claude/plugins -name "plan.js" -path "*/sdlc*/scripts/skill/plan.js" 2>/dev/null | sort -V | tail -1)
@@ -608,6 +606,8 @@ Where `<verdict line>` is the verbatim verdict label from the scorecard: *"All c
 Then call ExitPlanMode. Do NOT invoke execute-plan-sdlc or ship-sdlc in this turn — they run after the user accepts in the next turn.
 
 **Normal mode:** Announce the plan path, then present the Workflow Continuation menu (see below). Prepend any advisory output from the wrapper above the menu's `ship` / `execute` / `done` lines.
+
+Do NOT report the plan as "validated" on format-floor PASS alone. Format floor = deterministic structure. Render/narrate quality was judged by the content-coverage lane in Step 3. Surface both, separately.
 
 ## Error Recovery
 

--- a/plugins/sdlc-utilities/skills/plan-sdlc/lane-content-coverage-prompt.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/lane-content-coverage-prompt.md
@@ -53,10 +53,11 @@ Derive the task's plan type from its `Files:` paths:
 
 A **mixed-artifact** task (e.g. a `.js` file plus a `.md` prompt) is judged against its **dominant** artifact's column — the one its primary deliverable touches. A task that touches no artifacts (pure coordination) is exempt. Do NOT flag a task whose Contract pins a concrete, type-appropriate shape — only flag genuinely unsettled tasks.
 
-**G19 — Render-don't-narrate:** Flag (error-severity, blocking:true) any task whose
-Files:/Description touch a render-trigger surface (R46 catalog #1–#8) but whose body
-renders NO concrete artifact (fenced block / table / before→after diff) for it.
-Docs-typo / rename tasks touch no surface → NOT flagged (anti-bloat).
+**G19 — Render-don't-narrate:** For EACH render-trigger surface (R46 catalog #1–#8) a
+task's Files:/Description touch, flag (error-severity, blocking:true) if that surface's
+shape is narrated in prose rather than rendered (fenced block / table / before→after
+diff). A render for one surface does NOT excuse prose for another surface in the same
+task. Docs-typo / rename tasks touch no surface → NOT flagged (anti-bloat).
 
 A ` ```mermaid ` fenced block is a **valid render** for flow / call-order / state
 surfaces (catalog #4/#5/#6) — a Mermaid-rendered flow PASSES G19 and must NOT be

--- a/plugins/sdlc-utilities/skills/plan-sdlc/plan-format-reference.md
+++ b/plugins/sdlc-utilities/skills/plan-sdlc/plan-format-reference.md
@@ -36,8 +36,7 @@ assumes beyond, the literal request — so reviewers can audit intent without re
 | Retry policy | (not specified) | adds 3-attempt exponential backoff | transient broker failures must not drop messages |
 ```
 
-The columns are `Item | asked | does | why`. When a plan introduces no divergences or assumptions,
-render the header with a single row stating "none". The section is required on every plan.
+When a plan introduces no divergences or assumptions, render the header with a single row stating "none".
 
 ## Key Decisions (optional)
 
@@ -210,8 +209,6 @@ docs/rename tasks with no structural change render nothing.
 
 ### Rendering Conventions
 
-One elided example per distinct contract shape (not per surface category). Scale verbosity to change size.
-
 **#1 — API payload (RFC 7386 / AIP-193): success + error paired**
 
 ```http
@@ -281,6 +278,22 @@ After:   { "id": 12, "status": "active",  "retries": 0, … }
 | Token expired | 401 | `UNAUTHENTICATED` | Refresh flow triggered |
 | Token malformed | 401 | `UNAUTHENTICATED` | Request rejected, no refresh |
 | … | … | … | … |
+
+### Negative exemplar — prose narrating a render-trigger surface (BAD → GOOD)
+
+> **BAD — prose narrates the change (G19 must flag):**
+> "The consent gate needs special handling because errnorm normally converts a `StatusFailure`+AppError into a 302 `access_denied` redirect. To avoid this, when it detects an already-finalized session it writes the 400 JSON directly and returns `StatusPending` — the same technique as `redirectToConsent` — so the second POST yields a 400 `{"code":"ID3823"}` instead of another 302 with a fresh code, and only one grant issues."
+>
+> **GOOD — render replaces the narration:**
+> errnorm turns `StatusFailure`+AppError into a 302 `access_denied` (`errnorm/decorators.go:29-47`). Consent gate writes 400 JSON directly + returns `StatusPending` (mirror `redirectToConsent`).
+>
+> | | 1st POST | 2nd now | 2nd after |
+> |---|---|---|---|
+> | status | 302 | 302 | **400** |
+> | body | `?code=A` | `?code=B` (bug) | `{"code":"ID3823"}` |
+> | grants | 1 | **2** | **1** |
+>
+> Why BAD fails: it touches a render-trigger surface (state transition) but makes the reader reconstruct the table. Naming files != rendering.
 
 ### Size Cap and Anti-Bloat
 

--- a/tests/promptfoo/datasets/plan-format-exec.yaml
+++ b/tests/promptfoo/datasets/plan-format-exec.yaml
@@ -32,6 +32,8 @@
       value: "Plan Format Validation Report"
     - type: icontains
       value: "PASS"
+    - type: icontains
+      value: "Format floor"
 
 - description: "plan-format: missing Verification header triggers PF1 fail"
   vars:

--- a/tests/promptfoo/datasets/plan-sdlc.yaml
+++ b/tests/promptfoo/datasets/plan-sdlc.yaml
@@ -20,6 +20,7 @@
 #   plan-deviations-notes              -- CORRECT: code plan with top-of-plan Deviations table, T1 (Notes rationale-only), T2 (Notes restates Contract); exercises R47 Deviations + R48/G20 Notes rationale-only (Fixes #472)
 #   plan-per-event-contracts           -- CORRECT: code plan, T1 emits 3 distinct events each with its own payload record; exercises per-distinct-shape render cap (catalog #2/#3, R49, Fixes #472)
 #   plan-bare-ref                      -- CORRECT: code plan, T1 has a bare file:line CHANGE ref (forbidden) + a Contract.mirror line-anchor (allowed carve-out); exercises Code reference anchoring convention (R51, Fixes #472)
+#   plan-g19-prose-flood               -- CORRECT: code plan, T1 narrates its HTTP payload surface (#1) entirely in prose while rendering an unrelated config-delta surface (#7) as a table; exercises the NEW per-surface G19 rule — the incidental render must NOT excuse the prose-narrated surface (R46, Fixes #488)
 
 # --- Fan-out parallelization cases (P1/P2/P3 — Fixes #418) ---
 
@@ -1051,6 +1052,35 @@
         structure, no state machine). G19 does not demand a rendered artifact for trivial
         tasks. The response must NOT flag Task 3 — flagging a typo fix is a false positive
         that G19 explicitly avoids per the anti-bloat rule.
+
+- description: "plan-sdlc: G19 per-surface prose-flood — an incidental unrelated render does NOT excuse a prose-narrated surface in the same task (R46, G19, #488)"
+  vars:
+    skill_path: "plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md"
+    project_context: "file://fixtures/plan-g19-prose-flood.md"
+    user_request: >
+      Run /plan-sdlc. Evaluate the Step 3 G19 render-don't-narrate gate for Task 1
+      ("PATCH /jobs/{id}/priority — update priority + add MAX_PRIORITY_QUEUE_DEPTH env
+      var") in the plan. Task 1 touches two render-trigger surfaces: the endpoint's
+      request/response payload (described only in the Description prose — no fenced
+      block, no table for it) and the MAX_PRIORITY_QUEUE_DEPTH config delta (rendered as
+      a typed-op table under Rendered artifacts). Is Task 1 flagged by G19? Does the
+      rendered config-delta table excuse the un-rendered payload surface?
+  assert:
+    - type: icontains
+      value: "G19"
+    - type: llm-rubric
+      value: >
+        The response evaluates the G19 gate PER-SURFACE and FLAGS Task 1 specifically for
+        the HTTP request/response PAYLOAD surface (catalog #1): that surface's shape
+        (the priority field, the success response fields, the 422 error body) is narrated
+        entirely in prose in the Description field with no fenced block, table, or
+        before→after diff rendering it. The response explicitly rejects the idea that the
+        task's rendered MAX_PRIORITY_QUEUE_DEPTH config-delta table (catalog #7) excuses
+        or satisfies G19 for the payload surface — it states that a render for one surface
+        (the config delta) does NOT excuse prose for another surface (the payload) in the
+        same task. The response confirms G19 is error-severity and blocking, and does NOT
+        conclude that Task 1 passes G19 merely because the task contains some rendered
+        artifact.
 
 # --- Render-don't-narrate hardening: Mermaid, per-distinct-shape, blocking, Notes, Deviations (R47–R52, Fixes #472) ---
 

--- a/tests/promptfoo/fixtures/plan-g19-prose-flood.md
+++ b/tests/promptfoo/fixtures/plan-g19-prose-flood.md
@@ -1,0 +1,70 @@
+# Sample Plan — G19 Per-Surface Render Gate (Fixes #488)
+
+This fixture is a **code** plan. It carries one task that trips the NEW per-surface G19
+rule: the task touches TWO render-trigger surfaces — an HTTP request/response payload
+(catalog #1) and a config/env-flag delta (catalog #7) — but only renders ONE of them.
+
+- **Task 1** — adds a `PATCH /jobs/{id}/priority` endpoint AND a new
+  `MAX_PRIORITY_QUEUE_DEPTH` env var. The env var's config delta IS rendered as a
+  typed-op table (artifact #7, RFC 6902) — an incidental render for a surface UNRELATED
+  to the endpoint. The endpoint's request/response payload (artifact #1, AIP-193) is
+  described ENTIRELY in prose in the Description field — no fenced block, no table, no
+  before→after diff for that surface anywhere in the task.
+  Under the OLD binary G19 (any render anywhere in the task body satisfies the gate),
+  this task would PASS because it does render *something* (the env var table). Under the
+  NEW per-surface G19, the un-rendered payload surface must still be flagged — a render
+  for one surface does NOT excuse prose for another surface in the same task. G19 must
+  FLAG Task 1 for the un-rendered HTTP payload surface (error-severity, blocking).
+
+---
+
+# Job Priority Plan
+
+**Goal:** Add a PATCH /jobs/{id}/priority endpoint that updates a job's priority, plus a new env var that caps queue depth for priority processing.
+**Architecture:** REST handler wired into the existing Express router; priority is an integer 1-10; queue depth capped via a new env var read at startup.
+**Source:** conversation context
+**Verification:** npm test
+
+---
+
+### Task 1: PATCH /jobs/{id}/priority — update priority + add MAX_PRIORITY_QUEUE_DEPTH env var
+
+**Complexity:** Standard
+**Risk:** Medium
+**Depends on:** none
+**Verify:** tests
+
+**Files:**
+- Create: `src/routes/jobs-priority.ts`
+- Modify: `src/config/env.ts`
+- Test: `tests/routes/jobs-priority.test.ts`
+
+**Description:**
+Add a `PATCH /jobs/{id}/priority` route. The route accepts a JSON body with a single
+`priority` field, an integer between 1 and 10 inclusive. On success it returns 200 with
+the updated job record, containing the job's `id`, its new `priority`, and an
+`updatedAt` timestamp. When `priority` is missing, non-numeric, or outside the 1-10
+range, the route returns 422 with a structured error body containing the field name
+that failed validation and a human-readable message. The handler also reads a new
+environment variable, `MAX_PRIORITY_QUEUE_DEPTH`, at startup to cap how many jobs may
+sit in the priority queue simultaneously.
+
+**Acceptance criteria:**
+- [ ] Returns 200 with the updated job record on valid input
+- [ ] Returns 422 with a structured error body on invalid `priority`
+- [ ] `MAX_PRIORITY_QUEUE_DEPTH` is read once at startup with a default of `50`
+
+**Contract:**
+- shape (code): `updateJobPriority(id: string, body: UpdatePriorityBody): Promise<Job>`; throws `JobNotFoundError` | `InvalidPriorityError`; reads from `process.env.MAX_PRIORITY_QUEUE_DEPTH`.
+- names: `updateJobPriority`, `UpdatePriorityBody`, `JobNotFoundError`, `InvalidPriorityError`, `MAX_PRIORITY_QUEUE_DEPTH`.
+- mirror: existing route style at `src/routes/orgs.ts:1-50`.
+- decisions: typed errors over boolean returns; env var read once at module load, not per-request.
+- sync: `src/config/env.ts` — new env var must be documented alongside existing `DB_URL`/`LOG_LEVEL` entries.
+
+**Rendered artifacts:**
+
+`MAX_PRIORITY_QUEUE_DEPTH` config delta (artifact #7 — RFC 6902 typed-op table):
+
+| Op  | Key                         | Type    | Value | Notes                                     |
+|-----|------------------------------|---------|-------|---------------------------------------------|
+| add | `MAX_PRIORITY_QUEUE_DEPTH`   | integer | `50`  | Default cap; overridable per environment    |


### PR DESCRIPTION
## Summary
Fixes plan-sdlc's G19 render-don't-narrate gate so it evaluates each render-trigger surface in a task independently — rendering one surface no longer excuses leaving another surface narrated in prose — and clarifies that the deterministic format-floor report is structure-only, not a content-quality verdict.

## Business Context
plan-sdlc's G19 gate previously passed a task as soon as *any* render-trigger surface in it was rendered, even if the task touched other render-trigger surfaces that were only described in prose. A task could add both an HTTP endpoint and a config flag, render only the config flag, and still pass G19 — leaving the endpoint's payload shape unverified except through prose a reviewer had to reconstruct by hand. Separately, the format-floor validator's "Overall: PASS" wording was easy to misread as a full content-quality pass, when it only checks deterministic structure (headers, Contract presence, metadata).

## Business Benefits
Plans produced by plan-sdlc now catch multi-surface tasks that render one surface and narrate another, closing a gap that let under-specified contracts through review. The format-floor report is now explicitly labeled "Format floor" with a note that it doesn't judge render-vs-narrate or prose density, preventing reviewers from over-trusting a structural PASS. The judge calibration reference also gained a labeled negative (BAD → GOOD) exemplar, giving the content-coverage lane a concrete anti-pattern to match against instead of positive examples only.

## Github Issue
https://github.com/rnagrodzki/sdlc-marketplace/issues/488

## Technical Design
Split the single overloaded G19 rule into two explicit rules: "each render-trigger surface must be rendered" (coverage) and "cap: one example per distinct contract shape" (capping) — previously one sentence conflated both. This wording was updated consistently across `docs/skills/plan-sdlc.md`, `docs/specs/plan-sdlc.md` (R54 extended, new R55), `plugins/sdlc-utilities/skills/plan-sdlc/SKILL.md`, and the Step 3 judge instructions in `lane-content-coverage-prompt.md`, so the LLM judge, the spec, and the user-facing doc all state per-surface evaluation identically. Added new spec requirement R55: the format-floor report must present itself as deterministic-structure-only, distinct from the Step 3 content gates (G18-G21); `validate-plan-format.js`'s markdown formatter was updated to emit "Format floor: PASS/FAIL | N/M deterministic structure checks" plus an explanatory note instead of "Overall: PASS/FAIL". Added a negative BAD → GOOD worked exemplar to `plan-format-reference.md` per the R54 extension. Also trimmed two redundant prose lines (a duplicated verbosity-scaling note, and a TDD-mandate reminder already covered elsewhere) as incidental cleanup.

## Technical Impact
Affects plan-sdlc's Step 3 content-coverage judge prompt, its Step 6.6 format-floor report wording, and the calibration reference doc read by that judge. No changes to plugin manifest fields beyond the routine version bump (0.21.15 → 0.21.16), and no breaking changes to any skill invocation surface — plan-sdlc's external interface (flags, output locations) is unchanged.

## Changes Overview
- G19 render-don't-narrate now evaluates each render-trigger surface independently — a task touching N render-trigger surfaces must render all N; rendering one surface no longer excuses prose narration of another
- Format-floor validation report relabeled to make clear it checks deterministic structure only, with an explicit note that it does not judge render-vs-narrate or prose density
- Judge calibration reference gains a negative BAD → GOOD worked exemplar (prose narrating a render-trigger surface, paired with its corrected render) so the content-coverage lane has a labeled anti-pattern to match against
- Redundant prose trimmed from the plan-sdlc skill and its format reference doc (duplicate verbosity note, already-covered TDD reminder)
- New spec requirements added: R55 (format-floor report integrity) and an extension to R54 (negative exemplar requirement)
- New promptfoo fixture and dataset case exercising the per-surface G19 rule (a task that renders one surface but narrates another must still be flagged)

## Testing
Automated: a new promptfoo dataset case ("plan-sdlc: G19 per-surface prose-flood") was added in `tests/promptfoo/datasets/plan-sdlc.yaml` with fixture `tests/promptfoo/fixtures/plan-g19-prose-flood.md`, asserting G19 flags a task whose HTTP payload surface is left in prose even though an unrelated config-delta surface was rendered. `tests/promptfoo/datasets/plan-format-exec.yaml` was updated to assert the new "Format floor" report label. Per this repo's testing policy, full-suite `promptfoo eval` runs are user-initiated only and were not executed as part of this PR step; the new coverage is available for a targeted run on request.
